### PR TITLE
CalculateCoverage: Fix file not foundexception

### DIFF
--- a/src/coverlet.core/Coverage.cs
+++ b/src/coverlet.core/Coverage.cs
@@ -93,6 +93,7 @@ namespace Coverlet.Core
         {
             foreach (var result in _results)
             {
+                if (!File.Exists(result.HitsFilePath)) { continue; }
                 var lines = File.ReadAllLines(result.HitsFilePath);
                 for (int i = 0; i < lines.Length; i++)
                 {

--- a/src/coverlet.core/CoverageSummary.cs
+++ b/src/coverlet.core/CoverageSummary.cs
@@ -12,6 +12,8 @@ namespace Coverlet.Core
         public CoverageSummaryResult CalculateSummary()
         {
             CoverageSummaryResult result = new CoverageSummaryResult();
+            int totalModuleLines = 0, moduleLinesCovered = 0;
+
             foreach (var mod in _result.Modules)
             {
                 int totalLines = 0, linesCovered = 0;
@@ -30,10 +32,11 @@ namespace Coverlet.Core
                         }
                     }
                 }
-
+                totalModuleLines += totalLines;
+                moduleLinesCovered += linesCovered;
                 result.Add(System.IO.Path.GetFileNameWithoutExtension(mod.Key), (linesCovered * 100) / totalLines);
             }
-
+            result.Add("Covered", (moduleLinesCovered * 100) / totalModuleLines);
             return result;
         }
     }


### PR DESCRIPTION
Check if the file HitsFilePath exists

--
I have the same issue as https://github.com/tonerdo/coverlet/issues/8
This simple check fix my problem