### PR TITLE
fix open cover reporter so that it uses unique ids over multiple modules

### DIFF
--- a/src/coverlet.core/Reporters/OpenCoverReporter.cs
+++ b/src/coverlet.core/Reporters/OpenCoverReporter.cs
@@ -25,6 +25,8 @@ namespace Coverlet.Core.Reporters
             int numSequencePoints = 0, numClasses = 0, numMethods = 0;
             int visitedSequencePoints = 0, visitedClasses = 0, visitedMethods = 0;
 
+            int i = 1;
+
             foreach (var mod in result.Modules)
             {
                 XmlElement module = xml.CreateElement("Module");
@@ -44,10 +46,8 @@ namespace Coverlet.Core.Reporters
                 module.AppendChild(name);
 
                 XmlElement files = xml.CreateElement("Files");
-                XmlElement classes = xml.CreateElement("Classes");
-
-                int i = 1;
-
+                XmlElement classes = xml.CreateElement("Classes");                                
+                                
                 foreach (var doc in mod.Value)
                 {
                     XmlElement file = xml.CreateElement("File");

--- a/test/coverlet.core.tests/Reporters/OpenCoverReporterTests.cs
+++ b/test/coverlet.core.tests/Reporters/OpenCoverReporterTests.cs
@@ -10,6 +10,34 @@ namespace Coverlet.Core.Reporters.Tests
         {
             CoverageResult result = new CoverageResult();
             result.Identifier = Guid.NewGuid().ToString();
+            
+            result.Modules = new Modules();
+            result.Modules.Add("Coverlet.Core.Reporters.Tests", CreateFirstDocuments());
+
+            OpenCoverReporter reporter = new OpenCoverReporter();
+            Assert.NotEqual(string.Empty, reporter.Format(result));
+        }
+
+        [Fact]
+        public void TestFilesHaveUniqueIdsOverMultipleModules()
+        {
+            CoverageResult result = new CoverageResult();
+            result.Identifier = Guid.NewGuid().ToString();
+            
+            result.Modules = new Modules();
+            result.Modules.Add("Coverlet.Core.Reporters.Tests", CreateFirstDocuments());
+            result.Modules.Add("Some.Other.Module", CreateSecondDocuments());
+
+            OpenCoverReporter reporter = new OpenCoverReporter();
+            var xml = reporter.Format(result);
+            Assert.NotEqual(string.Empty, xml);
+
+            Assert.Contains(@"<FileRef uid=""1"" />", xml);
+            Assert.Contains(@"<FileRef uid=""2"" />", xml);
+        }
+
+        private static Documents CreateFirstDocuments()
+        {
             Lines lines = new Lines();
             lines.Add(1, 1);
             lines.Add(2, 0);
@@ -19,11 +47,25 @@ namespace Coverlet.Core.Reporters.Tests
             classes.Add("Coverlet.Core.Reporters.Tests.OpenCoverReporterTests", methods);
             Documents documents = new Documents();
             documents.Add("doc.cs", classes);
-            result.Modules = new Modules();
-            result.Modules.Add("module", documents);
+            return documents;
+        }
 
-            OpenCoverReporter reporter = new OpenCoverReporter();
-            Assert.NotEqual(string.Empty, reporter.Format(result));
+        private static Documents CreateSecondDocuments()
+        {            
+            Lines lines = new Lines();
+            lines.Add(1, 1);
+            lines.Add(2, 0);
+
+            Methods methods = new Methods();
+            methods.Add("System.Void Some.Other.Module.TestClass.TestMethod()", lines);
+
+            Classes classes2 = new Classes();
+            classes2.Add("Some.Other.Module.TestClass", methods);
+
+            var documents = new Documents();
+            documents.Add("TestClass.cs", classes2);
+
+            return documents;
         }
     }
 }


### PR DESCRIPTION
The open cover output doesn't work with [report generator](https://github.com/danielpalme/ReportGenerator) as it has the same uid values for different files over multiple modules.

`<ModuleName>Module.A</ModuleName>`
`      <Files>`
`        <File uid="1" fullPath="C:\code\testproject\src\Module.A\Example.A.cs" />`
...
`<ModuleName>Module.B</ModuleName>`
`      <Files>`
`        <File uid="1" fullPath="C:\code\testproject\src\Module.B\Example.B.cs" />`

instead of

`<ModuleName>Module.A</ModuleName>`
`      <Files>`
`        <File uid="1" fullPath="C:\code\testproject\src\Module.A\Example.A.cs" />`
...
`<ModuleName>Module.B</ModuleName>`
`      <Files>`
`        <File uid="2" fullPath="C:\code\testproject\src\Module.B\Example.B.cs" />`
