### PR TITLE
Implementation of HTML Reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,6 +119,7 @@ _TeamCity*
 *.coverage
 *.coveragexml
 lcov.info
+test/coverlet.core.tests/report/
 
 # NCrunch
 _NCrunch_*

--- a/README.md
+++ b/README.md
@@ -66,6 +66,16 @@ Supported Formats:
 
 The output folder of the coverage result file can also be specified using the `CoverletOutputDirectory` property.
 
+### Generating Coverage Reports
+
+On top of supporting multiple coverage output formats, static reports can be generated in any of the output formats supported by [ReportGenerator](https://github.com/danielpalme/ReportGenerator/wiki/Output-formats).
+
+```bash
+dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:ReportTypes=HTML
+```
+
+The output folder of these reports will be a `report` subdirectory inside the output directory specified by the `CoverletOutputDirectory` property.
+
 ### Threshold
 
 Coverlet allows you to specify a coverage threshold below which it fails the build. This allows you to enforce a minimum coverage percent on all changes to your project.

--- a/build.proj
+++ b/build.proj
@@ -24,7 +24,7 @@
   </Target>
 
   <Target Name="RunTests" AfterTargets="CopyMSBuildScripts">
-    <Exec Command="dotnet test &quot;$(MSBuildThisFileDirectory)test\coverlet.core.tests\coverlet.core.tests.csproj&quot; -c $(Configuration) /p:CollectCoverage=true /p:CoverletOutputFormat=opencover"/>
+    <Exec Command="dotnet test &quot;$(MSBuildThisFileDirectory)test\coverlet.core.tests\coverlet.core.tests.csproj&quot; -c $(Configuration) /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:ReportTypes=HTML"/>
   </Target>
 
   <Target Name="CreateNuGetPackage" AfterTargets="RunTests" Condition="$(Configuration) == 'Release'">

--- a/src/coverlet.msbuild.tasks/coverlet.msbuild.tasks.csproj
+++ b/src/coverlet.msbuild.tasks/coverlet.msbuild.tasks.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <PackageReference Include="ConsoleTables" Version="2.1.0" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.5.180" />
+    <PackageReference Include="ReportGenerator.Core" Version="4.0.0-alpha6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/coverlet.msbuild/coverlet.msbuild.props
+++ b/src/coverlet.msbuild/coverlet.msbuild.props
@@ -5,6 +5,7 @@
     <CoverletOutputDirectory Condition="$(CoverletOutputDirectory) == ''">$(MSBuildProjectDirectory)</CoverletOutputDirectory>
     <CoverletOutputName Condition=" '$(CoverletOutputName)' == '' ">coverage</CoverletOutputName>
     <CoverletOutput>$([MSBuild]::EnsureTrailingSlash('$(CoverletOutputDirectory)'))$(CoverletOutputName)</CoverletOutput>
+    <ReportTypes Condition="$(ReportTypes) == ''"></ReportTypes>
     <Exclude Condition="$(Exclude) == ''"></Exclude>
     <ExcludeByFile Condition="$(ExcludeByFile) == ''"></ExcludeByFile>
     <Threshold Condition="$(Threshold) == ''">0</Threshold>

--- a/src/coverlet.msbuild/coverlet.msbuild.targets
+++ b/src/coverlet.msbuild/coverlet.msbuild.targets
@@ -24,6 +24,7 @@
       Condition="$(CollectCoverage) == 'true'"
       Output="$(CoverletOutput)"
       OutputFormat="$(CoverletOutputFormat)"
+      ReportTypes="$(ReportTypes)"
       Threshold="$(Threshold)"
       ThresholdType="$(ThresholdType)" />
   </Target>


### PR DESCRIPTION
I know that you mentioned in #90 that you were leaning toward letting people choose their own HTML report generator, but my PR into ReportGenerator was recently merged, and this is a completely optional way of letting people who want to generate both coverage results and HTML reports in one command do so.  If the new, optional, `ReportTypes` property is not specified, nothing changes.