### PR TITLE
Additional coverage reporting for properties and nested types

### DIFF
--- a/src/coverlet.core/Attributes/ExcludeFromCoverage.cs
+++ b/src/coverlet.core/Attributes/ExcludeFromCoverage.cs
@@ -2,6 +2,6 @@ using System;
 
 namespace Coverlet.Core.Attributes
 {
-    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor)]
-    public class ExcludeFromCoverageAttribute : Attribute { }
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Method | AttributeTargets.Constructor)]
+    public sealed class ExcludeFromCoverageAttribute : Attribute { }
 }

--- a/src/coverlet.core/Helpers/InstrumentationHelper.cs
+++ b/src/coverlet.core/Helpers/InstrumentationHelper.cs
@@ -63,13 +63,7 @@ namespace Coverlet.Core.Helpers
 
             // Restore the original module - retry up to 10 times, since the destination file could be locked
             // See: https://github.com/tonerdo/coverlet/issues/25
-            var currentSleep = 6;
-            TimeSpan retryStrategy()
-            {
-                var sleep = TimeSpan.FromMilliseconds(currentSleep);
-                currentSleep *= 2;
-                return sleep;
-            }
+            var retryStrategy = CreateRetryStrategy();
 
             RetryHelper.Retry(() => {
                 File.Copy(backupPath, module, true);
@@ -81,13 +75,7 @@ namespace Coverlet.Core.Helpers
         {
             // Retry hitting the hits file - retry up to 10 times, since the file could be locked
             // See: https://github.com/tonerdo/coverlet/issues/25
-            var currentSleep = 6;
-            TimeSpan retryStrategy()
-            {
-                var sleep = TimeSpan.FromMilliseconds(currentSleep);
-                currentSleep *= 2;
-                return sleep;
-            }
+            var retryStrategy = CreateRetryStrategy();
 
             return RetryHelper.Do(() => File.ReadLines(path), retryStrategy, 10);
         }
@@ -96,13 +84,7 @@ namespace Coverlet.Core.Helpers
         {
             // Retry hitting the hits file - retry up to 10 times, since the file could be locked
             // See: https://github.com/tonerdo/coverlet/issues/25
-            var currentSleep = 6;
-            TimeSpan retryStrategy()
-            {
-                var sleep = TimeSpan.FromMilliseconds(currentSleep);
-                currentSleep *= 2;
-                return sleep;
-            }
+            var retryStrategy = CreateRetryStrategy();
 
             RetryHelper.Retry(() => File.Delete(path), retryStrategy, 10);
         }
@@ -163,6 +145,18 @@ namespace Coverlet.Core.Helpers
                 Path.GetTempPath(),
                 Path.GetFileNameWithoutExtension(module) + "_" + identifier + ".dll"
             );
+        }
+
+        private static Func<TimeSpan> CreateRetryStrategy(int initialSleepSeconds = 6)
+        {
+            TimeSpan retryStrategy()
+            {
+                var sleep = TimeSpan.FromMilliseconds(initialSleepSeconds);
+                initialSleepSeconds *= 2;
+                return sleep;
+            }
+
+            return retryStrategy;
         }
     }
 }

--- a/src/coverlet.core/Helpers/RetryHelper.cs
+++ b/src/coverlet.core/Helpers/RetryHelper.cs
@@ -58,3 +58,4 @@ namespace Coverlet.Core
             throw new AggregateException(exceptions);
         }
     }
+}

--- a/src/coverlet.core/Helpers/RetryHelper.cs
+++ b/src/coverlet.core/Helpers/RetryHelper.cs
@@ -2,56 +2,59 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 
-// A slightly amended version of the code found here: https://stackoverflow.com/a/1563234/186184
-// This code allows for varying backoff strategies through the use of Func<TimeSpan>.
-public static class RetryHelper
+namespace Coverlet.Core
 {
-    /// <summary>
-    /// Retry a void method.
-    /// </summary>
-    /// <param name="action">The action to perform</param>
-    /// <param name="backoffStrategy">A function returning a Timespan defining the backoff strategy to use.</param>
-    /// <param name="maxAttemptCount">The maximum number of retries before bailing out. Defaults to 3.</param>
-    public static void Retry(
-        Action action,
-        Func<TimeSpan> backoffStrategy,
-        int maxAttemptCount = 3)
+    // A slightly amended version of the code found here: https://stackoverflow.com/a/1563234/186184
+    // This code allows for varying backoff strategies through the use of Func<TimeSpan>.
+    public static class RetryHelper
     {
-        Do<object>(() =>
+        /// <summary>
+        /// Retry a void method.
+        /// </summary>
+        /// <param name="action">The action to perform</param>
+        /// <param name="backoffStrategy">A function returning a Timespan defining the backoff strategy to use.</param>
+        /// <param name="maxAttemptCount">The maximum number of retries before bailing out. Defaults to 3.</param>
+        public static void Retry(
+            Action action,
+            Func<TimeSpan> backoffStrategy,
+            int maxAttemptCount = 3)
         {
-            action();
-            return null;
-        }, backoffStrategy, maxAttemptCount);
-    }
-
-    /// <summary>
-    /// Retry a method returning type T.
-    /// </summary>
-    /// <param name="action">The action to perform</param>
-    /// <param name="backoffStrategy">A function returning a Timespan defining the backoff strategy to use.</param>
-    /// <param name="maxAttemptCount">The maximum number of retries before bailing out. Defaults to 3.</param>
-    public static T Do<T>(
-        Func<T> action,
-        Func<TimeSpan> backoffStrategy,
-        int maxAttemptCount = 3)
-    {
-        var exceptions = new List<Exception>();
-
-        for (int attempted = 0; attempted < maxAttemptCount; attempted++)
-        {
-            try
+            Do<object>(() =>
             {
-                if (attempted > 0)
-                {
-                    Thread.Sleep(backoffStrategy());
-                }
-                return action();
-            }
-            catch (Exception ex)
-            {
-                exceptions.Add(ex);
-            }
+                action();
+                return null;
+            }, backoffStrategy, maxAttemptCount);
         }
-        throw new AggregateException(exceptions);
+
+        /// <summary>
+        /// Retry a method returning type T.
+        /// </summary>
+        /// <typeparam name="T">The type of the object to return</typeparam>
+        /// <param name="action">The action to perform</param>
+        /// <param name="backoffStrategy">A function returning a Timespan defining the backoff strategy to use.</param>
+        /// <param name="maxAttemptCount">The maximum number of retries before bailing out. Defaults to 3.</param>
+        public static T Do<T>(
+            Func<T> action,
+            Func<TimeSpan> backoffStrategy,
+            int maxAttemptCount = 3)
+        {
+            var exceptions = new List<Exception>();
+
+            for (int attempted = 0; attempted < maxAttemptCount; attempted++)
+            {
+                try
+                {
+                    if (attempted > 0)
+                    {
+                        Thread.Sleep(backoffStrategy());
+                    }
+                    return action();
+                }
+                catch (Exception ex)
+                {
+                    exceptions.Add(ex);
+                }
+            }
+            throw new AggregateException(exceptions);
+        }
     }
-}

--- a/src/coverlet.core/Instrumentation/Instrumenter.cs
+++ b/src/coverlet.core/Instrumentation/Instrumenter.cs
@@ -1,12 +1,15 @@
+using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 
+using Coverlet.Core.Attributes;
 using Coverlet.Core.Helpers;
 
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 using Mono.Cecil.Rocks;
-using System.Collections.Generic;
 
 namespace Coverlet.Core.Instrumentation
 {
@@ -14,7 +17,8 @@ namespace Coverlet.Core.Instrumentation
     {
         private readonly string _module;
         private readonly string _identifier;
-        private IEnumerable<string> _excludedFiles;
+        private readonly IEnumerable<string> _excludedFiles;
+        private readonly static Lazy<MethodInfo> _markExecutedMethodLoader = new Lazy<MethodInfo>(GetMarkExecutedMethod);
         private InstrumenterResult _result;
 
         public Instrumenter(string module, string identifier, IEnumerable<string> excludedFiles = null)
@@ -57,18 +61,7 @@ namespace Coverlet.Core.Instrumentation
                 {
                     foreach (var type in module.GetTypes())
                     {
-                        if (type.CustomAttributes.Any(a => a.AttributeType.Name == "ExcludeFromCoverageAttribute" || a.AttributeType.Name == "ExcludeFromCoverage"))
-                            continue;
-
-                        foreach (var method in type.Methods)
-                        {
-	                        var sourceFile = method.DebugInformation.SequencePoints.Select(s => s.Document.Url).FirstOrDefault();
-	                        if (!string.IsNullOrEmpty(sourceFile) && _excludedFiles.Contains(sourceFile)) {
-	                            continue;
-	                        }
-                            if (!method.CustomAttributes.Any(a => a.AttributeType.Name == "ExcludeFromCoverageAttribute" || a.AttributeType.Name == "ExcludeFromCoverage"))
-                                InstrumentMethod(method);
-                        }
+                        InstrumentType(type);
                     }
 
                     module.Write(stream);
@@ -76,9 +69,54 @@ namespace Coverlet.Core.Instrumentation
             }
         }
 
+        private void InstrumentType(TypeDefinition type)
+        {
+            if (type.CustomAttributes.Any(IsExcludeAttribute))
+                return;
+
+            foreach (var method in type.Methods)
+            {
+                if (!method.CustomAttributes.Any(IsExcludeAttribute))
+                    InstrumentMethod(method);
+            }
+
+            foreach (var property in type.Properties)
+            {
+                if (!property.CustomAttributes.Any(IsExcludeAttribute))
+                    InstrumentProperty(property);
+            }
+
+            if (type.HasNestedTypes)
+            {
+                foreach (var nestedType in type.NestedTypes)
+                    InstrumentType(nestedType);
+            }
+        }
+
+        private void InstrumentProperty(PropertyDefinition property)
+        {
+            if (property.GetMethod != null && !property.GetMethod.IsAbstract)
+            {
+                InstrumentMethod(property.GetMethod);
+            }
+
+            if (property.SetMethod != null && !property.SetMethod.IsAbstract)
+            {
+                InstrumentMethod(property.SetMethod);
+            }
+        }
+
         private void InstrumentMethod(MethodDefinition method)
         {
-            if (!method.HasBody)
+            var sourceFile = method.DebugInformation.SequencePoints.Select(s => s.Document.Url).FirstOrDefault();
+            if (!string.IsNullOrEmpty(sourceFile) && _excludedFiles.Contains(sourceFile))
+                return;
+
+            var methodBody = GetMethodBody(method);
+            if (methodBody == null)
+                return;
+
+            if (method.IsNative)
                 return;
 
             InstrumentIL(method);
@@ -95,7 +133,7 @@ namespace Coverlet.Core.Instrumentation
             {
                 var instruction = processor.Body.Instructions[index];
                 var sequencePoint = method.DebugInformation.GetSequencePoint(instruction);
-                if (sequencePoint == null || sequencePoint.StartLine == 16707566)
+                if (sequencePoint == null || sequencePoint.StartLine == HiddenSequencePoint)
                 {
                     index++;
                     continue;
@@ -135,7 +173,7 @@ namespace Coverlet.Core.Instrumentation
 
             var pathInstr = Instruction.Create(OpCodes.Ldstr, _result.HitsFilePath);
             var markInstr = Instruction.Create(OpCodes.Ldstr, marker);
-            var callInstr = Instruction.Create(OpCodes.Call, processor.Body.Method.Module.ImportReference(typeof(CoverageTracker).GetMethod("MarkExecuted")));
+            var callInstr = Instruction.Create(OpCodes.Call, processor.Body.Method.Module.ImportReference(_markExecutedMethodLoader.Value));
 
             processor.InsertBefore(instruction, callInstr);
             processor.InsertBefore(callInstr, markInstr);
@@ -198,5 +236,29 @@ namespace Coverlet.Core.Instrumentation
             if (handler.TryStart == oldTarget)
                 handler.TryStart = newTarget;
         }
+
+        private static bool IsExcludeAttribute(CustomAttribute customAttribute)
+        {
+            return customAttribute.AttributeType.Name == nameof(ExcludeFromCoverageAttribute) || customAttribute.AttributeType.Name == "ExcludeFromCoverage";
+        }
+
+        private static Mono.Cecil.Cil.MethodBody GetMethodBody(MethodDefinition method)
+        {
+            try
+            {
+                return method.HasBody ? method.Body : null;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static MethodInfo GetMarkExecutedMethod()
+        {
+            return typeof(CoverageTracker).GetMethod(nameof(CoverageTracker.MarkExecuted));
+        }
+
+        private const int HiddenSequencePoint = 0xFEEFEE;
     }
 }

--- a/src/coverlet.core/Instrumentation/Instrumenter.cs
+++ b/src/coverlet.core/Instrumentation/Instrumenter.cs
@@ -79,31 +79,6 @@ namespace Coverlet.Core.Instrumentation
                 if (!method.CustomAttributes.Any(IsExcludeAttribute))
                     InstrumentMethod(method);
             }
-
-            foreach (var property in type.Properties)
-            {
-                if (!property.CustomAttributes.Any(IsExcludeAttribute))
-                    InstrumentProperty(property);
-            }
-
-            if (type.HasNestedTypes)
-            {
-                foreach (var nestedType in type.NestedTypes)
-                    InstrumentType(nestedType);
-            }
-        }
-
-        private void InstrumentProperty(PropertyDefinition property)
-        {
-            if (property.GetMethod != null && !property.GetMethod.IsAbstract)
-            {
-                InstrumentMethod(property.GetMethod);
-            }
-
-            if (property.SetMethod != null && !property.SetMethod.IsAbstract)
-            {
-                InstrumentMethod(property.SetMethod);
-            }
         }
 
         private void InstrumentMethod(MethodDefinition method)

--- a/src/coverlet.core/Instrumentation/Instrumenter.cs
+++ b/src/coverlet.core/Instrumentation/Instrumenter.cs
@@ -133,7 +133,7 @@ namespace Coverlet.Core.Instrumentation
             {
                 var instruction = processor.Body.Instructions[index];
                 var sequencePoint = method.DebugInformation.GetSequencePoint(instruction);
-                if (sequencePoint == null || sequencePoint.StartLine == HiddenSequencePoint)
+                if (sequencePoint == null || sequencePoint.IsHidden)
                 {
                     index++;
                     continue;
@@ -258,7 +258,5 @@ namespace Coverlet.Core.Instrumentation
         {
             return typeof(CoverageTracker).GetMethod(nameof(CoverageTracker.MarkExecuted));
         }
-
-        private const int HiddenSequencePoint = 0xFEEFEE;
     }
 }


### PR DESCRIPTION
This should fix #7 and #39.

Nested types were not being covered, which is probably why some LINQ code and anonymous types were not being marked as covered.

In addition to this I've also modified `ExcludeFromCodeCoverageAttribute` so that it can be applied to properties.

There have also been some other minor refactorings:
* Inline functions to local functions.
* Extract method for obtaining backup module path.
* Avoid hard-coding coverlet assembly name.
* Place the RetryHelper into an explicit `namespace`

Finally, I've improved performance by caching some reflection that retrieves `CoverageTracker.MarkExecuted()`. This should be a one-off operation instead of (potentially) once per sequence point.