### PR TITLE
Logging concept

### DIFF
--- a/src/coverlet.core/Coverage.cs
+++ b/src/coverlet.core/Coverage.cs
@@ -37,7 +37,7 @@ namespace Coverlet.Core
                 if (InstrumentationHelper.IsModuleExcluded(module, _filters))
                     continue;
 
-                var instrumenter = new Instrumenter(module, _identifier, _filters, excludedFiles);
+                var instrumenter = InstrumenterFactory.Create(module, _identifier, _filters, excludedFiles);
                 if (instrumenter.CanInstrument())
                 {
                     InstrumentationHelper.BackupOriginalModule(module, _identifier);

--- a/src/coverlet.core/Coverage.cs
+++ b/src/coverlet.core/Coverage.cs
@@ -30,7 +30,7 @@ namespace Coverlet.Core
         {
             string[] modules = InstrumentationHelper.GetCoverableModules(_module);
             string[] excludedFiles =  InstrumentationHelper.GetExcludedFiles(_rules);
-            _filters = _filters?.Where(f => InstrumentationHelper.IsValidFilterExpression(f)).ToArray();
+            _filters = _filters?.Where(InstrumentationHelper.IsValidFilterExpression).ToArray();
 
             foreach (var module in modules)
             {

--- a/src/coverlet.core/Instrumentation/IInstrumenter.cs
+++ b/src/coverlet.core/Instrumentation/IInstrumenter.cs
@@ -1,0 +1,9 @@
+namespace Coverlet.Core.Instrumentation
+{
+    internal interface IInstrumenter
+    {
+        bool CanInstrument();
+
+        InstrumenterResult Instrument();
+    }
+}

--- a/src/coverlet.core/Instrumentation/Instrumenter.cs
+++ b/src/coverlet.core/Instrumentation/Instrumenter.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -14,37 +13,6 @@ using Mono.Cecil.Rocks;
 
 namespace Coverlet.Core.Instrumentation
 {
-    internal interface IInstrumenter
-    {
-        bool CanInstrument();
-
-        InstrumenterResult Instrument();
-    }
-
-    internal static class InstrumenterFactory
-    {
-        private static readonly List<Func<IInstrumenter, IInstrumenter>>  DecoratorFunctions = new List<Func<IInstrumenter, IInstrumenter>>();
-
-        public static IInstrumenter Create(string module, string identifier, string[] filters, string[] excludedFiles)
-        {
-            IInstrumenter result = new Instrumenter(module, identifier, filters, excludedFiles);
-
-            // Decorate the real Instrumenter instance
-            foreach (var decoratorFunc in DecoratorFunctions)
-                result = decoratorFunc.Invoke(result);
-
-            return result;
-        }
-
-        public static void RegisterDecorator(Func<IInstrumenter, IInstrumenter> decoratingFunc)
-        {
-            if (decoratingFunc == null)
-                throw new ArgumentNullException(nameof(decoratingFunc));
-
-            DecoratorFunctions.Add(decoratingFunc);
-        }
-    }
-
     internal class Instrumenter  : IInstrumenter
     {
         private readonly string _module;
@@ -147,7 +115,7 @@ namespace Coverlet.Core.Instrumentation
                 var instruction = processor.Body.Instructions[index];
                 var sequencePoint = method.DebugInformation.GetSequencePoint(instruction);
                 var targetedBranchPoints = branchPoints.Where(p => p.EndOffset == instruction.Offset);
-                
+
                 if (sequencePoint != null && !sequencePoint.IsHidden)
                 {
                     var target = AddInstrumentationCode(method, processor, instruction, sequencePoint);
@@ -170,7 +138,7 @@ namespace Coverlet.Core.Instrumentation
                         */
                     if (_branchTarget.StartLine == -1 || _branchTarget.Document == null)
                         continue;
-                    
+
                     var target = AddInstrumentationCode(method, processor, instruction, _branchTarget);
                     foreach (var _instruction in processor.Body.Instructions)
                         ReplaceInstructionTarget(_instruction, instruction, target);

--- a/src/coverlet.core/Instrumentation/Instrumenter.cs
+++ b/src/coverlet.core/Instrumentation/Instrumenter.cs
@@ -23,12 +23,25 @@ namespace Coverlet.Core.Instrumentation
 
     internal static class InstrumenterFactory
     {
+        private static readonly List<Func<IInstrumenter, IInstrumenter>>  DecoratorFunctions = new List<Func<IInstrumenter, IInstrumenter>>();
 
         public static IInstrumenter Create(string module, string identifier, string[] filters, string[] excludedFiles)
         {
             IInstrumenter result = new Instrumenter(module, identifier, filters, excludedFiles);
 
+            // Decorate the real Instrumenter instance
+            foreach (var decoratorFunc in DecoratorFunctions)
+                result = decoratorFunc.Invoke(result);
+
             return result;
+        }
+
+        public static void RegisterDecorator(Func<IInstrumenter, IInstrumenter> decoratingFunc)
+        {
+            if (decoratingFunc == null)
+                throw new ArgumentNullException(nameof(decoratingFunc));
+
+            DecoratorFunctions.Add(decoratingFunc);
         }
     }
 

--- a/src/coverlet.core/Instrumentation/Instrumenter.cs
+++ b/src/coverlet.core/Instrumentation/Instrumenter.cs
@@ -21,6 +21,17 @@ namespace Coverlet.Core.Instrumentation
         InstrumenterResult Instrument();
     }
 
+    internal static class InstrumenterFactory
+    {
+
+        public static IInstrumenter Create(string module, string identifier, string[] filters, string[] excludedFiles)
+        {
+            IInstrumenter result = new Instrumenter(module, identifier, filters, excludedFiles);
+
+            return result;
+        }
+    }
+
     internal class Instrumenter  : IInstrumenter
     {
         private readonly string _module;

--- a/src/coverlet.core/Instrumentation/Instrumenter.cs
+++ b/src/coverlet.core/Instrumentation/Instrumenter.cs
@@ -14,7 +14,14 @@ using Mono.Cecil.Rocks;
 
 namespace Coverlet.Core.Instrumentation
 {
-    internal class Instrumenter
+    internal interface IInstrumenter
+    {
+        bool CanInstrument();
+
+        InstrumenterResult Instrument();
+    }
+
+    internal class Instrumenter  : IInstrumenter
     {
         private readonly string _module;
         private readonly string _identifier;

--- a/src/coverlet.core/Instrumentation/InstrumenterFactory.cs
+++ b/src/coverlet.core/Instrumentation/InstrumenterFactory.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+
+namespace Coverlet.Core.Instrumentation
+{
+    internal static class InstrumenterFactory
+    {
+        private static readonly List<Func<IInstrumenter, IInstrumenter>>  DecoratorFunctions = new List<Func<IInstrumenter, IInstrumenter>>();
+
+        public static IInstrumenter Create(string module, string identifier, string[] filters, string[] excludedFiles)
+        {
+            IInstrumenter result = new Instrumenter(module, identifier, filters, excludedFiles);
+
+            // Decorate the real Instrumenter instance
+            foreach (var decoratorFunc in DecoratorFunctions)
+                result = decoratorFunc.Invoke(result);
+
+            return result;
+        }
+
+        public static void RegisterDecorator(Func<IInstrumenter, IInstrumenter> decoratingFunc)
+        {
+            if (decoratingFunc == null)
+                throw new ArgumentNullException(nameof(decoratingFunc));
+
+            DecoratorFunctions.Add(decoratingFunc);
+        }
+    }
+}

--- a/src/coverlet.core/Logging/ConsoleLogger.cs
+++ b/src/coverlet.core/Logging/ConsoleLogger.cs
@@ -10,11 +10,12 @@ namespace Coverlet.Core.Logging
 
         public static ILogger Instance { get; } = new ConsoleLogger();
 
-        public void Log(string s)
+        public void Log(string text)
         {
-            if (s == null)
+            if (text == null)
                 return;
-            Console.WriteLine(s);
+
+            Console.WriteLine(text);
         }
     }
 }

--- a/src/coverlet.core/Logging/ConsoleLogger.cs
+++ b/src/coverlet.core/Logging/ConsoleLogger.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace Coverlet.Core.Logging
+{
+    public class ConsoleLogger : ILogger
+    {
+        private ConsoleLogger()
+        {
+        }
+
+        public static ILogger Instance { get; } = new ConsoleLogger();
+
+        public void Log(string s)
+        {
+            if (s == null)
+                return;
+            Console.WriteLine(s);
+        }
+    }
+}

--- a/src/coverlet.core/Logging/Decorators/InstrumenterLoggerDecorator.cs
+++ b/src/coverlet.core/Logging/Decorators/InstrumenterLoggerDecorator.cs
@@ -1,0 +1,29 @@
+using Coverlet.Core.Instrumentation;
+using Coverlet.Core.Logging;
+
+namespace coverlet.core.Logging.Decorators
+{
+    internal class InstrumenterLoggerDecorator : IInstrumenter
+    {
+        private readonly IInstrumenter _decoratee;
+        private readonly ILogger _logger;
+
+        public InstrumenterLoggerDecorator(IInstrumenter decoratee, ILogger logger)
+        {
+            _decoratee = decoratee;
+            _logger = logger;
+        }
+
+        public bool CanInstrument()
+        {
+            return _decoratee.CanInstrument();
+        }
+
+        public InstrumenterResult Instrument()
+        {
+            var result = _decoratee.Instrument();
+            _logger.Log($"Module {result.Module} was instrumented.");
+            return result;
+        }
+    }
+}

--- a/src/coverlet.core/Logging/EnableLogging.cs
+++ b/src/coverlet.core/Logging/EnableLogging.cs
@@ -8,6 +8,7 @@ namespace coverlet.core.Logging
     {
         public static void Execute()
         {
+            LoggerFactory.GetLogger().Log("Logging enabled.");
             InstrumenterFactory.RegisterDecorator(instrumenter => new InstrumenterLoggerDecorator(instrumenter, LoggerFactory.GetLogger()));
         }
     }

--- a/src/coverlet.core/Logging/EnableLogging.cs
+++ b/src/coverlet.core/Logging/EnableLogging.cs
@@ -1,0 +1,14 @@
+﻿using coverlet.core.Logging.Decorators;
+using Coverlet.Core.Instrumentation;
+using Coverlet.Core.Logging;
+
+namespace coverlet.core.Logging
+{
+    public static class EnableLogging
+    {
+        public static void Execute()
+        {
+            InstrumenterFactory.RegisterDecorator(instrumenter => new InstrumenterLoggerDecorator(instrumenter, LoggerFactory.GetLogger()));
+        }
+    }
+}

--- a/src/coverlet.core/Logging/ILogger.cs
+++ b/src/coverlet.core/Logging/ILogger.cs
@@ -2,6 +2,6 @@
 {
     public interface ILogger
     {
-        void Log(string s);
+        void Log(string text);
     }
 }

--- a/src/coverlet.core/Logging/ILogger.cs
+++ b/src/coverlet.core/Logging/ILogger.cs
@@ -1,0 +1,7 @@
+﻿namespace Coverlet.Core.Logging
+{
+    public interface ILogger
+    {
+        void Log(string s);
+    }
+}

--- a/src/coverlet.core/Logging/LoggerFactory.cs
+++ b/src/coverlet.core/Logging/LoggerFactory.cs
@@ -1,0 +1,10 @@
+﻿namespace Coverlet.Core.Logging
+{
+    public static class LoggerFactory
+    {
+        public static ILogger GetLogger()
+        {
+            return ConsoleLogger.Instance;
+        }
+    }
+}

--- a/src/coverlet.msbuild.tasks/InstrumentationTask.cs
+++ b/src/coverlet.msbuild.tasks/InstrumentationTask.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using coverlet.core.Logging;
 using Coverlet.Core;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
@@ -23,7 +24,7 @@ namespace Coverlet.MSbuild.Tasks
             get { return _path; }
             set { _path = value; }
         }
-        
+
         public string Exclude
         {
             get { return _exclude; }
@@ -36,12 +37,17 @@ namespace Coverlet.MSbuild.Tasks
             set { _excludeByFile = value; }
         }
 
+        public bool Verbose { get; set; }
+
         public override bool Execute()
         {
             try
             {
                 var rules = _excludeByFile?.Split(',');
                 var filters = _exclude?.Split(',');
+
+                if (Verbose)
+                    EnableLogging.Execute();
 
                 _coverage = new Coverage(_path, Guid.NewGuid().ToString(), filters, rules);
                 _coverage.PrepareModules();

--- a/test/coverlet.core.tests/Logging/ConsoleLoggerTests.cs
+++ b/test/coverlet.core.tests/Logging/ConsoleLoggerTests.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.IO;
+using Coverlet.Core.Logging;
+using Xunit;
+
+namespace Coverlet.Core.Tests.Logging
+{
+    public class ConsoleLoggerTests
+    {
+        private readonly TextWriter _textWriter;
+
+        public ConsoleLoggerTests()
+        {
+            _textWriter = new StringWriter();
+            Console.SetOut(_textWriter);
+        }
+
+        [Fact]
+        public void TestConsoleLoggerLogShouldWriteMessageToConsole()
+        {
+            // arrange
+            const string message = "this is a test message";
+
+            // act
+            ConsoleLogger.Instance.Log(message);
+
+            // assert
+            _textWriter.Flush();
+            Assert.Equal($"{message}{Environment.NewLine}" , _textWriter.ToString());
+        }
+
+        [Fact]
+        public void TestConsoleLoggerLogShouldWriteNothingWhenMessageIsNull()
+        {
+            // arrange
+
+            // act
+            ConsoleLogger.Instance.Log(null);
+
+            // assert
+            _textWriter.Flush();
+            Assert.Empty(_textWriter.ToString());
+        }
+    }
+}

--- a/test/coverlet.core.tests/Logging/Decorators/InstrumenterLoggerDecoratorTests.cs
+++ b/test/coverlet.core.tests/Logging/Decorators/InstrumenterLoggerDecoratorTests.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Text;
+using coverlet.core.Logging.Decorators;
+using Coverlet.Core.Instrumentation;
+using Coverlet.Core.Logging;
+using Xunit;
+
+namespace Coverlet.Core.Tests.Logging.Decorators
+{
+    public class InstrumenterLoggerDecoratorTests
+    {
+        private readonly FakeInstumenter _decoratee;
+        private readonly FakeLogger _logger;
+        private readonly InstrumenterLoggerDecorator _sut;
+
+        public InstrumenterLoggerDecoratorTests()
+        {
+            _decoratee = new FakeInstumenter();
+            _logger = new FakeLogger();
+            _sut = new InstrumenterLoggerDecorator(_decoratee, _logger);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void TestCanInstrumentIsForwardedToDecoratee(bool setupCanInstrument)
+        {
+            // arrange
+            var canInstrumentCalled = false;
+            _decoratee.SetCanInstrument(() =>
+            {
+                canInstrumentCalled = true;
+                return setupCanInstrument;
+            });
+
+            // act
+            var result = _sut.CanInstrument();
+
+            // assert
+            Assert.True(canInstrumentCalled);
+            Assert.Equal(setupCanInstrument, result);
+        }
+
+
+        [Fact]
+        public void TestInstrumentIsForwardedToDecorateeAndLoggedInLogger()
+        {
+            // arrange
+            var setupResult = new InstrumenterResult { Module = "m0dule"};
+            var instrumentCalled = false;
+            _decoratee.SetInstrument(() =>
+            {
+                instrumentCalled = true;
+                return setupResult;
+            });
+
+            // act
+            var result = _sut.Instrument();
+
+            // assert
+            Assert.True(instrumentCalled);
+            Assert.Equal(setupResult, result);
+            Assert.Equal($"Module {result.Module} was instrumented.{Environment.NewLine}", _logger.ToString());
+        }
+    }
+
+    public class FakeLogger : ILogger
+    {
+        private readonly StringBuilder _sb;
+
+        public FakeLogger()
+        {
+            _sb = new StringBuilder();
+        }
+
+        public void Log(string text)
+        {
+            _sb.AppendLine(text);
+        }
+
+        public override string ToString()
+        {
+            return _sb.ToString();
+        }
+    }
+
+    internal class FakeInstumenter : IInstrumenter
+    {
+        private Func<bool> _canInstrument = () => throw new NotImplementedException();
+        private Func<InstrumenterResult> _instrumenterResult = () => throw new NotImplementedException();
+
+        public void SetCanInstrument(Func<bool> func)
+        {
+            _canInstrument = func ?? throw new ArgumentNullException(nameof(func));
+        }
+
+        public bool CanInstrument()
+        {
+            return _canInstrument.Invoke();
+        }
+
+        public void SetInstrument(Func<InstrumenterResult> instrumenterResult)
+        {
+            _instrumenterResult = instrumenterResult ?? throw new ArgumentNullException(nameof(instrumenterResult));
+        }
+
+        public InstrumenterResult Instrument()
+        {
+            return _instrumenterResult.Invoke();
+        }
+
+    }
+}

--- a/test/coverlet.core.tests/Logging/EnableLoggingTests.cs
+++ b/test/coverlet.core.tests/Logging/EnableLoggingTests.cs
@@ -1,0 +1,34 @@
+﻿using coverlet.core.Logging;
+using coverlet.core.Logging.Decorators;
+using Coverlet.Core.Instrumentation;
+using Xunit;
+
+namespace Coverlet.Core.Tests.Logging
+{
+    public class EnableLoggingTests
+    {
+        const string Module = "MOD";
+        const string Identifier = "123";
+        private string[] _filters;
+        private string[] _excludedFiles;
+
+        [Fact]
+        public void TestExecuteShouldRegisterDecoraterToFactory()
+        {
+            // arrange
+            _filters = new string[0];
+            _excludedFiles = new string[0];
+
+            // assume
+            var before = InstrumenterFactory.Create(Module, Identifier, _filters, _excludedFiles);
+            Assert.IsNotType<InstrumenterLoggerDecorator>(before);
+
+            // act
+            EnableLogging.Execute();
+
+            // assert
+            var after = InstrumenterFactory.Create(Module, Identifier, _filters, _excludedFiles);
+            Assert.IsType<InstrumenterLoggerDecorator>(after);
+        }
+    }
+}

--- a/test/coverlet.core.tests/Logging/LoggerFactoryTests.cs
+++ b/test/coverlet.core.tests/Logging/LoggerFactoryTests.cs
@@ -1,0 +1,20 @@
+﻿using Coverlet.Core.Logging;
+using Xunit;
+
+namespace Coverlet.Core.Tests.Logging
+{
+    public class LoggerFactoryTests
+    {
+        [Fact]
+        public void TestGetLoggerReturnsConsoleLoggerInstance()
+        {
+            // arrange
+
+            // act
+            var result = LoggerFactory.GetLogger();
+
+            // assert
+            Assert.Equal(ConsoleLogger.Instance, result);
+        }
+    }
+}


### PR DESCRIPTION
Since version 2.0 I have an issue with a project running on Linux where coverage is not calculated (https://github.com/tonerdo/coverlet/issues/72 and https://github.com/tonerdo/coverlet/issues/107) . Running on Windows doesn't have any problems. My problem is that it is pretty hard to do investigation on Travis and why my project isnt covered. 

Would it be nice if you can enable logging in order to give the user the ability to do a first investigation (and maybe fix and send a PR) before adding an issue.


First of all, I dislike lines like `logger.Log("bla bla");` through all production code at all kind of places. IMO too much of these lines blur the original intention of the code. 

This PR is a starting point of how logging can be inplemented. Hopefully, you all see the value of logging and we can have a discussion about this. 

The logging is done by decorating classes with a `LoggingDecorator`. 

1) https://github.com/coenm/coverlet/commit/f28a7047d2800026c2f8e4ab41e97c16a44a0c04 Added ILogger, ConsoleLogger, and LoggerFactory. No functionality changed.
2) https://github.com/coenm/coverlet/commit/0888e0d7bb3ca48c14dcd0d8ddcd264ddb223e63 Added new interface to existing Instrumenter class. No functionality changed.
3) https://github.com/coenm/coverlet/commit/3cd15cecea760cc7fa93cb18178879fc468e19e9 Creation of Instrumenter is done using static Factory class. No functionality changed.
4) https://github.com/coenm/coverlet/commit/2010ed942504b01211e73fc20eab1ed87ac5095b Added InstrumenterLoggerDecorator to decorate an instance of IInstrumenter. No functionality changed.
5) https://github.com/coenm/coverlet/commit/6f2fc30a012e6be44d923aaf9439f416b12c2ce8 Added functionality to register the decorator to the InstrumenterFactory. EnableLogging class has responsibility to create and add the logging decorator to the InstrumenterFactory. No functionality changed.
6) https://github.com/coenm/coverlet/commit/80aef4b6ee7537cbc95990a072aa30ef24343f1d This step adds a property Verbose to the InstrumentationTask and when this property is true, it enables Logging.
7) https://github.com/coenm/coverlet/commit/b4e66f7adc6970a08ea1e0351f9a634364c2ee3a Seperated classes to own files.

Please note that the original code was extended (decorated) and hardly touched. Only the creation of `Instrumenter` is now done using a factory, and the `Instrumenter` class now implements an interface.


If you like this idea, I'm willing to take this further



BTW, I don't expect this PR to be accepted as is right now as it doesn't add real value at this point.
I just didn't want to put too much effort in this without knowing what the you think about logging and about this concept.