### PR TITLE
Bugfix/spaces in path

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -8,11 +8,11 @@
 
   <Target Name="BuildAllProjects">
     <RemoveDir Directories="$(OutputPath)" Condition="Exists('$(MSBuildThisFileDirectory)\build')" />
-    <Exec Command="dotnet build $(MSBuildThisFileDirectory)src\coverlet.msbuild.tasks\coverlet.msbuild.tasks.csproj -c $(Configuration)" />
+    <Exec Command="dotnet build &quot;$(MSBuildThisFileDirectory)src\coverlet.msbuild.tasks\coverlet.msbuild.tasks.csproj&quot; -c $(Configuration)" />
   </Target>
 
   <Target Name="PublishMSBuildTaskProject" AfterTargets="BuildAllProjects">
-    <Exec Command="dotnet publish $(MSBuildThisFileDirectory)src\coverlet.msbuild.tasks\coverlet.msbuild.tasks.csproj -c $(Configuration) -o $(OutputPath)" />
+    <Exec Command="dotnet publish &quot;$(MSBuildThisFileDirectory)src\coverlet.msbuild.tasks\coverlet.msbuild.tasks.csproj&quot; -c $(Configuration) -o &quot;$(OutputPath)&quot;" />
   </Target>
 
   <Target Name="CopyMSBuildScripts" AfterTargets="PublishMSBuildTaskProject">
@@ -24,11 +24,11 @@
   </Target>
 
   <Target Name="RunTests" AfterTargets="CopyMSBuildScripts">
-    <Exec Command="dotnet test $(MSBuildThisFileDirectory)test\coverlet.core.tests\coverlet.core.tests.csproj -c $(Configuration) /p:CollectCoverage=true /p:CoverletOutputFormat=opencover"/>
+    <Exec Command="dotnet test &quot;$(MSBuildThisFileDirectory)test\coverlet.core.tests\coverlet.core.tests.csproj&quot; -c $(Configuration) /p:CollectCoverage=true /p:CoverletOutputFormat=opencover"/>
   </Target>
 
   <Target Name="CreateNuGetPackage" AfterTargets="RunTests" Condition="$(Configuration) == 'Release'">
-    <Exec Command="dotnet pack $(MSBuildThisFileDirectory)src\coverlet.msbuild.tasks\coverlet.msbuild.tasks.csproj -c $(Configuration) -o $(OutputPath) /p:NuspecFile=$(NuspecFile)" />
+    <Exec Command="dotnet pack &quot;$(MSBuildThisFileDirectory)src\coverlet.msbuild.tasks\coverlet.msbuild.tasks.csproj&quot; -c $(Configuration) -o $(OutputPath) /p:NuspecFile=$(NuspecFile)" />
   </Target>
 
 </Project>


### PR DESCRIPTION
Fix build.proj to allow spaces in a the directory.

Note: Only tested on Windows.



Reproduction scenario:
1) clone repository in a directory containing at least one space. Ie. 'C;/repo si to ries/coverlet'
2) open console and run `dotnet msbuild build.proj`.

Result:
```
Microsoft (R) Build Engine version 15.6.84.34536 for .NET Core
Copyright (C) Microsoft Corporation. All rights reserved.

  Microsoft (R) Build Engine version 15.6.84.34536 for .NET Core
  Copyright (C) Microsoft Corporation. All rights reserved.

MSBUILD : error MSB1008: Only one project can be specified. [C:\Repositories\co ver let\build.proj]
  Switch: ver

  For switch syntax, type "MSBuild /help"
C:\Repositories\co ver let\build.proj(11,5): error MSB3073: The command "dotnet build C:\Repositories\co ver let\src\coverlet.msbuild.tasks\coverlet.msbuild.tasks.csproj -c Debug" exited with code 1.
```