### PR TITLE
[Skip CI] Specify what project to add the NuGet

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ _Note: The assembly you'd like to get coverage for must be different from the as
 
 ## Usage
 
-Coverlet doesn't require any additional setup other than including the NuGet package. It integrates with the `dotnet test` infrastructure built into the .NET Core CLI and when enabled, will automatically generate coverage results after tests are run.
+Coverlet doesn't require any additional setup other than including the NuGet package to the unit test project. It integrates with the `dotnet test` infrastructure built into the .NET Core CLI and when enabled, will automatically generate coverage results after tests are run.
 
 ### Code Coverage
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ _Note: The assembly you'd like to get coverage for must be different from the as
 
 ## Usage
 
-Coverlet doesn't require any additional setup other than including the NuGet package to the unit test project. It integrates with the `dotnet test` infrastructure built into the .NET Core CLI and when enabled, will automatically generate coverage results after tests are run.
+Coverlet doesn't require any additional setup other than including the NuGet package in the unit test project. It integrates with the `dotnet test` infrastructure built into the .NET Core CLI and when enabled, will automatically generate coverage results after tests are run.
 
 ### Code Coverage
 


### PR DESCRIPTION
As someone who never used code coverage it was not clear to me until I've read it in this post: https://medium.com/@tonerdo/setting-up-coveralls-with-coverlet-for-a-net-core-project-2c8ec6c5dc58