### PR TITLE
Issue #92 : Added a ThresholdType switch

### DIFF
--- a/src/coverlet.msbuild.tasks/CoverageResultTask.cs
+++ b/src/coverlet.msbuild.tasks/CoverageResultTask.cs
@@ -1,11 +1,10 @@
 using System;
-using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Text;
 using ConsoleTables;
-
 using Coverlet.Core;
 using Coverlet.Core.Reporters;
-
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
@@ -16,6 +15,7 @@ namespace Coverlet.MSbuild.Tasks
         private string _filename;
         private string _format;
         private int _threshold;
+        private string _thresholdTypes;
 
         [Required]
         public string Output
@@ -38,17 +38,26 @@ namespace Coverlet.MSbuild.Tasks
             set { _threshold = value; }
         }
 
+        [Required]
+        public string ThresholdType
+        {
+            get { return _thresholdTypes; }
+            set { _thresholdTypes = value; }
+        }
+
         public override bool Execute()
         {
             try
             {
                 Console.WriteLine("\nCalculating coverage result...");
                 var coverage = InstrumentationTask.Coverage;
-                CoverageResult result = coverage.GetCoverageResult();
+                var result = coverage.GetCoverageResult();
 
                 var directory = Path.GetDirectoryName(_filename);
                 if (!Directory.Exists(directory))
+                {
                     Directory.CreateDirectory(directory);
+                }
 
                 var formats = _format.Split(',');
                 foreach (var format in formats)
@@ -62,25 +71,66 @@ namespace Coverlet.MSbuild.Tasks
                     File.WriteAllText(report, reporter.Report(result));
                 }
 
-                double total = 0;
-                CoverageSummary summary = new CoverageSummary();
-                ConsoleTable table = new ConsoleTable("Module", "Line", "Branch", "Method");
+                var branchTotal = 0d;
+                var methodTotal = 0d;
+                var lineTotal = 0d;
+                var summary = new CoverageSummary();
+                var table = new ConsoleTable("Module", "Line", "Branch", "Method");
 
                 foreach (var module in result.Modules)
                 {
-                    double linePercent = summary.CalculateLineCoverage(module.Value).Percent * 100;
-                    double branchPercent = summary.CalculateBranchCoverage(module.Value).Percent * 100;
-                    double methodPercent = summary.CalculateMethodCoverage(module.Value).Percent * 100;
+                    var linePercent = summary.CalculateLineCoverage(module.Value).Percent * 100;
+                    var branchPercent = summary.CalculateBranchCoverage(module.Value).Percent * 100;
+                    var methodPercent = summary.CalculateMethodCoverage(module.Value).Percent * 100;
                     table.AddRow(Path.GetFileNameWithoutExtension(module.Key), $"{linePercent}%", $"{branchPercent}%", $"{methodPercent}%");
-                    total += linePercent;
+
+                    lineTotal += linePercent;
+                    branchTotal += branchPercent;
+                    methodTotal += methodPercent;
                 }
 
                 Console.WriteLine();
                 Console.WriteLine(table.ToStringAlternative());
 
-                double average = total / result.Modules.Count;
-                if (average < _threshold)
-                    throw new Exception($"Overall average coverage '{average}%' is lower than specified threshold '{_threshold}%'");
+                if (_threshold > 0)
+                {
+                    var thresholdFailed = false;
+                    var exceptionBuilder = new StringBuilder();
+                    var lineAverage = lineTotal / result.Modules.Count;
+                    var branchAverage = branchTotal / result.Modules.Count;
+                    var methodAverage = methodTotal / result.Modules.Count;
+                    var thresholdTypes = _thresholdTypes.Split(',').Select(t => t.ToLower());
+                    foreach (var thresholdType in thresholdTypes)
+                    {
+                        if (thresholdType == "line" && lineAverage < _threshold)
+                        {
+                            thresholdFailed = true;
+                            exceptionBuilder.AppendLine($"Overall average '{thresholdType}' coverage '{lineAverage}%' is lower than specified threshold '{_threshold}%'");
+                        }
+
+                        else if (thresholdType == "branch" && branchAverage < _threshold)
+                        {
+                            thresholdFailed = true;
+                            exceptionBuilder.AppendLine($"Overall average '{thresholdType}' coverage '{branchAverage}%' is lower than specified threshold '{_threshold}%'");
+                        }
+
+                        else if (thresholdType == "method" && methodAverage < _threshold)
+                        {
+                            thresholdFailed = true;
+                            exceptionBuilder.AppendLine($"Overall average '{thresholdType}' coverage '{methodAverage}%' is lower than specified threshold '{_threshold}%'");
+                        }
+
+                        else if (thresholdType != "line" && thresholdType != "branch" && thresholdType != "method")
+                        {
+                            Console.WriteLine($"Threshold type of {thresholdType} is not recognized/supported and will be ignored.");
+                        }
+                    }
+
+                    if (thresholdFailed)
+                    {
+                        throw new Exception(exceptionBuilder.ToString().TrimEnd(Environment.NewLine.ToCharArray()));
+                    }
+                }
             }
             catch (Exception ex)
             {

--- a/src/coverlet.msbuild/coverlet.msbuild.props
+++ b/src/coverlet.msbuild/coverlet.msbuild.props
@@ -7,6 +7,7 @@
     <CoverletOutput>$([MSBuild]::EnsureTrailingSlash('$(CoverletOutputDirectory)'))$(CoverletOutputName)</CoverletOutput>
     <Exclude Condition="$(Exclude) == ''"></Exclude>
     <Threshold Condition="$(Threshold) == ''">0</Threshold>
+    <ThresholdType Condition="$(ThresholdType) == ''">line,branch,method</ThresholdType>
     <CollectCoverage Condition="$(CollectCoverage) == ''">false</CollectCoverage>
   </PropertyGroup>
 

--- a/src/coverlet.msbuild/coverlet.msbuild.targets
+++ b/src/coverlet.msbuild/coverlet.msbuild.targets
@@ -22,7 +22,8 @@
       Condition="$(CollectCoverage) == 'true'"
       Output="$(CoverletOutput)"
       OutputFormat="$(CoverletOutputFormat)"
-      Threshold="$(Threshold)" />
+      Threshold="$(Threshold)"
+      ThresholdType="$(ThresholdType)" />
   </Target>
 
 </Project>


### PR DESCRIPTION
Issue #92 : Added a ThresholdType switch that accepts a comma separated string of coverage types to apply to the threshold. It defaults to all coverage types and will ignore any unsupported coverage type