### PR TITLE
Fixes assembly resolution so it scans the module directory as well.

### DIFF
--- a/src/coverlet.core/Instrumentation/Instrumenter.cs
+++ b/src/coverlet.core/Instrumentation/Instrumenter.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -50,7 +49,9 @@ namespace Coverlet.Core.Instrumentation
         {
             using (var stream = new FileStream(_module, FileMode.Open, FileAccess.ReadWrite))
             {
-                var parameters = new ReaderParameters { ReadSymbols = true };
+                var resolver = new DefaultAssemblyResolver();
+                resolver.AddSearchDirectory(Path.GetDirectoryName(_module));
+                var parameters = new ReaderParameters { ReadSymbols = true, AssemblyResolver = resolver };
                 ModuleDefinition module = ModuleDefinition.ReadModule(stream, parameters);
 
                 foreach (var type in module.GetTypes())


### PR DESCRIPTION
The fix works, and is only 2 additional lines.

What I've struggled to do is understand what conditions are required to trigger this.  Almost all other assemblies that in our solution don't even try and resolve other assemblies when being re-written.  However, 2 do, and this PR fixes the issue with them. See: (https://github.com/tonerdo/coverlet/issues/21)