### PR TITLE
Adds retry functionality to copy back the original assembly.

### DIFF
--- a/src/coverlet.core/Coverage.cs
+++ b/src/coverlet.core/Coverage.cs
@@ -80,16 +80,7 @@ namespace Coverlet.Core
                 }
 
                 modules.Add(result.ModulePath, documents);
-                
-                // Restore the original module - retry up to 10 times, since the destination file could be locked
-                // See: https://github.com/tonerdo/coverlet/issues/25
-                var currentSleep = 6;
-                Func<TimeSpan> retryStrategy = () => {
-                    var sleep = TimeSpan.FromMilliseconds(currentSleep);
-                    currentSleep *= 2;
-                    return sleep;
-                };
-                RetryHelper.Retry(() => InstrumentationHelper.RestoreOriginalModule(result.ModulePath, _identifier), retryStrategy, 10);
+                InstrumentationHelper.RestoreOriginalModule(result.ModulePath, _identifier);
             }
 
             return new CoverageResult
@@ -130,15 +121,7 @@ namespace Coverlet.Core
                     }
                 }
 
-                // Restore the original module - retry up to 10 times, since the destination file could be locked
-                // See: https://github.com/tonerdo/coverlet/issues/25
-                var currentSleep = 6;
-                Func<TimeSpan> retryStrategy = () => {
-                    var sleep = TimeSpan.FromMilliseconds(currentSleep);
-                    currentSleep *= 2;
-                    return sleep;
-                };
-                RetryHelper.Retry(() => File.Delete(result.HitsFilePath), retryStrategy, 10);
+                InstrumentationHelper.DeleteHitsFile(result.HitsFilePath);
             }
         }
     }

--- a/src/coverlet.core/Coverage.cs
+++ b/src/coverlet.core/Coverage.cs
@@ -130,7 +130,15 @@ namespace Coverlet.Core
                     }
                 }
 
-                File.Delete(result.HitsFilePath);
+                // Restore the original module - retry up to 10 times, since the destination file could be locked
+                // See: https://github.com/tonerdo/coverlet/issues/25
+                var currentSleep = 6;
+                Func<TimeSpan> retryStrategy = () => {
+                    var sleep = TimeSpan.FromMilliseconds(currentSleep);
+                    currentSleep *= 2;
+                    return sleep;
+                };
+                RetryHelper.Retry(() => File.Delete(result.HitsFilePath), retryStrategy, 10);
             }
         }
     }

--- a/src/coverlet.core/Helpers/RetryHelper.cs
+++ b/src/coverlet.core/Helpers/RetryHelper.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+// A slightly amended version of the code found here: https://stackoverflow.com/a/1563234/186184
+// This code allows for varying backoff strategies through the use of Func<TimeSpan>.
+public static class RetryHelper
+{
+    /// <summary>
+    /// Retry a void method.
+    /// </summary>
+    /// <param name="action">The action to perform</param>
+    /// <param name="backoffStrategy">A function returning a Timespan defining the backoff strategy to use.</param>
+    /// <param name="maxAttemptCount">The maximum number of retries before bailing out. Defaults to 3.</param>
+    public static void Retry(
+        Action action,
+        Func<TimeSpan> backoffStrategy,
+        int maxAttemptCount = 3)
+    {
+        Do<object>(() =>
+        {
+            action();
+            return null;
+        }, backoffStrategy, maxAttemptCount);
+    }
+
+    /// <summary>
+    /// Retry a method returning type T.
+    /// </summary>
+    /// <param name="action">The action to perform</param>
+    /// <param name="backoffStrategy">A function returning a Timespan defining the backoff strategy to use.</param>
+    /// <param name="maxAttemptCount">The maximum number of retries before bailing out. Defaults to 3.</param>
+    public static T Do<T>(
+        Func<T> action,
+        Func<TimeSpan> backoffStrategy,
+        int maxAttemptCount = 3)
+    {
+        var exceptions = new List<Exception>();
+
+        for (int attempted = 0; attempted < maxAttemptCount; attempted++)
+        {
+            try
+            {
+                if (attempted > 0)
+                {
+                    Thread.Sleep(backoffStrategy());
+                }
+                return action();
+            }
+            catch (Exception ex)
+            {
+                exceptions.Add(ex);
+            }
+        }
+        throw new AggregateException(exceptions);
+    }
+}

--- a/test/coverlet.core.tests/Helpers/RetryHelperTests.cs
+++ b/test/coverlet.core.tests/Helpers/RetryHelperTests.cs
@@ -1,0 +1,79 @@
+using System;
+using System.IO;
+
+using Xunit;
+using Coverlet.Core.Helpers;
+
+namespace Coverlet.Core.Helpers.Tests
+{
+    public class RetryHelperTests
+    {
+        [Fact]
+        public void TestRetryWithFixedRetryBackoff()
+        {
+            Func<TimeSpan> retryStrategy = () => {
+                return TimeSpan.FromMilliseconds(1);
+            };
+
+            var target = new RetryTarget();
+            try
+            {
+                RetryHelper.Retry(() => target.TargetActionThrows(), retryStrategy, 7);
+            }
+            catch
+            {
+                Assert.Equal(7, target.Calls);
+            }
+        }
+
+        [Fact]
+        public void TestRetryWithExponentialRetryBackoff()
+        {
+            var currentSleep = 6;
+            Func<TimeSpan> retryStrategy = () => {
+                var sleep = TimeSpan.FromMilliseconds(currentSleep);
+                currentSleep *= 2;
+                return sleep;
+            };
+
+            var target = new RetryTarget();
+            try 
+            {
+                RetryHelper.Retry(() => target.TargetActionThrows(), retryStrategy, 3);
+            }
+            catch
+            {
+                Assert.Equal(3, target.Calls);
+                Assert.Equal(24, currentSleep);
+            }
+        }
+
+        [Fact]
+        public void TestRetryFinishesIfSuccessful()
+        {
+            Func<TimeSpan> retryStrategy = () => {
+                return TimeSpan.FromMilliseconds(1);
+            };
+
+            var target = new RetryTarget();
+            RetryHelper.Retry(() => target.TargetActionThrows5Times(), retryStrategy, 20);
+            Assert.Equal(6, target.Calls);
+        }
+
+    }
+
+    public class RetryTarget
+    {
+        public int Calls { get; set; }
+        public void TargetActionThrows() 
+        {
+            Calls++;
+            throw new Exception("Simulating Failure");
+        }
+        public void TargetActionThrows5Times() 
+        {
+            Calls++;
+            if (Calls < 6) throw new Exception("Simulating Failure");
+        }
+    }
+}


### PR DESCRIPTION
Fixes: https://github.com/tonerdo/coverlet/issues/25

I've run this locally, and it seems fine.  Would be handy to have someone else verify that.