### PR TITLE
Avoid leaving file handles open

### DIFF
--- a/src/coverlet.core/Helpers/InstrumentationHelper.cs
+++ b/src/coverlet.core/Helpers/InstrumentationHelper.cs
@@ -19,7 +19,8 @@ namespace Coverlet.Core.Helpers
 
         public static bool HasPdb(string module)
         {
-            using (var peReader = new PEReader(File.OpenRead(module)))
+            using (var moduleStream = File.OpenRead(module))
+            using (var peReader = new PEReader(moduleStream))
             {
                 foreach (var entry in peReader.ReadDebugDirectory())
                 {


### PR DESCRIPTION
When calculating code coverage for a solution of mine, I found that two projects where reliably stuck on file locking.

The only process using the files were the `dotnet` process running code coverage reporting. After wrapping disposable objects in `using` statements, the problem appears to be resolved.

Additionally, I think this may also allow the `RetryHelper` code to be removed, but this has not been done yet.