### PR TITLE
Branch Enhancements (take 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,6 +118,7 @@ _TeamCity*
 # Visual Studio code coverage results
 *.coverage
 *.coveragexml
+lcov.info
 
 # NCrunch
 _NCrunch_*

--- a/src/coverlet.core/CoverageDetails.cs
+++ b/src/coverlet.core/CoverageDetails.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Coverlet.Core
+{
+    public class CoverageDetails
+    {
+        public double Covered { get; internal set; }
+        public int Total { get; internal set; }
+        public double Percent
+        {
+            get => Math.Round(Total == 0 ? Total : Covered / Total, 3);
+        }
+    }
+}

--- a/src/coverlet.core/CoverageResult.cs
+++ b/src/coverlet.core/CoverageResult.cs
@@ -8,11 +8,29 @@ namespace Coverlet.Core
     public class LineInfo
     {
         public int Hits { get; set; }
-        public bool IsBranchPoint { get; set; }
+    }
+
+    public class BranchInfo : LineInfo
+    {
+        public int Offset { get; set; }
+        public int EndOffset { get; set; }
+        public int Path { get; set; }
+        public uint Ordinal { get; set; }
     }
 
     public class Lines : SortedDictionary<int, LineInfo> { }
-    public class Methods : Dictionary<string, Lines> { }
+    public class Branches : SortedDictionary<int, List<BranchInfo>> { }
+    public class Method
+    {
+        internal Method()
+        {
+            Lines = new Lines();
+            Branches = new Branches();
+        }
+        public Lines Lines;
+        public Branches Branches;
+    }
+    public class Methods : Dictionary<string, Method> { }
     public class Classes : Dictionary<string, Methods> { }
     public class Documents : Dictionary<string, Classes> { }
     public class Modules : Dictionary<string, Documents> { }

--- a/src/coverlet.core/CoverageSummary.cs
+++ b/src/coverlet.core/CoverageSummary.cs
@@ -4,149 +4,232 @@ using System.Linq;
 
 namespace Coverlet.Core
 {
+    public class CoverageDetails
+    {
+        public double Covered { get; set; }
+        public int Total { get; set; }
+        public double Percent { get; set; }
+    }
     public class CoverageSummary
     {
-        public double CalculateLineCoverage(Lines lines)
+        public CoverageDetails CalculateLineCoverage(Lines lines)
         {
-            double linesCovered = lines.Where(l => l.Value.Hits > 0).Count();
-            double coverage = lines.Count == 0 ? lines.Count : linesCovered / lines.Count;
-            return Math.Round(coverage, 3);
+            var details = new CoverageDetails();
+            details.Covered = lines.Where(l => l.Value.Hits > 0).Count();
+            details.Total = lines.Count;
+            double coverage = details.Total == 0 ? details.Total : details.Covered / details.Total;
+            details.Percent = Math.Round(coverage, 3);
+            return details;
         }
 
-        public double CalculateLineCoverage(Methods methods)
+        public CoverageDetails CalculateLineCoverage(Methods methods)
         {
-            double total = 0, average = 0;
+            var details = new CoverageDetails();
             foreach (var method in methods)
-                total += CalculateLineCoverage(method.Value);
+            {
+                var methodCoverage = CalculateLineCoverage(method.Value.Lines);
+                details.Covered += methodCoverage.Covered;
+                details.Total += methodCoverage.Total;
+            }
 
-            average = total / methods.Count;
-            return Math.Round(average, 3);
+            double coverage = details.Total == 0 ? details.Total : details.Covered / details.Total;
+            details.Percent = Math.Round(coverage, 3);
+            return details;
         }
 
-        public double CalculateLineCoverage(Classes classes)
+        public CoverageDetails CalculateLineCoverage(Classes classes)
         {
-            double total = 0, average = 0;
+            var details = new CoverageDetails();
             foreach (var @class in classes)
-                total += CalculateLineCoverage(@class.Value);
+            {
+                var classCoverage = CalculateLineCoverage(@class.Value);
+                details.Covered += classCoverage.Covered;
+                details.Total += classCoverage.Total;
+            }
 
-            average = total / classes.Count;
-            return Math.Round(average, 3);
+            double coverage = details.Total == 0 ? details.Total : details.Covered / details.Total;
+            details.Percent = Math.Round(coverage, 3);
+            return details;
         }
 
-        public double CalculateLineCoverage(Documents documents)
+        public CoverageDetails CalculateLineCoverage(Documents documents)
         {
-            double total = 0, average = 0;
+            var details = new CoverageDetails();
             foreach (var document in documents)
-                total += CalculateLineCoverage(document.Value);
+            {
+                var documentCoverage = CalculateLineCoverage(document.Value);
+                details.Covered += documentCoverage.Covered;
+                details.Total += documentCoverage.Total;
+            }
 
-            average = total / documents.Count;
-            return Math.Round(average, 3);
+            double coverage = details.Total == 0 ? details.Total : details.Covered / details.Total;
+            details.Percent = Math.Round(coverage, 3);
+            return details;
         }
 
-        public double CalculateLineCoverage(Modules modules)
+        public CoverageDetails CalculateLineCoverage(Modules modules)
         {
-            double total = 0, average = 0;
+            var details = new CoverageDetails();
             foreach (var module in modules)
-                total += CalculateLineCoverage(module.Value);
+            {
+                var moduleCoverage = CalculateLineCoverage(module.Value);
+                details.Covered += moduleCoverage.Covered;
+                details.Total += moduleCoverage.Total;
+            }
 
-            average = total / modules.Count;
-            return Math.Round(average, 3);
+            double coverage = details.Total == 0 ? details.Total : details.Covered / details.Total;
+            details.Percent = Math.Round(coverage, 3);
+            return details;
         }
 
-        public double CalculateBranchCoverage(Lines lines)
+        public CoverageDetails CalculateBranchCoverage(List<BranchInfo> branchInfo)
         {
-            double pointsCovered = lines.Where(l => l.Value.Hits > 0 && l.Value.IsBranchPoint).Count();
-            double totalPoints = lines.Where(l => l.Value.IsBranchPoint).Count();
-            double coverage = totalPoints == 0 ? totalPoints : pointsCovered / totalPoints;
-            return Math.Round(coverage, 3);
+            var details = new CoverageDetails();
+            details.Covered = branchInfo.Count(bi => bi.Hits > 0);
+            details.Total = branchInfo.Count;
+            double coverage = details.Total == 0 ? details.Total : details.Covered / details.Total;
+            details.Percent = Math.Round(coverage, 3);
+            return details;
         }
 
-        public double CalculateBranchCoverage(Methods methods)
+        public CoverageDetails CalculateBranchCoverage(Branches branches)
         {
-            double total = 0, average = 0;
+            var details = new CoverageDetails();
+            details.Covered = branches.Sum(b => b.Value.Where(bi => bi.Hits > 0).Count());
+            details.Total = branches.Sum(b => b.Value.Count());
+            double coverage = details.Total == 0 ? details.Total : details.Covered / details.Total;
+            details.Percent = Math.Round(coverage, 3);
+            return details;
+        }
+
+        public CoverageDetails CalculateBranchCoverage(Methods methods)
+        {
+            var details = new CoverageDetails();
             foreach (var method in methods)
-                total += CalculateBranchCoverage(method.Value);
+            {
+                var methodCoverage = CalculateBranchCoverage(method.Value.Branches);
+                details.Covered += methodCoverage.Covered;
+                details.Total += methodCoverage.Total;
+            }
 
-            average = total / methods.Count;
-            return Math.Round(average, 3);
+            double coverage = details.Total == 0 ? details.Total : details.Covered / details.Total;
+            details.Percent = Math.Round(coverage, 3);
+            return details;
         }
 
-        public double CalculateBranchCoverage(Classes classes)
+        public CoverageDetails CalculateBranchCoverage(Classes classes)
         {
-            double total = 0, average = 0;
+            var details = new CoverageDetails();
             foreach (var @class in classes)
-                total += CalculateBranchCoverage(@class.Value);
+            {
+                var classCoverage = CalculateBranchCoverage(@class.Value);
+                details.Covered += classCoverage.Covered;
+                details.Total += classCoverage.Total;
+            }
 
-            average = total / classes.Count;
-            return Math.Round(average, 3);
+            double coverage = details.Total == 0 ? details.Total : details.Covered / details.Total;
+            details.Percent = Math.Round(coverage, 3);
+            return details;
         }
 
-        public double CalculateBranchCoverage(Documents documents)
+        public CoverageDetails CalculateBranchCoverage(Documents documents)
         {
-            double total = 0, average = 0;
+            var details = new CoverageDetails();
             foreach (var document in documents)
-                total += CalculateBranchCoverage(document.Value);
+            {
+                var documentCoverage = CalculateBranchCoverage(document.Value);
+                details.Covered += documentCoverage.Covered;
+                details.Total += documentCoverage.Total;
+            }
 
-            average = total / documents.Count;
-            return Math.Round(average, 3);
+            double coverage = details.Total == 0 ? details.Total : details.Covered / details.Total;
+            details.Percent = Math.Round(coverage, 3);
+            return details;
         }
 
-        public double CalculateBranchCoverage(Modules modules)
+        public CoverageDetails CalculateBranchCoverage(Modules modules)
         {
-            double total = 0, average = 0;
+            var details = new CoverageDetails();
             foreach (var module in modules)
-                total += CalculateBranchCoverage(module.Value);
+            {
+                var moduleCoverage = CalculateBranchCoverage(module.Value);
+                details.Covered += moduleCoverage.Covered;
+                details.Total += moduleCoverage.Total;
+            }
 
-            average = total / modules.Count;
-            return Math.Round(average, 3);
+            double coverage = details.Total == 0 ? details.Total : details.Covered / details.Total;
+            details.Percent = Math.Round(coverage, 3);
+            return details;
         }
 
-        public double CalculateMethodCoverage(Lines lines)
+        public CoverageDetails CalculateMethodCoverage(Lines lines)
         {
-            if (lines.Any(l => l.Value.Hits > 0))
-                return 1;
-
-            return 0;
+            var details = new CoverageDetails();
+            details.Covered = lines.Any(l => l.Value.Hits > 0) ? 1 : 0;
+            details.Total = 1;
+            details.Percent = details.Covered;
+            return details;
         }
 
-        public double CalculateMethodCoverage(Methods methods)
+        public CoverageDetails CalculateMethodCoverage(Methods methods)
         {
-            double total = 0, average = 0;
-            foreach (var method in methods)
-                total += CalculateMethodCoverage(method.Value);
+            var details = new CoverageDetails();
+            var methodsWithLines = methods.Where(m => m.Value.Lines.Count > 0);
+            foreach (var method in methodsWithLines)
+            {
+                var methodCoverage = CalculateMethodCoverage(method.Value.Lines);
+                details.Covered += methodCoverage.Covered;
+            }
+            details.Total = methodsWithLines.Count();
 
-            average = total / methods.Count;
-            return Math.Round(average, 3);
+            double coverage = details.Total == 0 ? details.Total : details.Covered / details.Total;
+            details.Percent = Math.Round(coverage, 3);
+            return details;
         }
 
-        public double CalculateMethodCoverage(Classes classes)
+        public CoverageDetails CalculateMethodCoverage(Classes classes)
         {
-            double total = 0, average = 0;
+            var details = new CoverageDetails();
             foreach (var @class in classes)
-                total += CalculateMethodCoverage(@class.Value);
+            {
+                var classCoverage = CalculateMethodCoverage(@class.Value);
+                details.Covered += classCoverage.Covered;
+                details.Total += classCoverage.Total;
+            }
 
-            average = total / classes.Count;
-            return Math.Round(average, 3);
+            double coverage = details.Total == 0 ? details.Total : details.Covered / details.Total;
+            details.Percent = Math.Round(coverage, 3);
+            return details;
         }
 
-        public double CalculateMethodCoverage(Documents documents)
+        public CoverageDetails CalculateMethodCoverage(Documents documents)
         {
-            double total = 0, average = 0;
+            var details = new CoverageDetails();
             foreach (var document in documents)
-                total += CalculateMethodCoverage(document.Value);
+            {
+                var documentCoverage = CalculateMethodCoverage(document.Value);
+                details.Covered += documentCoverage.Covered;
+                details.Total += documentCoverage.Total;
+            }
 
-            average = total / documents.Count;
-            return Math.Round(average, 3);
+            double coverage = details.Total == 0 ? details.Total : details.Covered / details.Total;
+            details.Percent = Math.Round(coverage, 3);
+            return details;
         }
 
-        public double CalculateMethodCoverage(Modules modules)
+        public CoverageDetails CalculateMethodCoverage(Modules modules)
         {
-            double total = 0, average = 0;
+            var details = new CoverageDetails();
             foreach (var module in modules)
-                total += CalculateMethodCoverage(module.Value);
+            {
+                var moduleCoverage = CalculateMethodCoverage(module.Value);
+                details.Covered += moduleCoverage.Covered;
+                details.Total += moduleCoverage.Total;
+            }
 
-            average = total / modules.Count;
-            return Math.Round(average, 3);
+            double coverage = details.Total == 0 ? details.Total : details.Covered / details.Total;
+            details.Percent = Math.Round(coverage, 3);
+            return details;
         }
     }
 }

--- a/src/coverlet.core/CoverageSummary.cs
+++ b/src/coverlet.core/CoverageSummary.cs
@@ -4,12 +4,6 @@ using System.Linq;
 
 namespace Coverlet.Core
 {
-    public class CoverageDetails
-    {
-        public double Covered { get; set; }
-        public int Total { get; set; }
-        public double Percent { get; set; }
-    }
     public class CoverageSummary
     {
         public CoverageDetails CalculateLineCoverage(Lines lines)
@@ -17,8 +11,6 @@ namespace Coverlet.Core
             var details = new CoverageDetails();
             details.Covered = lines.Where(l => l.Value.Hits > 0).Count();
             details.Total = lines.Count;
-            double coverage = details.Total == 0 ? details.Total : details.Covered / details.Total;
-            details.Percent = Math.Round(coverage, 3);
             return details;
         }
 
@@ -31,9 +23,6 @@ namespace Coverlet.Core
                 details.Covered += methodCoverage.Covered;
                 details.Total += methodCoverage.Total;
             }
-
-            double coverage = details.Total == 0 ? details.Total : details.Covered / details.Total;
-            details.Percent = Math.Round(coverage, 3);
             return details;
         }
 
@@ -46,9 +35,6 @@ namespace Coverlet.Core
                 details.Covered += classCoverage.Covered;
                 details.Total += classCoverage.Total;
             }
-
-            double coverage = details.Total == 0 ? details.Total : details.Covered / details.Total;
-            details.Percent = Math.Round(coverage, 3);
             return details;
         }
 
@@ -61,9 +47,6 @@ namespace Coverlet.Core
                 details.Covered += documentCoverage.Covered;
                 details.Total += documentCoverage.Total;
             }
-
-            double coverage = details.Total == 0 ? details.Total : details.Covered / details.Total;
-            details.Percent = Math.Round(coverage, 3);
             return details;
         }
 
@@ -76,9 +59,6 @@ namespace Coverlet.Core
                 details.Covered += moduleCoverage.Covered;
                 details.Total += moduleCoverage.Total;
             }
-
-            double coverage = details.Total == 0 ? details.Total : details.Covered / details.Total;
-            details.Percent = Math.Round(coverage, 3);
             return details;
         }
 
@@ -87,8 +67,6 @@ namespace Coverlet.Core
             var details = new CoverageDetails();
             details.Covered = branchInfo.Count(bi => bi.Hits > 0);
             details.Total = branchInfo.Count;
-            double coverage = details.Total == 0 ? details.Total : details.Covered / details.Total;
-            details.Percent = Math.Round(coverage, 3);
             return details;
         }
 
@@ -97,8 +75,6 @@ namespace Coverlet.Core
             var details = new CoverageDetails();
             details.Covered = branches.Sum(b => b.Value.Where(bi => bi.Hits > 0).Count());
             details.Total = branches.Sum(b => b.Value.Count());
-            double coverage = details.Total == 0 ? details.Total : details.Covered / details.Total;
-            details.Percent = Math.Round(coverage, 3);
             return details;
         }
 
@@ -111,9 +87,6 @@ namespace Coverlet.Core
                 details.Covered += methodCoverage.Covered;
                 details.Total += methodCoverage.Total;
             }
-
-            double coverage = details.Total == 0 ? details.Total : details.Covered / details.Total;
-            details.Percent = Math.Round(coverage, 3);
             return details;
         }
 
@@ -126,9 +99,6 @@ namespace Coverlet.Core
                 details.Covered += classCoverage.Covered;
                 details.Total += classCoverage.Total;
             }
-
-            double coverage = details.Total == 0 ? details.Total : details.Covered / details.Total;
-            details.Percent = Math.Round(coverage, 3);
             return details;
         }
 
@@ -141,9 +111,6 @@ namespace Coverlet.Core
                 details.Covered += documentCoverage.Covered;
                 details.Total += documentCoverage.Total;
             }
-
-            double coverage = details.Total == 0 ? details.Total : details.Covered / details.Total;
-            details.Percent = Math.Round(coverage, 3);
             return details;
         }
 
@@ -156,9 +123,6 @@ namespace Coverlet.Core
                 details.Covered += moduleCoverage.Covered;
                 details.Total += moduleCoverage.Total;
             }
-
-            double coverage = details.Total == 0 ? details.Total : details.Covered / details.Total;
-            details.Percent = Math.Round(coverage, 3);
             return details;
         }
 
@@ -167,7 +131,6 @@ namespace Coverlet.Core
             var details = new CoverageDetails();
             details.Covered = lines.Any(l => l.Value.Hits > 0) ? 1 : 0;
             details.Total = 1;
-            details.Percent = details.Covered;
             return details;
         }
 
@@ -181,9 +144,6 @@ namespace Coverlet.Core
                 details.Covered += methodCoverage.Covered;
             }
             details.Total = methodsWithLines.Count();
-
-            double coverage = details.Total == 0 ? details.Total : details.Covered / details.Total;
-            details.Percent = Math.Round(coverage, 3);
             return details;
         }
 
@@ -196,9 +156,6 @@ namespace Coverlet.Core
                 details.Covered += classCoverage.Covered;
                 details.Total += classCoverage.Total;
             }
-
-            double coverage = details.Total == 0 ? details.Total : details.Covered / details.Total;
-            details.Percent = Math.Round(coverage, 3);
             return details;
         }
 
@@ -211,9 +168,6 @@ namespace Coverlet.Core
                 details.Covered += documentCoverage.Covered;
                 details.Total += documentCoverage.Total;
             }
-
-            double coverage = details.Total == 0 ? details.Total : details.Covered / details.Total;
-            details.Percent = Math.Round(coverage, 3);
             return details;
         }
 
@@ -226,9 +180,6 @@ namespace Coverlet.Core
                 details.Covered += moduleCoverage.Covered;
                 details.Total += moduleCoverage.Total;
             }
-
-            double coverage = details.Total == 0 ? details.Total : details.Covered / details.Total;
-            details.Percent = Math.Round(coverage, 3);
             return details;
         }
     }

--- a/src/coverlet.core/CoverageTracker.cs
+++ b/src/coverlet.core/CoverageTracker.cs
@@ -33,6 +33,7 @@ namespace Coverlet.Core
             }
         }
 
+        [ExcludeFromCoverage]
         public static void CurrentDomain_ProcessExit(object sender, EventArgs e)
         {
             foreach (var kvp in _markers)

--- a/src/coverlet.core/Extensions/HelperExtensions.cs
+++ b/src/coverlet.core/Extensions/HelperExtensions.cs
@@ -1,0 +1,16 @@
+
+using System;
+using Coverlet.Core.Attributes;
+
+namespace Coverlet.Core.Extensions
+{
+    internal static class HelperExtensions
+    {
+        [ExcludeFromCoverage]
+        public static TRet Maybe<T, TRet>(this T value, Func<T, TRet> action, TRet defValue = default(TRet))
+            where T : class
+        {
+            return (value != null) ? action(value) : defValue;
+        }
+    }
+}

--- a/src/coverlet.core/Instrumentation/Instrumenter.cs
+++ b/src/coverlet.core/Instrumentation/Instrumenter.cs
@@ -126,28 +126,25 @@ namespace Coverlet.Core.Instrumentation
                     index += 3;
                 }
 
-                if (targetedBranchPoints.Count() > 0)
+                foreach (var _branchTarget in targetedBranchPoints)
                 {
-                    foreach (var _branchTarget in targetedBranchPoints)
-                    {
-                        /*
-                         * Skip branches with no sequence point reference for now.
-                         * In this case for an anonymous class the compiler will dynamically create an Equals 'utility' method.
-                         * The CecilSymbolHelper will create branch points with a start line of -1 and no document, which
-                         * I am currently not sure how to handle.
-                         */
-                        if (_branchTarget.StartLine == -1 || _branchTarget.Document == null)
-                            continue;
-                        
-                        var target = AddInstrumentationCode(method, processor, instruction, _branchTarget);
-                        foreach (var _instruction in processor.Body.Instructions)
-                            ReplaceInstructionTarget(_instruction, instruction, target);
+                    /*
+                        * Skip branches with no sequence point reference for now.
+                        * In this case for an anonymous class the compiler will dynamically create an Equals 'utility' method.
+                        * The CecilSymbolHelper will create branch points with a start line of -1 and no document, which
+                        * I am currently not sure how to handle.
+                        */
+                    if (_branchTarget.StartLine == -1 || _branchTarget.Document == null)
+                        continue;
+                    
+                    var target = AddInstrumentationCode(method, processor, instruction, _branchTarget);
+                    foreach (var _instruction in processor.Body.Instructions)
+                        ReplaceInstructionTarget(_instruction, instruction, target);
 
-                        foreach (ExceptionHandler handler in processor.Body.ExceptionHandlers)
-                            ReplaceExceptionHandlerBoundary(handler, instruction, target);
+                    foreach (ExceptionHandler handler in processor.Body.ExceptionHandlers)
+                        ReplaceExceptionHandlerBoundary(handler, instruction, target);
 
-                        index += 3;
-                    }
+                    index += 3;
                 }
 
                 index++;
@@ -171,7 +168,6 @@ namespace Coverlet.Core.Instrumentation
                     document.Lines.Add(new Line { Number = i, Class = method.DeclaringType.FullName, Method = method.FullName });
             }
 
-            // string flag = branchPoints.Count > 0 ? "B" : "L";
             string marker = $"L,{document.Path},{sequencePoint.StartLine},{sequencePoint.EndLine}";
 
             var pathInstr = Instruction.Create(OpCodes.Ldstr, _result.HitsFilePath);

--- a/src/coverlet.core/Instrumentation/Instrumenter.cs
+++ b/src/coverlet.core/Instrumentation/Instrumenter.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 
 using Coverlet.Core.Attributes;
 using Coverlet.Core.Helpers;
+using Coverlet.Core.Symbols;
 
 using Mono.Cecil;
 using Mono.Cecil.Cil;
@@ -99,32 +100,59 @@ namespace Coverlet.Core.Instrumentation
 
         private void InstrumentIL(MethodDefinition method)
         {
+            method.Body.SimplifyMacros();
             ILProcessor processor = method.Body.GetILProcessor();
 
             var index = 0;
             var count = processor.Body.Instructions.Count;
 
+            var branchPoints = CecilSymbolHelper.GetBranchPoints(method);
+
             for (int n = 0; n < count; n++)
             {
                 var instruction = processor.Body.Instructions[index];
                 var sequencePoint = method.DebugInformation.GetSequencePoint(instruction);
-                if (sequencePoint == null || sequencePoint.IsHidden)
+                var targetedBranchPoints = branchPoints.Where(p => p.EndOffset == instruction.Offset);
+                
+                if (sequencePoint != null && !sequencePoint.IsHidden)
                 {
-                    index++;
-                    continue;
+                    var target = AddInstrumentationCode(method, processor, instruction, sequencePoint);
+                    foreach (var _instruction in processor.Body.Instructions)
+                        ReplaceInstructionTarget(_instruction, instruction, target);
+
+                    foreach (ExceptionHandler handler in processor.Body.ExceptionHandlers)
+                        ReplaceExceptionHandlerBoundary(handler, instruction, target);
+
+                    index += 3;
                 }
 
-                var target = AddInstrumentationCode(method, processor, instruction, sequencePoint);
-                foreach (var _instruction in processor.Body.Instructions)
-                    ReplaceInstructionTarget(_instruction, instruction, target);
+                if (targetedBranchPoints.Count() > 0)
+                {
+                    foreach (var _branchTarget in targetedBranchPoints)
+                    {
+                        /*
+                         * Skip branches with no sequence point reference for now.
+                         * In this case for an anonymous class the compiler will dynamically create an Equals 'utility' method.
+                         * The CecilSymbolHelper will create branch points with a start line of -1 and no document, which
+                         * I am currently not sure how to handle.
+                         */
+                        if (_branchTarget.StartLine == -1 || _branchTarget.Document == null)
+                            continue;
+                        
+                        var target = AddInstrumentationCode(method, processor, instruction, _branchTarget);
+                        foreach (var _instruction in processor.Body.Instructions)
+                            ReplaceInstructionTarget(_instruction, instruction, target);
 
-                foreach (ExceptionHandler handler in processor.Body.ExceptionHandlers)
-                    ReplaceExceptionHandlerBoundary(handler, instruction, target);
+                        foreach (ExceptionHandler handler in processor.Body.ExceptionHandlers)
+                            ReplaceExceptionHandlerBoundary(handler, instruction, target);
 
-                index += 4;
+                        index += 3;
+                    }
+                }
+
+                index++;
             }
 
-            method.Body.SimplifyMacros();
             method.Body.OptimizeMacros();
         }
 
@@ -143,8 +171,8 @@ namespace Coverlet.Core.Instrumentation
                     document.Lines.Add(new Line { Number = i, Class = method.DeclaringType.FullName, Method = method.FullName });
             }
 
-            string flag = IsBranchTarget(processor, instruction) ? "B" : "L";
-            string marker = $"{document.Path},{sequencePoint.StartLine},{sequencePoint.EndLine},{flag}";
+            // string flag = branchPoints.Count > 0 ? "B" : "L";
+            string marker = $"L,{document.Path},{sequencePoint.StartLine},{sequencePoint.EndLine}";
 
             var pathInstr = Instruction.Create(OpCodes.Ldstr, _result.HitsFilePath);
             var markInstr = Instruction.Create(OpCodes.Ldstr, marker);
@@ -157,21 +185,40 @@ namespace Coverlet.Core.Instrumentation
             return pathInstr;
         }
 
-        private static bool IsBranchTarget(ILProcessor processor, Instruction instruction)
+        private Instruction AddInstrumentationCode(MethodDefinition method, ILProcessor processor, Instruction instruction, BranchPoint branchPoint)
         {
-            foreach (var _instruction in processor.Body.Instructions)
+            var document = _result.Documents.FirstOrDefault(d => d.Path == branchPoint.Document);
+            if (document == null)
             {
-                if (_instruction.Operand is Instruction target)
-                {
-                    if (target == instruction)
-                        return true;
-                }
-
-                if (_instruction.Operand is Instruction[] targets)
-                    return targets.Any(t => t == instruction);
+                document = new Document { Path = branchPoint.Document };
+                _result.Documents.Add(document);
             }
 
-            return false;
+            if (!document.Branches.Exists(l => l.Number == branchPoint.StartLine && l.Ordinal == branchPoint.Ordinal))
+                document.Branches.Add(
+                    new Branch
+                    {
+                        Number = branchPoint.StartLine,
+                        Class = method.DeclaringType.FullName,
+                        Method = method.FullName,
+                        Offset = branchPoint.Offset,
+                        EndOffset = branchPoint.EndOffset,
+                        Path = branchPoint.Path,
+                        Ordinal = branchPoint.Ordinal
+                    }
+                );
+
+            string marker = $"B,{document.Path},{branchPoint.StartLine},{branchPoint.Ordinal}";
+
+            var pathInstr = Instruction.Create(OpCodes.Ldstr, _result.HitsFilePath);
+            var markInstr = Instruction.Create(OpCodes.Ldstr, marker);
+            var callInstr = Instruction.Create(OpCodes.Call, processor.Body.Method.Module.ImportReference(_markExecutedMethodLoader.Value));
+
+            processor.InsertBefore(instruction, callInstr);
+            processor.InsertBefore(callInstr, markInstr);
+            processor.InsertBefore(markInstr, pathInstr);
+
+            return pathInstr;
         }
 
         private static void ReplaceInstructionTarget(Instruction instruction, Instruction oldTarget, Instruction newTarget)

--- a/src/coverlet.core/Instrumentation/InstrumenterResult.cs
+++ b/src/coverlet.core/Instrumentation/InstrumenterResult.cs
@@ -7,16 +7,28 @@ namespace Coverlet.Core.Instrumentation
         public int Number;
         public string Class;
         public string Method;
-        public bool IsBranchTarget;
         public int Hits;
+    }
+
+    internal class Branch : Line
+    {
+        public int Offset;
+        public int EndOffset;
+        public int Path;
+        public uint Ordinal;
     }
 
     internal class Document
     {
-        public Document() => Lines = new List<Line>();
+        public Document()
+        {
+            Lines = new List<Line>();
+            Branches = new List<Branch>();
+        }
 
         public string Path;
         public List<Line> Lines { get; private set; }
+        public List<Branch> Branches { get; private set; }
     }
 
     internal class InstrumenterResult

--- a/src/coverlet.core/Reporters/LcovReporter.cs
+++ b/src/coverlet.core/Reporters/LcovReporter.cs
@@ -12,58 +12,48 @@ namespace Coverlet.Core.Reporters
 
         public string Report(CoverageResult result)
         {
+            CoverageSummary summary = new CoverageSummary();
             List<string> lcov = new List<string>();
-            int numSequencePoints = 0, numBranchPoints = 0, numMethods = 0, numBlockBranch = 1;
-            int visitedSequencePoints = 0, visitedBranchPoints = 0, visitedMethods = 0;
 
             foreach (var module in result.Modules)
             {
                 foreach (var doc in module.Value)
                 {
+                    var docLineCoverage = summary.CalculateLineCoverage(doc.Value);
+                    var docBranchCoverage = summary.CalculateBranchCoverage(doc.Value);
+                    var docMethodCoverage = summary.CalculateMethodCoverage(doc.Value);
+
                     lcov.Add("SF:" + doc.Key);
                     foreach (var @class in doc.Value)
                     {
-                        bool methodVisited = false;
                         foreach (var method in @class.Value)
                         {
-                            lcov.Add($"FN:{method.Value.First().Key - 1},{method.Key}");
-                            lcov.Add($"FNDA:{method.Value.First().Value.Hits},{method.Key}");
+                            // Skip all methods with no lines
+                            if (method.Value.Lines.Count == 0)
+                                continue;
 
-                            foreach (var line in method.Value)
-                            {
+                            lcov.Add($"FN:{method.Value.Lines.First().Key - 1},{method.Key}");
+                            lcov.Add($"FNDA:{method.Value.Lines.First().Value.Hits},{method.Key}");
+
+                            foreach (var line in method.Value.Lines)
                                 lcov.Add($"DA:{line.Key},{line.Value.Hits}");
-                                numSequencePoints++;
 
-                                if (line.Value.IsBranchPoint)
-                                {
-                                    lcov.Add($"BRDA:{line.Key},{numBlockBranch},{numBlockBranch},{line.Value.Hits}");
-                                    numBlockBranch++;
-                                    numBranchPoints++;
-                                }
-
-                                if (line.Value.Hits > 0)
-                                {
-                                    visitedSequencePoints++;
-                                    methodVisited = true;
-                                    if (line.Value.IsBranchPoint)
-                                        visitedBranchPoints++;
-                                }
+                            foreach (var branchs in method.Value.Branches)
+                            {
+                                foreach (var branch in branchs.Value)
+                                    lcov.Add($"BRDA:{branchs.Key},{branch.Offset},{branch.Path},{branch.Hits}");
                             }
-
-                            numMethods++;
-                            if (methodVisited)
-                                visitedMethods++;
                         }
                     }
 
-                    lcov.Add($"LH:{visitedSequencePoints}");
-                    lcov.Add($"LF:{numSequencePoints}");
+                    lcov.Add($"LF:{docLineCoverage.Total}");
+                    lcov.Add($"LH:{docLineCoverage.Covered}");
 
-                    lcov.Add($"BRF:{numBranchPoints}");
-                    lcov.Add($"BRH:{visitedBranchPoints}");
+                    lcov.Add($"BRF:{docBranchCoverage.Total}");
+                    lcov.Add($"BRH:{docBranchCoverage.Covered}");
 
-                    lcov.Add($"FNF:{numMethods}");
-                    lcov.Add($"FNH:{visitedMethods}");
+                    lcov.Add($"FNF:{docMethodCoverage.Total}");
+                    lcov.Add($"FNH:{docMethodCoverage.Covered}");
 
                     lcov.Add("end_of_record");
                 }

--- a/src/coverlet.core/Symbols/BranchPoint.cs
+++ b/src/coverlet.core/Symbols/BranchPoint.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Text.RegularExpressions;
+
+namespace Coverlet.Core.Symbols
+{
+    /// <summary>
+    /// a branch point
+    /// </summary>
+    public class BranchPoint
+    {
+        /// <summary>
+        /// Line of the branching instruction
+        /// </summary>
+        public int StartLine { get; set; }
+
+        /// <summary>
+        /// A path that can be taken
+        /// </summary>
+        public int Path { get; set; }
+
+        /// <summary>
+        /// An order of the point within the method
+        /// </summary>
+        public UInt32 Ordinal { get; set; }
+
+        /// <summary>
+        /// List of OffsetPoints between Offset and EndOffset (exclusive)
+        /// </summary>
+        public System.Collections.Generic.List<int> OffsetPoints { get; set; }
+
+        /// <summary>
+        /// The IL offset of the point
+        /// </summary>
+        public int Offset { get; set; }
+
+        /// <summary>
+        /// Last Offset == EndOffset.
+        /// Can be same as Offset
+        /// </summary>
+        public int EndOffset { get; set; }
+
+        /// <summary>
+        /// The url to the document if an entry was not mapped to an id
+        /// </summary>
+        public string Document { get; set; }
+    }
+}

--- a/src/coverlet.core/Symbols/CecilSymbolHelper.cs
+++ b/src/coverlet.core/Symbols/CecilSymbolHelper.cs
@@ -1,0 +1,290 @@
+//
+// This class is based heavily on the work of the OpenCover
+// team in OpenCover.Framework.Symbols.CecilSymbolManager
+//
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+using Coverlet.Core.Extensions;
+
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Mono.Collections.Generic;
+
+namespace Coverlet.Core.Symbols
+{
+    public static class CecilSymbolHelper
+    {
+        private const int StepOverLineCode = 0xFEEFEE;
+        private static readonly Regex IsMovenext = new Regex(@"\<[^\s>]+\>\w__\w(\w)?::MoveNext\(\)$", RegexOptions.Compiled | RegexOptions.ExplicitCapture);
+        public static List<BranchPoint> GetBranchPoints(MethodDefinition methodDefinition)
+        {
+            var list = new List<BranchPoint>();
+            GetBranchPoints(methodDefinition, list);
+            return list;
+        }
+        private static void GetBranchPoints(MethodDefinition methodDefinition, List<BranchPoint> list)
+        {
+            if (methodDefinition == null) 
+                return;
+            try
+            {
+                UInt32 ordinal = 0;
+                var instructions = methodDefinition.Body.Instructions;
+                
+                // if method is a generated MoveNext skip first branch (could be a switch or a branch)
+                var skipFirstBranch = IsMovenext.IsMatch(methodDefinition.FullName);
+
+                foreach (var instruction in instructions.Where(instruction => instruction.OpCode.FlowControl == FlowControl.Cond_Branch))
+                {
+                    if (skipFirstBranch)
+                    {
+                        skipFirstBranch = false;
+                        continue;
+                    }
+
+                    if (BranchIsInGeneratedFinallyBlock(instruction, methodDefinition)) 
+                        continue;
+
+                    var pathCounter = 0;
+
+                    // store branch origin offset
+                    var branchOffset = instruction.Offset;
+                    var closestSeqPt = FindClosestInstructionWithSequencePoint(methodDefinition.Body, instruction).Maybe(i => methodDefinition.DebugInformation.GetSequencePoint(i));
+                    var branchingInstructionLine = closestSeqPt.Maybe(x => x.StartLine, -1);
+                    var document = closestSeqPt.Maybe(x => x.Document.Url);
+
+                    if (null == instruction.Next)
+                        return;
+
+                    if (!BuildPointsForConditionalBranch(list, instruction, branchingInstructionLine, document, branchOffset, pathCounter, instructions, ref ordinal, methodDefinition)) 
+                        return;
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException(
+                    $"An error occurred with 'GetBranchPointsForToken' for method '{methodDefinition.FullName}'", ex);
+            }
+        }
+
+        private static bool BuildPointsForConditionalBranch(List<BranchPoint> list, Instruction instruction,
+            int branchingInstructionLine, string document, int branchOffset, int pathCounter, 
+            Collection<Instruction> instructions, ref uint ordinal, MethodDefinition methodDefinition)
+        {
+            // Add Default branch (Path=0)
+
+            // Follow else/default instruction
+            var @else = instruction.Next;
+
+            var pathOffsetList = GetBranchPath(@else);
+
+            // add Path 0
+            var path0 = new BranchPoint
+            {
+                StartLine = branchingInstructionLine,
+                Document = document,
+                Offset = branchOffset,
+                Ordinal = ordinal++,
+                Path = pathCounter++,
+                OffsetPoints =
+                    pathOffsetList.Count > 1
+                        ? pathOffsetList.GetRange(0, pathOffsetList.Count - 1)
+                        : new List<int>(),
+                EndOffset = pathOffsetList.Last()
+            };
+
+            // Add Conditional Branch (Path=1)
+            if (instruction.OpCode.Code != Code.Switch)
+            {
+                // Follow instruction at operand
+                var @then = instruction.Operand as Instruction;
+                if (@then == null)
+                    return false;
+
+                ordinal = BuildPointsForBranch(list, then, branchingInstructionLine, document, branchOffset,
+                    ordinal, pathCounter, path0, instructions, methodDefinition);
+            }
+            else // instruction.OpCode.Code == Code.Switch
+            {
+                var branchInstructions = instruction.Operand as Instruction[];
+                if (branchInstructions == null || branchInstructions.Length == 0)
+                    return false;
+
+                ordinal = BuildPointsForSwitchCases(list, path0, branchInstructions, branchingInstructionLine,
+                    document, branchOffset, ordinal, ref pathCounter);
+            }
+            return true;
+        }
+
+        private static uint BuildPointsForBranch(List<BranchPoint> list, Instruction then, int branchingInstructionLine, string document,
+            int branchOffset, uint ordinal, int pathCounter, BranchPoint path0, Collection<Instruction> instructions, MethodDefinition methodDefinition)
+        {
+            var pathOffsetList1 = GetBranchPath(@then);
+
+            // Add path 1
+            var path1 = new BranchPoint
+            {
+                StartLine = branchingInstructionLine,
+                Document = document,
+                Offset = branchOffset,
+                Ordinal = ordinal++,
+                Path = pathCounter,
+                OffsetPoints =
+                    pathOffsetList1.Count > 1
+                        ? pathOffsetList1.GetRange(0, pathOffsetList1.Count - 1)
+                        : new List<int>(),
+                EndOffset = pathOffsetList1.Last()
+            };
+
+            // only add branch if branch does not match a known sequence 
+            // e.g. auto generated field assignment
+            // or encapsulates at least one sequence point
+            var offsets = new[]
+            {
+                path0.Offset,
+                path0.EndOffset,
+                path1.Offset,
+                path1.EndOffset
+            };
+
+            var ignoreSequences = new[]
+            {
+                // we may need other samples
+                new[] {Code.Brtrue_S, Code.Pop, Code.Ldsfld, Code.Ldftn, Code.Newobj, Code.Dup, Code.Stsfld, Code.Newobj}, // CachedAnonymousMethodDelegate field allocation 
+            };
+
+            var bs = offsets.Min();
+            var be = offsets.Max();
+
+            var range = instructions.Where(i => (i.Offset >= bs) && (i.Offset <= be)).ToList();
+
+            var match = ignoreSequences
+                .Where(ignoreSequence => range.Count >= ignoreSequence.Length)
+                .Any(ignoreSequence => range.Zip(ignoreSequence, (instruction, code) => instruction.OpCode.Code == code).All(x => x));
+
+            var count = range
+                .Count(i => methodDefinition.DebugInformation.GetSequencePoint(i) != null);
+
+            if (!match || count > 0)
+            {
+                list.Add(path0);
+                list.Add(path1);
+            }
+            return ordinal;
+        }
+
+        private static uint BuildPointsForSwitchCases(List<BranchPoint> list, BranchPoint path0, Instruction[] branchInstructions,
+            int branchingInstructionLine, string document, int branchOffset, uint ordinal, ref int pathCounter)
+        {
+            var counter = pathCounter;
+            list.Add(path0);
+            // Add Conditional Branches (Path>0)
+            list.AddRange(branchInstructions.Select(GetBranchPath)
+                .Select(pathOffsetList1 => new BranchPoint
+                {
+                    StartLine = branchingInstructionLine,
+                    Document = document,
+                    Offset = branchOffset,
+                    Ordinal = ordinal++,
+                    Path = counter++,
+                    OffsetPoints =
+                        pathOffsetList1.Count > 1
+                            ? pathOffsetList1.GetRange(0, pathOffsetList1.Count - 1)
+                            : new List<int>(),
+                    EndOffset = pathOffsetList1.Last()
+                }));
+            pathCounter = counter;
+            return ordinal;
+        }
+
+        private static bool BranchIsInGeneratedFinallyBlock(Instruction branchInstruction, MethodDefinition methodDefinition)
+        {
+            if (!methodDefinition.Body.HasExceptionHandlers) 
+                return false;
+            
+            // a generated finally block will have no sequence points in its range
+            var handlers = methodDefinition.Body.ExceptionHandlers
+                .Where(e => e.HandlerType == ExceptionHandlerType.Finally)
+                .ToList();
+
+            return handlers
+                .Where(e => branchInstruction.Offset >= e.HandlerStart.Offset)
+                .Where( e =>branchInstruction.Offset < e.HandlerEnd.Maybe(h => h.Offset, GetOffsetOfNextEndfinally(methodDefinition.Body, e.HandlerStart.Offset)))
+                .OrderByDescending(h => h.HandlerStart.Offset) // we need to work inside out
+                .Any(eh => !(methodDefinition.DebugInformation.GetSequencePointMapping()
+                    .Where(i => i.Value.StartLine != StepOverLineCode)
+                    .Any(i => i.Value.Offset >= eh.HandlerStart.Offset && i.Value.Offset < eh.HandlerEnd.Maybe(h => h.Offset, GetOffsetOfNextEndfinally(methodDefinition.Body, eh.HandlerStart.Offset)))));
+        }
+
+        private static int GetOffsetOfNextEndfinally(MethodBody body, int startOffset)
+        {
+            var lastOffset = body.Instructions.LastOrDefault().Maybe(i => i.Offset, int.MaxValue);
+            return body.Instructions.FirstOrDefault(i => i.Offset >= startOffset && i.OpCode.Code == Code.Endfinally).Maybe(i => i.Offset, lastOffset);
+        }
+
+        private static List<int> GetBranchPath(Instruction instruction)
+        {
+            var offsetList = new List<int>();
+
+            if (instruction != null)
+            {
+                var point = instruction;
+                offsetList.Add(point.Offset);
+                while ( point.OpCode == OpCodes.Br || point.OpCode == OpCodes.Br_S )
+                {
+                    var nextPoint = point.Operand as Instruction;
+                    if (nextPoint != null)
+                    {
+                        point = nextPoint;
+                        offsetList.Add(point.Offset);
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+            }
+
+            return offsetList;
+        }
+
+        private static Instruction FindClosestInstructionWithSequencePoint(MethodBody methodBody, Instruction instruction)
+        {
+            var sequencePointsInMethod = methodBody.Instructions.Where(i => HasValidSequencePoint(i, methodBody.Method)).ToList();
+            if (!sequencePointsInMethod.Any()) 
+                return null;
+            var idx = sequencePointsInMethod.BinarySearch(instruction, new InstructionByOffsetComparer());
+            Instruction prev;
+            if (idx < 0)
+            {
+                // no exact match, idx corresponds to the next, larger element
+                var lower = Math.Max(~idx - 1, 0);
+                prev = sequencePointsInMethod[lower];
+            }
+            else
+            {
+                // exact match, idx corresponds to the match
+                prev = sequencePointsInMethod[idx];
+            }
+
+            return prev;
+        }
+
+        private static bool HasValidSequencePoint(Instruction instruction, MethodDefinition methodDefinition)
+        {
+            var sp = methodDefinition.DebugInformation.GetSequencePoint(instruction);
+            return sp != null && sp.StartLine != StepOverLineCode;
+        }
+
+        private class InstructionByOffsetComparer : IComparer<Instruction>
+        {
+            public int Compare(Instruction x, Instruction y)
+            {
+                return x.Offset.CompareTo(y.Offset);
+            }
+        }
+    }
+}

--- a/src/coverlet.core/Symbols/CecilSymbolHelper.cs
+++ b/src/coverlet.core/Symbols/CecilSymbolHelper.cs
@@ -19,6 +19,7 @@ namespace Coverlet.Core.Symbols
     {
         private const int StepOverLineCode = 0xFEEFEE;
         private static readonly Regex IsMovenext = new Regex(@"\<[^\s>]+\>\w__\w(\w)?::MoveNext\(\)$", RegexOptions.Compiled | RegexOptions.ExplicitCapture);
+
         public static List<BranchPoint> GetBranchPoints(MethodDefinition methodDefinition)
         {
             var list = new List<BranchPoint>();
@@ -56,7 +57,7 @@ namespace Coverlet.Core.Symbols
                     var branchingInstructionLine = closestSeqPt.Maybe(x => x.StartLine, -1);
                     var document = closestSeqPt.Maybe(x => x.Document.Url);
 
-                    if (null == instruction.Next)
+                    if (instruction.Next == null)
                         return;
 
                     if (!BuildPointsForConditionalBranch(list, instruction, branchingInstructionLine, document, branchOffset, pathCounter, instructions, ref ordinal, methodDefinition)) 

--- a/src/coverlet.msbuild.tasks/CoverageResultTask.cs
+++ b/src/coverlet.msbuild.tasks/CoverageResultTask.cs
@@ -59,12 +59,13 @@ namespace Coverlet.MSbuild.Tasks
 
                 double total = 0;
                 CoverageSummary summary = new CoverageSummary();
-                ConsoleTable table = new ConsoleTable("Module", "Coverage");
+                ConsoleTable table = new ConsoleTable("Module", "Line Coverage", "Branch Coverage");
 
                 foreach (var module in result.Modules)
                 {
-                    double percent = summary.CalculateLineCoverage(module.Value) * 100;
-                    table.AddRow(System.IO.Path.GetFileNameWithoutExtension(module.Key), $"{percent}%");
+                    double percent = summary.CalculateLineCoverage(module.Value).Percent * 100;
+                    double branchPercent = summary.CalculateBranchCoverage(module.Value).Percent * 100;
+                    table.AddRow(System.IO.Path.GetFileNameWithoutExtension(module.Key), $"{percent}%", $"{branchPercent}%");
                     total += percent;
                 }
 

--- a/test/coverlet.core.tests/CoverageSummaryTests.cs
+++ b/test/coverlet.core.tests/CoverageSummaryTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 using Coverlet.Core;
@@ -14,11 +15,18 @@ namespace Coverlet.Core.Tests
         public CoverageSummaryTests()
         {
             Lines lines = new Lines();
-            lines.Add(1, new LineInfo { Hits = 1, IsBranchPoint = true });
+            lines.Add(1, new LineInfo { Hits = 1 });
             lines.Add(2, new LineInfo { Hits = 0 });
+            Branches branches = new Branches();
+            branches.Add(1, new List<BranchInfo>());
+            branches[1].Add(new BranchInfo { Hits = 1, Offset = 1, Path = 0, Ordinal = 1 });
+            branches[1].Add(new BranchInfo { Hits = 1, Offset = 1, Path = 1, Ordinal = 2 });
 
             Methods methods = new Methods();
-            methods.Add("System.Void Coverlet.Core.Tests.CoverageSummaryTests::TestCalculateSummary()", lines);
+            var methodString = "System.Void Coverlet.Core.Tests.CoverageSummaryTests::TestCalculateSummary()";
+            methods.Add(methodString, new Method());
+            methods[methodString].Lines = lines;
+            methods[methodString].Branches = branches;
 
             Classes classes = new Classes();
             classes.Add("Coverlet.Core.Tests.CoverageSummaryTests", methods);
@@ -40,10 +48,10 @@ namespace Coverlet.Core.Tests
             var @class = document.Value.First();
             var method = @class.Value.First();
             
-            Assert.Equal(0.5, summary.CalculateLineCoverage(module.Value));
-            Assert.Equal(0.5, summary.CalculateLineCoverage(document.Value));
-            Assert.Equal(0.5, summary.CalculateLineCoverage(@class.Value));
-            Assert.Equal(0.5, summary.CalculateLineCoverage(method.Value));
+            Assert.Equal(0.5, summary.CalculateLineCoverage(module.Value).Percent);
+            Assert.Equal(0.5, summary.CalculateLineCoverage(document.Value).Percent);
+            Assert.Equal(0.5, summary.CalculateLineCoverage(@class.Value).Percent);
+            Assert.Equal(0.5, summary.CalculateLineCoverage(method.Value.Lines).Percent);
         }
 
         [Fact]
@@ -56,10 +64,10 @@ namespace Coverlet.Core.Tests
             var @class = document.Value.First();
             var method = @class.Value.First();
 
-            Assert.Equal(1, summary.CalculateBranchCoverage(module.Value));
-            Assert.Equal(1, summary.CalculateBranchCoverage(document.Value));
-            Assert.Equal(1, summary.CalculateBranchCoverage(@class.Value));
-            Assert.Equal(1, summary.CalculateBranchCoverage(method.Value));
+            Assert.Equal(1, summary.CalculateBranchCoverage(module.Value).Percent);
+            Assert.Equal(1, summary.CalculateBranchCoverage(document.Value).Percent);
+            Assert.Equal(1, summary.CalculateBranchCoverage(@class.Value).Percent);
+            Assert.Equal(1, summary.CalculateBranchCoverage(method.Value.Branches).Percent);
         }
 
         [Fact]
@@ -72,10 +80,10 @@ namespace Coverlet.Core.Tests
             var @class = document.Value.First();
             var method = @class.Value.First();
 
-            Assert.Equal(1, summary.CalculateMethodCoverage(module.Value));
-            Assert.Equal(1, summary.CalculateMethodCoverage(document.Value));
-            Assert.Equal(1, summary.CalculateMethodCoverage(@class.Value));
-            Assert.Equal(1, summary.CalculateMethodCoverage(method.Value));
+            Assert.Equal(1, summary.CalculateMethodCoverage(module.Value).Percent);
+            Assert.Equal(1, summary.CalculateMethodCoverage(document.Value).Percent);
+            Assert.Equal(1, summary.CalculateMethodCoverage(@class.Value).Percent);
+            Assert.Equal(1, summary.CalculateMethodCoverage(method.Value.Lines).Percent);
         }
     }
 }

--- a/test/coverlet.core.tests/CoverageTests.cs
+++ b/test/coverlet.core.tests/CoverageTests.cs
@@ -5,6 +5,7 @@ using Xunit;
 using Moq;
 
 using Coverlet.Core;
+using System.Collections.Generic;
 
 namespace Coverlet.Core.Tests
 {
@@ -13,19 +14,26 @@ namespace Coverlet.Core.Tests
         [Fact]
         public void TestCoverage()
         {
-            string module = typeof(CoverageTests).Assembly.Location;
+            string module = GetType().Assembly.Location;
+            string pdb = Path.Combine(Path.GetDirectoryName(module), Path.GetFileNameWithoutExtension(module) + ".pdb");
             string identifier = Guid.NewGuid().ToString();
 
             var directory = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), identifier));
-            var tempModule = Path.Combine(directory.FullName, Path.GetFileName(module));
 
-            File.Copy(module, tempModule, true);
+            File.Copy(module, Path.Combine(directory.FullName, Path.GetFileName(module)), true);
+            File.Copy(pdb, Path.Combine(directory.FullName, Path.GetFileName(pdb)), true);
 
-            var coverage = new Coverage(tempModule, identifier);
+            // TODO: Find a way to mimick hits
+
+            // Since Coverage only instruments dependancies, we need a fake module here
+            var testModule = Path.Combine(directory.FullName, "test.module.dll");
+
+            var coverage = new Coverage(testModule, identifier);
             coverage.PrepareModules();
 
             var result = coverage.GetCoverageResult();
-            Assert.Empty(result.Modules);
+
+            Assert.NotEmpty(result.Modules);
 
             directory.Delete(true);
         }

--- a/test/coverlet.core.tests/Instrumentation/InstrumenterResultTests.cs
+++ b/test/coverlet.core.tests/Instrumentation/InstrumenterResultTests.cs
@@ -14,10 +14,11 @@ namespace Coverlet.Core.Instrumentation.Tests
         }
 
         [Fact]
-        public void TestEnsureLinesPropertyNotNull()
+        public void TestEnsureLinesAndBranchesPropertyNotNull()
         {
             Document document = new Document();
             Assert.NotNull(document.Lines);
+            Assert.NotNull(document.Branches);
         }
     }
 }

--- a/test/coverlet.core.tests/Instrumentation/InstrumenterTests.cs
+++ b/test/coverlet.core.tests/Instrumentation/InstrumenterTests.cs
@@ -11,7 +11,7 @@ namespace Coverlet.Core.Instrumentation.Tests
         [Fact]
         public void TestInstrument()
         {
-            string module = typeof(InstrumenterTests).Assembly.Location;
+            string module = GetType().Assembly.Location;
             string pdb = Path.Combine(Path.GetDirectoryName(module), Path.GetFileNameWithoutExtension(module) + ".pdb");
             string identifier = Guid.NewGuid().ToString();
 

--- a/test/coverlet.core.tests/Reporters/CoberturaReporterTests.cs
+++ b/test/coverlet.core.tests/Reporters/CoberturaReporterTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Xunit;
 
 namespace Coverlet.Core.Reporters.Tests
@@ -13,8 +14,16 @@ namespace Coverlet.Core.Reporters.Tests
             Lines lines = new Lines();
             lines.Add(1, new LineInfo { Hits = 1 });
             lines.Add(2, new LineInfo { Hits = 0 });
+            Branches branches = new Branches();
+            branches.Add(1, new List<BranchInfo> {
+                new BranchInfo{ Hits = 1, Offset = 23, EndOffset = 24, Path = 0, Ordinal = 1 },
+                new BranchInfo{ Hits = 0, Offset = 23, EndOffset = 27, Path = 1, Ordinal = 2 }
+            });
             Methods methods = new Methods();
-            methods.Add("System.Void Coverlet.Core.Reporters.Tests.CoberturaReporterTests::TestReport()", lines);
+            var methodString = "System.Void Coverlet.Core.Reporters.Tests.CoberturaReporterTests::TestReport()";
+            methods.Add(methodString, new Method());
+            methods[methodString].Lines = lines;
+            methods[methodString].Branches = branches;
             Classes classes = new Classes();
             classes.Add("Coverlet.Core.Reporters.Tests.CoberturaReporterTests", methods);
             Documents documents = new Documents();

--- a/test/coverlet.core.tests/Reporters/JsonReporterTests.cs
+++ b/test/coverlet.core.tests/Reporters/JsonReporterTests.cs
@@ -14,7 +14,9 @@ namespace Coverlet.Core.Reporters.Tests
             lines.Add(1, new LineInfo { Hits = 1 });
             lines.Add(2, new LineInfo { Hits = 0 });
             Methods methods = new Methods();
-            methods.Add("System.Void Coverlet.Core.Reporters.Tests.JsonReporterTests.TestReport()", lines);
+            var methodString = "System.Void Coverlet.Core.Reporters.Tests.JsonReporterTests.TestReport()";
+            methods.Add(methodString, new Method());
+            methods[methodString].Lines = lines;
             Classes classes = new Classes();
             classes.Add("Coverlet.Core.Reporters.Tests.JsonReporterTests", methods);
             Documents documents = new Documents();

--- a/test/coverlet.core.tests/Reporters/LcovReporterTests.cs
+++ b/test/coverlet.core.tests/Reporters/LcovReporterTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Xunit;
 
 namespace Coverlet.Core.Reporters.Tests
@@ -13,8 +14,16 @@ namespace Coverlet.Core.Reporters.Tests
             Lines lines = new Lines();
             lines.Add(1, new LineInfo { Hits = 1 });
             lines.Add(2, new LineInfo { Hits = 0 });
+            Branches branches = new Branches();
+            branches.Add(1, new List<BranchInfo> {
+                new BranchInfo{ Hits = 1, Offset = 23, EndOffset = 24, Path = 0, Ordinal = 1 },
+                new BranchInfo{ Hits = 0, Offset = 23, EndOffset = 27, Path = 1, Ordinal = 2 }
+            });
             Methods methods = new Methods();
-            methods.Add("System.Void Coverlet.Core.Reporters.Tests.LcovReporterTests.TestReport()", lines);
+            var methodString = "System.Void Coverlet.Core.Reporters.Tests.LcovReporterTests.TestReport()";
+            methods.Add(methodString, new Method());
+            methods[methodString].Lines = lines;
+            methods[methodString].Branches = branches;
             Classes classes = new Classes();
             classes.Add("Coverlet.Core.Reporters.Tests.LcovReporterTests", methods);
             Documents documents = new Documents();

--- a/test/coverlet.core.tests/Reporters/OpenCoverReporterTests.cs
+++ b/test/coverlet.core.tests/Reporters/OpenCoverReporterTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Xunit;
 
 namespace Coverlet.Core.Reporters.Tests
@@ -41,8 +42,16 @@ namespace Coverlet.Core.Reporters.Tests
             Lines lines = new Lines();
             lines.Add(1, new LineInfo { Hits = 1 });
             lines.Add(2, new LineInfo { Hits = 0 });
+            Branches branches = new Branches();
+            branches.Add(1, new List<BranchInfo> {
+                new BranchInfo{ Hits = 1, Offset = 23, EndOffset = 24, Path = 0, Ordinal = 1 },
+                new BranchInfo{ Hits = 0, Offset = 23, EndOffset = 27, Path = 1, Ordinal = 2 }
+            });
             Methods methods = new Methods();
-            methods.Add("System.Void Coverlet.Core.Reporters.Tests.OpenCoverReporterTests.TestReport()", lines);
+            var methodString = "System.Void Coverlet.Core.Reporters.Tests.OpenCoverReporterTests.TestReport()";
+            methods.Add(methodString, new Method());
+            methods[methodString].Lines = lines;
+            methods[methodString].Branches = branches;
             Classes classes = new Classes();
             classes.Add("Coverlet.Core.Reporters.Tests.OpenCoverReporterTests", methods);
             Documents documents = new Documents();
@@ -57,7 +66,9 @@ namespace Coverlet.Core.Reporters.Tests
             lines.Add(2, new LineInfo { Hits = 0 });
 
             Methods methods = new Methods();
-            methods.Add("System.Void Some.Other.Module.TestClass.TestMethod()", lines);
+            var methodString = "System.Void Some.Other.Module.TestClass.TestMethod()";
+            methods.Add(methodString, new Method());
+            methods[methodString].Lines = lines;
 
             Classes classes2 = new Classes();
             classes2.Add("Some.Other.Module.TestClass", methods);

--- a/test/coverlet.core.tests/Samples/Samples.cs
+++ b/test/coverlet.core.tests/Samples/Samples.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Coverlet.Core.Samples.Tests
+{
+    class ConstructorNotDeclaredClass
+    {        
+    }
+    class DeclaredConstructorClass
+    {
+        DeclaredConstructorClass() { }
+
+        public bool HasSingleDecision(string input)
+        {
+            if (input.Contains("test")) return true;
+            return false;
+        }        
+
+        public bool HasTwoDecisions(string input)
+        {
+            if (input.Contains("test")) return true;
+            if (input.Contains("xxx")) return true;
+            return false;
+        }
+
+        public bool HasCompleteIf(string input)
+        {
+            if (input.Contains("test"))
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public bool HasSwitch(int input)
+        {
+            switch (input)
+            {
+                case 0:
+                    return true;
+                case 1:
+                    return false;
+                case 2:
+                    return true;
+            }
+            return false;
+        }
+
+        public bool HasSwitchWithDefault(int input)
+        {
+            switch (input)
+            {
+                case 1:
+                    return true;
+                case 2:
+                    return false;
+                case 3:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        public bool HasSwitchWithBreaks(int input)
+        {
+            bool ret = false;
+            switch (input)
+            {
+                case 1:
+                    ret = true;
+                    break;
+                case 2:
+                    ret = false;
+                    break;
+                case 3:
+                    ret = true;
+                    break;
+            }
+
+            return ret;
+        }
+
+        public int HasSwitchWithMultipleCases(int input)
+        {
+            switch (input)
+            {
+                case 1:
+                    return -1;
+                case 2:
+                    return 2001;
+                case 3:
+                    return -5001;
+                default:
+                    return 7;
+            }
+        }
+
+        public string HasSimpleUsingStatement()
+        {
+            string value;
+            try
+            {
+                
+            }
+            finally
+            {
+                using (var stream = new MemoryStream())
+                {
+                    var x = stream.Length;
+                    value = x > 1000 ? "yes" : "no";
+                }
+            }
+            return value;
+        }
+
+        public void HasSimpleTaskWithLambda()
+        {
+            var t = new Task(() => { });
+        }
+
+        public string UsingWithException_Issue243()
+        {
+            using (var ms = new MemoryStream()) // IL generates a finally block for using to dispose the stream
+            {
+                throw new Exception();
+            }
+        }
+    }
+
+    public class LinqIssue
+    {
+        public void Method()
+        {
+            var s = new ObservableCollection<string>();
+            var x = (from a in s select new {a});
+        }
+
+        public object Property
+        {
+            get
+            {
+                var s = new ObservableCollection<string>();
+                var x = (from a in s select new { a });
+                return x;
+            }
+        }
+    }
+
+    public class Iterator
+    {
+        public IEnumerable<string> Fetch()
+        {
+            yield return "one";
+            yield return "two";
+        } 
+    }
+}

--- a/test/coverlet.core.tests/Symbols/CecilSymbolHelperTests.cs
+++ b/test/coverlet.core.tests/Symbols/CecilSymbolHelperTests.cs
@@ -1,0 +1,263 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+
+using Xunit;
+using Coverlet.Core.Samples.Tests;
+
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+
+namespace Coverlet.Core.Symbols.Tests
+{
+    public class CecilSymbolHelperTests
+    {
+        private ModuleDefinition _module;
+        public CecilSymbolHelperTests()
+        {
+            var location = GetType().Assembly.Location;
+            var resolver = new DefaultAssemblyResolver();
+            resolver.AddSearchDirectory(Path.GetDirectoryName(location));
+            var parameters = new ReaderParameters { ReadSymbols = true, AssemblyResolver = resolver };
+            _module = ModuleDefinition.ReadModule(location, parameters);
+        }
+
+        [Fact]
+        public void GetBranchPoints_OneBranch()
+        {
+            // arrange
+            var type = _module.Types.First(x => x.FullName == typeof(DeclaredConstructorClass).FullName);
+            var method = type.Methods.First(x => x.FullName.Contains("::HasSingleDecision"));
+
+            // act
+            var points = CecilSymbolHelper.GetBranchPoints(method);
+
+            // assert
+            Assert.NotNull(points);
+            Assert.Equal(2, points.Count());
+            Assert.Equal(points[0].Offset, points[1].Offset);
+            Assert.Equal(0, points[0].Path);
+            Assert.Equal(1, points[1].Path);
+            Assert.Equal(19, points[0].StartLine);
+            Assert.Equal(19, points[1].StartLine);
+            Assert.NotNull(points[1].Document);
+            Assert.Equal(points[0].Document, points[1].Document);
+        }
+
+        [Fact]
+        public void GetBranchPoints_Using_Where_GeneratedBranchesIgnored()
+        {
+            // arrange
+            var type = _module.Types.First(x => x.FullName == typeof(DeclaredConstructorClass).FullName);
+            var method = type.Methods.First(x => x.FullName.Contains("::HasSimpleUsingStatement"));
+
+            // act
+            var points = CecilSymbolHelper.GetBranchPoints(method);
+
+            Assert.Equal(2, points.Count());
+        }
+
+        [Fact]
+        public void GetBranchPoints_GeneratedBranches_DueToCachedAnonymousMethodDelegate_Ignored()
+        {
+            // arrange
+            var type = _module.Types.First(x => x.FullName == typeof(DeclaredConstructorClass).FullName);
+            var method = type.Methods.First(x => x.FullName.Contains("::HasSimpleTaskWithLambda"));
+
+            // act
+            var points = CecilSymbolHelper.GetBranchPoints(method);
+
+            Assert.Empty(points);
+        }
+
+        [Fact]
+        public void GetBranchPoints_TwoBranch()
+        {
+            // arrange
+            var type = _module.Types.First(x => x.FullName == typeof(DeclaredConstructorClass).FullName);
+            var method = type.Methods.First(x => x.FullName.Contains("::HasTwoDecisions"));
+
+            // act
+            var points = CecilSymbolHelper.GetBranchPoints(method);
+
+            // assert
+            Assert.NotNull(points);
+            Assert.Equal(4, points.Count());
+            Assert.Equal(points[0].Offset, points[1].Offset);
+            Assert.Equal(points[2].Offset, points[3].Offset);
+            Assert.Equal(25, points[0].StartLine);
+            Assert.Equal(26, points[2].StartLine);
+        }
+
+        [Fact]
+        public void GetBranchPoints_CompleteIf()
+        {
+            // arrange
+            var type = _module.Types.First(x => x.FullName == typeof(DeclaredConstructorClass).FullName);
+            var method = type.Methods.First(x => x.FullName.Contains("::HasCompleteIf"));
+
+            // act
+            var points = CecilSymbolHelper.GetBranchPoints(method);
+
+            // assert
+            Assert.NotNull(points);
+            Assert.Equal(2, points.Count());
+            Assert.Equal(points[0].Offset, points[1].Offset);
+            Assert.Equal(32, points[0].StartLine);
+            Assert.Equal(32, points[1].StartLine);
+        }
+
+        [Fact]
+        public void GetBranchPoints_Switch()
+        {
+            // arrange
+            var type = _module.Types.First(x => x.FullName == typeof(DeclaredConstructorClass).FullName);
+            var method = type.Methods.First(x => x.FullName.Contains("::HasSwitch"));
+
+            // act
+            var points = CecilSymbolHelper.GetBranchPoints(method);
+
+            // assert
+            Assert.NotNull(points);
+            Assert.Equal(4, points.Count());
+            Assert.Equal(points[0].Offset, points[1].Offset);
+            Assert.Equal(points[0].Offset, points[2].Offset);            
+            Assert.Equal(3, points[3].Path);
+            
+            Assert.Equal(44, points[0].StartLine);
+            Assert.Equal(44, points[1].StartLine);
+            Assert.Equal(44, points[2].StartLine);
+            Assert.Equal(44, points[3].StartLine);
+        }
+
+        [Fact]
+        public void GetBranchPoints_SwitchWithDefault()
+        {
+            // arrange
+            var type = _module.Types.First(x => x.FullName == typeof(DeclaredConstructorClass).FullName);
+            var method = type.Methods.First(x => x.FullName.Contains("::HasSwitchWithDefault"));
+
+            // act
+            var points = CecilSymbolHelper.GetBranchPoints(method);
+
+            // assert
+            Assert.NotNull(points);
+            Assert.Equal(4, points.Count());
+            Assert.Equal(points[0].Offset, points[1].Offset);
+            Assert.Equal(points[0].Offset, points[2].Offset);
+            Assert.Equal(3, points[3].Path);
+            
+            Assert.Equal(58, points[0].StartLine);
+            Assert.Equal(58, points[1].StartLine);
+            Assert.Equal(58, points[2].StartLine);
+            Assert.Equal(58, points[3].StartLine);
+        }
+
+        [Fact]
+        public void GetBranchPoints_SwitchWithBreaks()
+        {
+            // arrange
+            var type = _module.Types.First(x => x.FullName == typeof(DeclaredConstructorClass).FullName);
+            var method = type.Methods.First(x => x.FullName.Contains("::HasSwitchWithBreaks"));
+
+            // act
+            var points = CecilSymbolHelper.GetBranchPoints(method);
+
+            // assert
+            Assert.NotNull(points);
+            Assert.Equal(4, points.Count());
+            Assert.Equal(points[0].Offset, points[1].Offset);
+            Assert.Equal(points[0].Offset, points[2].Offset);
+            Assert.Equal(3, points[3].Path);
+
+            Assert.Equal(74, points[0].StartLine);
+            Assert.Equal(74, points[1].StartLine);
+            Assert.Equal(74, points[2].StartLine);
+            Assert.Equal(74, points[3].StartLine);
+        }
+
+        [Fact]
+        public void GetBranchPoints_SwitchWithMultipleCases()
+        {
+            // arrange
+            var type = _module.Types.First(x => x.FullName == typeof(DeclaredConstructorClass).FullName);
+            var method = type.Methods.First(x => x.FullName.Contains("::HasSwitchWithMultipleCases"));
+
+            // act
+            var points = CecilSymbolHelper.GetBranchPoints(method);
+            
+            // assert
+            Assert.NotNull(points);
+            Assert.Equal(4, points.Count()); 
+            Assert.Equal(points[0].Offset, points[1].Offset);
+            Assert.Equal(points[0].Offset, points[2].Offset);
+            Assert.Equal(points[0].Offset, points[3].Offset);
+            Assert.Equal(3, points[3].Path);
+
+            Assert.Equal(92, points[0].StartLine);
+            Assert.Equal(92, points[1].StartLine);
+            Assert.Equal(92, points[2].StartLine);
+            Assert.Equal(92, points[3].StartLine);
+        }
+
+        [Fact]
+        public void GetBranchPoints_AssignsNegativeLineNumberToBranchesInMethodsThatHaveNoInstrumentablePoints()
+        {
+            /* 
+             * Yes these actually exist - the compiler is very inventive
+             * in this case for an anonymous class the compiler will dynamically create an Equals 'utility' method. 
+             */
+            // arrange
+            var type = _module.Types.First(x => x.FullName.Contains("f__AnonymousType"));
+            var method = type.Methods.First(x => x.FullName.Contains("::Equals"));
+
+            // act
+            var points = CecilSymbolHelper.GetBranchPoints(method);
+
+            // assert
+            Assert.NotNull(points);
+            foreach (var branchPoint in points)
+                Assert.Equal(-1, branchPoint.StartLine);
+        }
+
+        [Fact]
+        public void GetBranchPoints_UsingWithException_Issue243_IgnoresBranchInFinallyBlock()
+        {
+            // arrange
+            var type = _module.Types.First(x => x.FullName == typeof(DeclaredConstructorClass).FullName);
+            var method = type.Methods.First(x => x.FullName.Contains("::UsingWithException_Issue243"));
+
+            // check that the method is laid out the way we discovered it to be during the defect
+            // @see https://github.com/OpenCover/opencover/issues/243
+            Assert.Single(method.Body.ExceptionHandlers);
+            Assert.NotNull(method.Body.ExceptionHandlers[0].HandlerStart);
+            Assert.Null(method.Body.ExceptionHandlers[0].HandlerEnd);
+            Assert.Equal(1, method.Body.Instructions.Count(i => i.OpCode.FlowControl == FlowControl.Cond_Branch));
+            Assert.True(method.Body.Instructions.First(i => i.OpCode.FlowControl == FlowControl.Cond_Branch).Offset > method.Body.ExceptionHandlers[0].HandlerStart.Offset);
+
+            // act
+            var points = CecilSymbolHelper.GetBranchPoints(method);
+
+            // assert
+            Assert.Empty(points);
+        }
+
+        [Fact]
+        public void GetBranchPoints_IgnoresSwitchIn_GeneratedMoveNext()
+        {
+            // arrange
+            var nestedName = typeof (Iterator).GetNestedTypes(BindingFlags.NonPublic).First().Name;
+            var type = _module.Types.FirstOrDefault(x => x.FullName == typeof(Iterator).FullName);
+            var nestedType = type.NestedTypes.FirstOrDefault(x => x.FullName.EndsWith(nestedName));
+            var method = nestedType.Methods.First(x => x.FullName.EndsWith("::MoveNext()"));
+
+            // act
+            var points = CecilSymbolHelper.GetBranchPoints(method);
+
+            // assert
+            Assert.Empty(points);
+
+        }
+    }
+}


### PR DESCRIPTION
## Description

This PR covers a lot of changes in order to better support branch coverage.  The main purpose of this refactor is two-fold.  First, to add improved support for branch coverage.  Second, to improve the output of the 3 supported report formats by adding previously missing information.

At a high level, this PR covers the objectives by:

- Resolving #67.
  - Updated all report generators with new branch logic.
- Changing Coverage Calculation from average of averages to a single average of the sums of covered/total points (for line, branch, and method).
  - Utilized the new `CoverageDetails` result model from `CoverageSummary` in report generators in lieu of manually tracking and incrementing visits and counts.

### Note

I re-forked and re-applied the changed from #69 because I managed to royally screw up the git history in that fork.  What that means is I've effectively squashed all those commits into one, so you don't get to see my fun debugging journey, and for that - I'm sorry.