### PR TITLE
Update readme with fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,13 +116,15 @@ Examples
  - `/p:Exclude="[coverlet.*]Coverlet.Core.Coverage"` => Excludes the Coverage class in the `Coverlet.Core` namespace belonging to any assembly that matches `coverlet.*` (e.g `coverlet.core`)
  - `/p:Exclude="[*]Coverlet.Core.Instrumentation.*"` => Excludes all types belonging to `Coverlet.Core.Instrumentation` namespace in any assembly
  - `/p:Exclude="[coverlet.*.tests?]*"` => Excludes all types in any assembly starting with `coverlet.` and ending with `.test` or `.tests` (the `?` makes the `s`  optional)
- - `/p:Exclude="[coverlet.*]*,[*]Coverlet.Core*"` => Excludes assemblies matching `coverlet.*` and excludes all types belonging to the `Coverlet.Core` namespace in any assembly
+ - `/p:Exclude=\"[coverlet.*]*,[*]Coverlet.Core*\"` => Excludes assemblies matching `coverlet.*` and excludes all types belonging to the `Coverlet.Core` namespace in any assembly
 
 ```bash
 dotnet test /p:CollectCoverage=true /p:Exclude="[coverlet.*]Coverlet.Core.Coverage"
 ```
 
-You can specify multiple fiter expressions by separting them with a comma (`,`).
+
+You can specify multiple filter expressions by separting them with a comma (`,`). If you specify multiple filters, then [you'll have to escape the surrounding quotes](https://github.com/Microsoft/msbuild/issues/2999#issuecomment-366078677) like this:
+`/p:Exclude=\"[coverlet.*]*,[*]Coverlet.Core*\"`.
 
 ## Roadmap
 


### PR DESCRIPTION
Update README with additional information how to use multiple expressions.

According to https://github.com/Microsoft/msbuild/issues/2999#issuecomment-366078677 you'll have to  escape the surrounding quotes in a parameter with a comma.

This has been described in the readme.

An other fix would be to have an other sperator. I.e. a space (like opencover).