### PR TITLE
Add ability to exclude assemblies by expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,18 +87,34 @@ You can ignore a method or an entire class from code coverage by creating and ap
 Coverlet just uses the type name, so the attributes can be created under any namespace of your choosing.
 
 #### Source Files  
-You can also ignore specific source files from code coverage using the `Exclude` property
+You can also ignore specific source files from code coverage using the `ExcludeByFile` property
  - Use single or multiple paths (separate by comma)
  - Use absolute or relative paths (relative to the project directory)
  - Use file path or directory path with globbing (e.g `dir1/*.cs`)
 
 ```bash
-dotnet test /p:CollectCoverage=true /p:Exclude=\"../dir1/class1.cs,../dir2/*.cs,../dir3/**/*.cs,\"
+dotnet test /p:CollectCoverage=true /p:ExcludeByFile=\"../dir1/class1.cs,../dir2/*.cs,../dir3/**/*.cs,\"
 ```
+
+#### Filters 
+Coverlet gives the ability to have fine grained control over what gets excluded using "filter expressions".
+
+Syntax: `/p:Exclude=[Assembly-Filter]Type-Filter`
+
+Examples
+ - `/p:Exclude="[*]*"` => Excludes all types in all assemblies (nothing is instrumented)
+ - `/p:Exclude="[coverlet.*]Coverlet.Core.Coverage"` => Excludes the Coverage class in the `Coverlet.Core` namespace belonging to any assembly that matches `coverlet.*` (e.g `coverlet.core`)
+ - `/p:Exclude="[*]Coverlet.Core.Instrumentation.*"` => Excludes all types belonging to `Coverlet.Core.Instrumentation` namespace in any assembly
+
+```bash
+dotnet test /p:CollectCoverage=true /p:Exclude="[coverlet.*]Coverlet.Core.Coverage"
+```
+
+You can specify multiple fiter expressions by separting them with a comma (`,`).
 
 ## Roadmap
 
-* Filter modules to be instrumented
+* Merging outputs (multiple test projects, one coverage result)
 * Support for more output formats (e.g. JaCoCo)
 * Console runner (removes the need for requiring a NuGet package)
 

--- a/src/coverlet.core/Coverage.cs
+++ b/src/coverlet.core/Coverage.cs
@@ -14,22 +14,22 @@ namespace Coverlet.Core
         private string _module;
         private string _identifier;
         private string[] _filters;
-        private string[] _excludes;
+        private string[] _rules;
         private List<InstrumenterResult> _results;
 
-        public Coverage(string module, string identifier, string[] filters, string[] excludes)
+        public Coverage(string module, string identifier, string[] filters, string[] rules)
         {
             _module = module;
             _identifier = identifier;
             _filters = filters;
-            _excludes = excludes;
+            _rules = rules;
             _results = new List<InstrumenterResult>();
         }
 
         public void PrepareModules()
         {
             string[] modules = InstrumentationHelper.GetCoverableModules(_module);
-            string[] excludedFiles =  InstrumentationHelper.GetExcludedFiles(_excludes);
+            string[] excludedFiles =  InstrumentationHelper.GetExcludedFiles(_rules);
 
             foreach (var module in modules)
             {

--- a/src/coverlet.core/Coverage.cs
+++ b/src/coverlet.core/Coverage.cs
@@ -13,24 +13,30 @@ namespace Coverlet.Core
     {
         private string _module;
         private string _identifier;
-        private IEnumerable<string> _excludeRules;
+        private string[] _filters;
+        private string[] _excludes;
         private List<InstrumenterResult> _results;
 
-        public Coverage(string module, string identifier, IEnumerable<string> excludeRules = null)
+        public Coverage(string module, string identifier, string[] filters, string[] excludes)
         {
             _module = module;
             _identifier = identifier;
-            _excludeRules = excludeRules;
+            _filters = filters;
+            _excludes = excludes;
             _results = new List<InstrumenterResult>();
         }
 
         public void PrepareModules()
         {
-            string[] modules = InstrumentationHelper.GetDependencies(_module);
-            var excludedFiles =  InstrumentationHelper.GetExcludedFiles(_excludeRules);
+            string[] modules = InstrumentationHelper.GetCoverableModules(_module);
+            string[] excludedFiles =  InstrumentationHelper.GetExcludedFiles(_excludes);
+
             foreach (var module in modules)
             {
-                var instrumenter = new Instrumenter(module, _identifier, excludedFiles);
+                if (InstrumentationHelper.IsModuleExcluded(module, _filters))
+                    continue;
+
+                var instrumenter = new Instrumenter(module, _identifier, _filters, excludedFiles);
                 if (instrumenter.CanInstrument())
                 {
                     InstrumentationHelper.BackupOriginalModule(module, _identifier);

--- a/src/coverlet.core/Helpers/InstrumentationHelper.cs
+++ b/src/coverlet.core/Helpers/InstrumentationHelper.cs
@@ -131,15 +131,15 @@ namespace Coverlet.Core.Helpers
             return isMatch;
         }
 
-        public static string[] GetExcludedFiles(string[] excludes)
+        public static string[] GetExcludedFiles(string[] rules)
         {
             const string RELATIVE_KEY = nameof(RELATIVE_KEY);
             string parentDir = Directory.GetCurrentDirectory();
 
-            if (excludes == null || !excludes.Any()) return Array.Empty<string>();
+            if (rules == null || !rules.Any()) return Array.Empty<string>();
 
             var matcherDict = new Dictionary<string, Matcher>() { { RELATIVE_KEY, new Matcher() } };
-            foreach (var excludeRule in excludes)
+            foreach (var excludeRule in rules)
             {
                 if (Path.IsPathRooted(excludeRule))
                 {

--- a/src/coverlet.core/Instrumentation/Instrumenter.cs
+++ b/src/coverlet.core/Instrumentation/Instrumenter.cs
@@ -75,7 +75,7 @@ namespace Coverlet.Core.Instrumentation
         private void InstrumentType(TypeDefinition type)
         {
             if (type.CustomAttributes.Any(IsExcludeAttribute)
-                && InstrumentationHelper.IsTypeExcluded(type.FullName, _filters))
+                || InstrumentationHelper.IsTypeExcluded(_module, type.FullName, _filters))
                 return;
 
             foreach (var method in type.Methods)

--- a/src/coverlet.msbuild.tasks/InstrumentationTask.cs
+++ b/src/coverlet.msbuild.tasks/InstrumentationTask.cs
@@ -9,6 +9,7 @@ namespace Coverlet.MSbuild.Tasks
     {
         private static Coverage _coverage;
         private string _path;
+        private string _filter;
         private string _exclude;
 
         internal static Coverage Coverage
@@ -22,19 +23,27 @@ namespace Coverlet.MSbuild.Tasks
             get { return _path; }
             set { _path = value; }
         }
+        
+        public string Filter
+        {
+            get { return _filter; }
+            set { _filter = value; }
+        }
 
         public string Exclude
         {
-            get { return _path; }
-            set { _path = value; }
+            get { return _exclude; }
+            set { _exclude = value; }
         }
 
         public override bool Execute()
         {
             try
             {
-                var excludeRules = _exclude?.Split(',');
-                _coverage = new Coverage(_path, Guid.NewGuid().ToString(), excludeRules);
+                var excludes = _exclude?.Split(',');
+                var filters = _filter?.Split(',');
+
+                _coverage = new Coverage(_path, Guid.NewGuid().ToString(), filters, excludes);
                 _coverage.PrepareModules();
             }
             catch (Exception ex)

--- a/src/coverlet.msbuild.tasks/InstrumentationTask.cs
+++ b/src/coverlet.msbuild.tasks/InstrumentationTask.cs
@@ -9,7 +9,7 @@ namespace Coverlet.MSbuild.Tasks
     {
         private static Coverage _coverage;
         private string _path;
-        private string _filter;
+        private string _exclude;
         private string _excludeByFile;
 
         internal static Coverage Coverage
@@ -24,10 +24,10 @@ namespace Coverlet.MSbuild.Tasks
             set { _path = value; }
         }
         
-        public string Filter
+        public string Exclude
         {
-            get { return _filter; }
-            set { _filter = value; }
+            get { return _exclude; }
+            set { _exclude = value; }
         }
 
         public string ExcludeByFile
@@ -40,10 +40,10 @@ namespace Coverlet.MSbuild.Tasks
         {
             try
             {
-                var excludes = _excludeByFile?.Split(',');
-                var filters = _filter?.Split(',');
+                var rules = _excludeByFile?.Split(',');
+                var filters = _exclude?.Split(',');
 
-                _coverage = new Coverage(_path, Guid.NewGuid().ToString(), filters, excludes);
+                _coverage = new Coverage(_path, Guid.NewGuid().ToString(), filters, rules);
                 _coverage.PrepareModules();
             }
             catch (Exception ex)

--- a/src/coverlet.msbuild.tasks/InstrumentationTask.cs
+++ b/src/coverlet.msbuild.tasks/InstrumentationTask.cs
@@ -10,7 +10,7 @@ namespace Coverlet.MSbuild.Tasks
         private static Coverage _coverage;
         private string _path;
         private string _filter;
-        private string _exclude;
+        private string _excludeByFile;
 
         internal static Coverage Coverage
         {
@@ -30,17 +30,17 @@ namespace Coverlet.MSbuild.Tasks
             set { _filter = value; }
         }
 
-        public string Exclude
+        public string ExcludeByFile
         {
-            get { return _exclude; }
-            set { _exclude = value; }
+            get { return _excludeByFile; }
+            set { _excludeByFile = value; }
         }
 
         public override bool Execute()
         {
             try
             {
-                var excludes = _exclude?.Split(',');
+                var excludes = _excludeByFile?.Split(',');
                 var filters = _filter?.Split(',');
 
                 _coverage = new Coverage(_path, Guid.NewGuid().ToString(), filters, excludes);

--- a/src/coverlet.msbuild.tasks/InstrumentationTask.cs
+++ b/src/coverlet.msbuild.tasks/InstrumentationTask.cs
@@ -6,23 +6,38 @@ using Microsoft.Build.Utilities;
 namespace Coverlet.MSbuild.Tasks
 {
     public class InstrumentationTask : Task
-    {        
-        internal static Coverage Coverage { get; private set; }
+    {
+        private static Coverage _coverage;
+        private string _path;
+        private string _exclude;
+
+        internal static Coverage Coverage
+        {
+            get { return _coverage; }
+        }
 
         [Required]
-        public string Path { get; set; }
-        
-        public string Exclude { get; set; }
-                
+        public string Path
+        {
+            get { return _path; }
+            set { _path = value; }
+        }
+
+        public string Exclude
+        {
+            get { return _path; }
+            set { _path = value; }
+        }
+
         public override bool Execute()
         {
             try
             {
-                var excludeRules = Exclude?.Split(',');
-                Coverage = new Coverage(Path, Guid.NewGuid().ToString(), excludeRules);
-                Coverage.PrepareModules();
+                var excludeRules = _exclude?.Split(',');
+                _coverage = new Coverage(_path, Guid.NewGuid().ToString(), excludeRules);
+                _coverage.PrepareModules();
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 Log.LogErrorFromException(ex);
                 return false;

--- a/src/coverlet.msbuild/coverlet.msbuild.props
+++ b/src/coverlet.msbuild/coverlet.msbuild.props
@@ -5,6 +5,7 @@
     <CoverletOutputDirectory Condition="$(CoverletOutputDirectory) == ''">$(MSBuildProjectDirectory)</CoverletOutputDirectory>
     <CoverletOutputName Condition=" '$(CoverletOutputName)' == '' ">coverage</CoverletOutputName>
     <CoverletOutput>$([MSBuild]::EnsureTrailingSlash('$(CoverletOutputDirectory)'))$(CoverletOutputName)</CoverletOutput>
+    <Filter Condition="$(Filter) == ''"></Filter>
     <Exclude Condition="$(Exclude) == ''"></Exclude>
     <Threshold Condition="$(Threshold) == ''">0</Threshold>
     <ThresholdType Condition="$(ThresholdType) == ''">line,branch,method</ThresholdType>

--- a/src/coverlet.msbuild/coverlet.msbuild.props
+++ b/src/coverlet.msbuild/coverlet.msbuild.props
@@ -5,7 +5,7 @@
     <CoverletOutputDirectory Condition="$(CoverletOutputDirectory) == ''">$(MSBuildProjectDirectory)</CoverletOutputDirectory>
     <CoverletOutputName Condition=" '$(CoverletOutputName)' == '' ">coverage</CoverletOutputName>
     <CoverletOutput>$([MSBuild]::EnsureTrailingSlash('$(CoverletOutputDirectory)'))$(CoverletOutputName)</CoverletOutput>
-    <Filter Condition="$(Filter) == ''"></Filter>
+    <Exclude Condition="$(Exclude) == ''"></Exclude>
     <ExcludeByFile Condition="$(ExcludeByFile) == ''"></ExcludeByFile>
     <Threshold Condition="$(Threshold) == ''">0</Threshold>
     <ThresholdType Condition="$(ThresholdType) == ''">line,branch,method</ThresholdType>

--- a/src/coverlet.msbuild/coverlet.msbuild.props
+++ b/src/coverlet.msbuild/coverlet.msbuild.props
@@ -6,7 +6,7 @@
     <CoverletOutputName Condition=" '$(CoverletOutputName)' == '' ">coverage</CoverletOutputName>
     <CoverletOutput>$([MSBuild]::EnsureTrailingSlash('$(CoverletOutputDirectory)'))$(CoverletOutputName)</CoverletOutput>
     <Filter Condition="$(Filter) == ''"></Filter>
-    <Exclude Condition="$(Exclude) == ''"></Exclude>
+    <ExcludeByFile Condition="$(ExcludeByFile) == ''"></ExcludeByFile>
     <Threshold Condition="$(Threshold) == ''">0</Threshold>
     <ThresholdType Condition="$(ThresholdType) == ''">line,branch,method</ThresholdType>
     <CollectCoverage Condition="$(CollectCoverage) == ''">false</CollectCoverage>

--- a/src/coverlet.msbuild/coverlet.msbuild.targets
+++ b/src/coverlet.msbuild/coverlet.msbuild.targets
@@ -13,6 +13,7 @@
   <Target Name="InstrumentModulesAfterBuild" AfterTargets="BuildProject">
     <Coverlet.MSbuild.Tasks.InstrumentationTask
       Condition="'$(VSTestNoBuild)' != 'true' and $(CollectCoverage) == 'true'"
+      Filter="$(Filter)"
       Exclude="$(Exclude)"
       Path="$(TargetPath)" />
   </Target>

--- a/src/coverlet.msbuild/coverlet.msbuild.targets
+++ b/src/coverlet.msbuild/coverlet.msbuild.targets
@@ -6,7 +6,7 @@
   <Target Name="InstrumentModulesNoBuild" BeforeTargets="VSTest">
     <Coverlet.MSbuild.Tasks.InstrumentationTask
       Condition="'$(VSTestNoBuild)' == 'true' and $(CollectCoverage) == 'true'"
-      Exclude="$(Exclude)"
+      ExcludeByFile="$(ExcludeByFile)"
       Path="$(TargetPath)" />
   </Target>
 
@@ -14,7 +14,7 @@
     <Coverlet.MSbuild.Tasks.InstrumentationTask
       Condition="'$(VSTestNoBuild)' != 'true' and $(CollectCoverage) == 'true'"
       Filter="$(Filter)"
-      Exclude="$(Exclude)"
+      ExcludeByFile="$(ExcludeByFile)"
       Path="$(TargetPath)" />
   </Target>
 

--- a/src/coverlet.msbuild/coverlet.msbuild.targets
+++ b/src/coverlet.msbuild/coverlet.msbuild.targets
@@ -6,6 +6,7 @@
   <Target Name="InstrumentModulesNoBuild" BeforeTargets="VSTest">
     <Coverlet.MSbuild.Tasks.InstrumentationTask
       Condition="'$(VSTestNoBuild)' == 'true' and $(CollectCoverage) == 'true'"
+      Exclude="$(Exclude)"
       ExcludeByFile="$(ExcludeByFile)"
       Path="$(TargetPath)" />
   </Target>
@@ -13,7 +14,7 @@
   <Target Name="InstrumentModulesAfterBuild" AfterTargets="BuildProject">
     <Coverlet.MSbuild.Tasks.InstrumentationTask
       Condition="'$(VSTestNoBuild)' != 'true' and $(CollectCoverage) == 'true'"
-      Filter="$(Filter)"
+      Exclude="$(Exclude)"
       ExcludeByFile="$(ExcludeByFile)"
       Path="$(TargetPath)" />
   </Target>

--- a/test/coverlet.core.tests/CoverageTests.cs
+++ b/test/coverlet.core.tests/CoverageTests.cs
@@ -28,7 +28,7 @@ namespace Coverlet.Core.Tests
             // Since Coverage only instruments dependancies, we need a fake module here
             var testModule = Path.Combine(directory.FullName, "test.module.dll");
 
-            var coverage = new Coverage(testModule, identifier);
+            var coverage = new Coverage(testModule, identifier, Array.Empty<string>(), Array.Empty<string>());
             coverage.PrepareModules();
 
             var result = coverage.GetCoverageResult();

--- a/test/coverlet.core.tests/Helpers/InstrumentationHelperTests.cs
+++ b/test/coverlet.core.tests/Helpers/InstrumentationHelperTests.cs
@@ -8,12 +8,12 @@ using System.Linq;
 namespace Coverlet.Core.Helpers.Tests
 {
     public class InstrumentationHelperTests
-    {            
+    {
         [Fact]
         public void TestGetDependencies()
         {
             string module = typeof(InstrumentationHelperTests).Assembly.Location;
-            var modules = InstrumentationHelper.GetDependencies(module);
+            var modules = InstrumentationHelper.GetCoverableModules(module);
             Assert.False(Array.Exists(modules, m => m == module));
         }
 
@@ -70,60 +70,60 @@ namespace Coverlet.Core.Helpers.Tests
             InstrumentationHelper.DeleteHitsFile(tempFile);
             Assert.False(File.Exists(tempFile));
         }
-        
-        
-        public static IEnumerable<object[]> GetExcludedFilesReturnsEmptyArgs => 
-        new[] 
+
+
+        public static IEnumerable<object[]> GetExcludedFilesReturnsEmptyArgs =>
+        new[]
         {
             new object[]{null},
-            new object[]{new List<string>()},
-            new object[]{new List<string>(){ Path.GetRandomFileName() }},
-            new object[]{new List<string>(){Path.GetRandomFileName(), 
+            new object[]{new string[0]},
+            new object[]{new string[]{ Path.GetRandomFileName() }},
+            new object[]{new string[]{Path.GetRandomFileName(),
                 Path.Combine(Directory.GetCurrentDirectory(), Path.GetRandomFileName())}
             }
         };
-        
+
         [Theory]
         [MemberData(nameof(GetExcludedFilesReturnsEmptyArgs))]
-        public void TestGetExcludedFilesReturnsEmpty(IEnumerable<string> excludedFiles) 
+        public void TestGetExcludedFilesReturnsEmpty(string[] excludedFiles)
         {
             Assert.False(InstrumentationHelper.GetExcludedFiles(excludedFiles)?.Any());
         }
-        
+
         [Fact]
-        public void TestGetExcludedFilesUsingAbsFile() 
+        public void TestGetExcludedFilesUsingAbsFile()
         {
             var file = Path.GetRandomFileName();
             File.Create(file).Dispose();
             var excludeFiles = InstrumentationHelper.GetExcludedFiles(
-                new List<string>() {Path.Combine(Directory.GetCurrentDirectory(), file)}
+                new string[] { Path.Combine(Directory.GetCurrentDirectory(), file) }
             );
             File.Delete(file);
             Assert.Single(excludeFiles);
         }
-            
+
         [Fact]
-        public void TestGetExcludedFilesUsingGlobbing() 
+        public void TestGetExcludedFilesUsingGlobbing()
         {
             var fileExtension = Path.GetRandomFileName();
             var paths = new string[]{
                 $"{Path.GetRandomFileName()}.{fileExtension}",
                 $"{Path.GetRandomFileName()}.{fileExtension}"
             };
-            
+
             foreach (var path in paths)
             {
                 File.Create(path).Dispose();
             }
-            
+
             var excludeFiles = InstrumentationHelper.GetExcludedFiles(
-                new List<string>(){$"*.{fileExtension}"});
-            
+                new string[] { $"*.{fileExtension}" });
+
             foreach (var path in paths)
-            {   
+            {
                 File.Delete(path);
             }
-            
+
             Assert.Equal(paths.Length, excludeFiles.Count());
         }
     }

--- a/test/coverlet.core.tests/Helpers/InstrumentationHelperTests.cs
+++ b/test/coverlet.core.tests/Helpers/InstrumentationHelperTests.cs
@@ -95,11 +95,11 @@ namespace Coverlet.Core.Helpers.Tests
         {
             var file = Path.GetRandomFileName();
             File.Create(file).Dispose();
-            var excludeFiles = InstrumentationHelper.GetExcludedFiles(
+            var excludedFiles = InstrumentationHelper.GetExcludedFiles(
                 new string[] { Path.Combine(Directory.GetCurrentDirectory(), file) }
             );
             File.Delete(file);
-            Assert.Single(excludeFiles);
+            Assert.Single(excludedFiles);
         }
 
         [Fact]
@@ -116,7 +116,7 @@ namespace Coverlet.Core.Helpers.Tests
                 File.Create(path).Dispose();
             }
 
-            var excludeFiles = InstrumentationHelper.GetExcludedFiles(
+            var excludedFiles = InstrumentationHelper.GetExcludedFiles(
                 new string[] { $"*.{fileExtension}" });
 
             foreach (var path in paths)
@@ -124,7 +124,7 @@ namespace Coverlet.Core.Helpers.Tests
                 File.Delete(path);
             }
 
-            Assert.Equal(paths.Length, excludeFiles.Count());
+            Assert.Equal(paths.Length, excludedFiles.Count());
         }
     }
 }

--- a/test/coverlet.core.tests/Instrumentation/InstrumenterTests.cs
+++ b/test/coverlet.core.tests/Instrumentation/InstrumenterTests.cs
@@ -21,7 +21,7 @@ namespace Coverlet.Core.Instrumentation.Tests
             File.Copy(pdb, Path.Combine(directory.FullName, Path.GetFileName(pdb)), true);
 
             module = Path.Combine(directory.FullName, Path.GetFileName(module));
-            Instrumenter instrumenter = new Instrumenter(module, identifier);
+            Instrumenter instrumenter = new Instrumenter(module, identifier, Array.Empty<string>(), Array.Empty<string>());
             var result = instrumenter.Instrument();
 
             Assert.Equal(Path.GetFileNameWithoutExtension(module), result.Module);


### PR DESCRIPTION
This PR introduces the ability to filter assemblies with an expression format closely resembling the one [used by OpenCover](https://github.com/opencover/opencover/wiki/Usage#understanding-filters). However, unlike OpenCover Coverlet doesn't support inclusion/exclusion syntax (`+`/`-`).

All instrument-able assemblies are inclusive by default and the `Exclude` property has been repurposed to accept a comma separated list of filter expressions. The ability to exclude source files (based on the work by @ido-namely) has been moved to the new `ExcludeByFile` property.

The filter rules can be used to exclude entire assemblies, all types in an assembly or all types in a specific namespace.

Syntax: `[Assembly-Filter]Type-Filter`

Examples:
`/p:Exclude=[*]*` => Excludes all types in all assemblies (nothing is instrumented)
`/p:Exclude=[coverlet.*]Coverlet.Core.Coverage` => Excludes the `Coverage` class in the `Coverlet.Core` namespace belonging to any assembly that matches `coverlet.*` (e.g `coverlet.core`)
`/p:Exclude=[*]Coverlet.Core.Instrumentation.*` => Excludes all types belonging to `Coverlet.Core.Instrumentation` namespace in any assembly

The PR introduces backwards incompatible changes and will be part of the `2.0` release this week

cc @MarcoRossignoli @ido-namely @jasonbock @SteveGilham @coenm @ryanmvt

Addresses #77 