### PR TITLE
Add support for merging results

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,16 @@ dotnet test /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
 
 You can specify multiple values for `ThresholdType` by separating them with commas. Valid values include `line`, `branch` and `method`.
 
+### Intermediate Result
+
+For combining the results of multiple projects, it is possible to use an intermediate result by using the `CoverletIntermediateResult` property. Coverage output will be merged with an intermediate result before generating the report(s). Ensure that all test runs point to the same intermediate result file.
+
+```bash
+dotnet test /p:CollectCoverage=true /p:CoverletIntermediateResult=intermediate.json
+```
+
+_Note: When using build automation, ensure that this intermediate result file is removed first. It doesn't make sense to merge with an intermediate result from a different build!_
+
 ### Excluding From Coverage
 
 #### Attributes

--- a/src/coverlet.console/Program.cs
+++ b/src/coverlet.console/Program.cs
@@ -18,6 +18,7 @@ namespace coverlet.console
 
             CommandArgument project = app.Argument("<PROJECT>", "The project to test. Defaults to the current directory.");
             CommandOption config = app.Option("-c|--configuration", "Configuration to use for building the project.", CommandOptionType.SingleValue);
+            CommandOption intermediateResult = app.Option("-i|--coverage-intermediate-result", "The output path of intermediate result (for merging multiple runs).", CommandOptionType.SingleValue);
             CommandOption output = app.Option("-o|--coverage-output", "The output path of the generated coverage report", CommandOptionType.SingleValue);
             CommandOption format = app.Option("-f|--coverage-format", "The format of the coverage report", CommandOptionType.SingleValue);
 
@@ -34,6 +35,9 @@ namespace coverlet.console
                     dotnetTestArgs.Add($"-c {config.Value()}");
 
                 dotnetTestArgs.Add("/p:CollectCoverage=true");
+
+                if (intermediateResult.HasValue())
+                    dotnetTestArgs.Add($"/p:CoverletIntermediateResult={intermediateResult.Value()}");
 
                 if (output.HasValue())
                     dotnetTestArgs.Add($"/p:CoverletOutput={output.Value()}");

--- a/src/coverlet.core/App.config
+++ b/src/coverlet.core/App.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" culture="Neutral" publicKeyToken="30ad4fe6b2a6aeed" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="9.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/coverlet.core/Coverage.cs
+++ b/src/coverlet.core/Coverage.cs
@@ -66,19 +66,19 @@ namespace Coverlet.Core
                             {
                                 if (methods.TryGetValue(line.Method, out Method method))
                                 {
-                                    documents[doc.Path][line.Class][line.Method].Lines.Add(line.Number, new LineInfo { Hits = line.Hits });
+                                    documents[doc.Path][line.Class][line.Method].Lines.Add(line.Number, new HitInfo { Hits = line.Hits });
                                 }
                                 else
                                 {
                                     documents[doc.Path][line.Class].Add(line.Method, new Method());
-                                    documents[doc.Path][line.Class][line.Method].Lines.Add(line.Number,  new LineInfo { Hits = line.Hits });
+                                    documents[doc.Path][line.Class][line.Method].Lines.Add(line.Number,  new HitInfo { Hits = line.Hits });
                                 }
                             }
                             else
                             {
                                 documents[doc.Path].Add(line.Class, new Methods());
                                 documents[doc.Path][line.Class].Add(line.Method, new Method());
-                                documents[doc.Path][line.Class][line.Method].Lines.Add(line.Number,  new LineInfo { Hits = line.Hits });
+                                documents[doc.Path][line.Class][line.Method].Lines.Add(line.Number,  new HitInfo { Hits = line.Hits });
                             }
                         }
                         else
@@ -86,50 +86,34 @@ namespace Coverlet.Core
                             documents.Add(doc.Path, new Classes());
                             documents[doc.Path].Add(line.Class, new Methods());
                             documents[doc.Path][line.Class].Add(line.Method, new Method());
-                            documents[doc.Path][line.Class][line.Method].Lines.Add(line.Number,  new LineInfo { Hits = line.Hits });
+                            documents[doc.Path][line.Class][line.Method].Lines.Add(line.Number,  new HitInfo { Hits = line.Hits });
                         }
                     }
 
                     // Construct Branch Results
                     foreach (var branch in doc.Branches)
                     {
+                        var key = (branch.Number, branch.Offset, branch.EndOffset, branch.Path, branch.Ordinal);
+
                         if (documents.TryGetValue(doc.Path, out Classes classes))
                         {
                             if (classes.TryGetValue(branch.Class, out Methods methods))
                             {
                                 if (methods.TryGetValue(branch.Method, out Method method))
                                 {
-                                    if (method.Branches.TryGetValue(branch.Number, out List<BranchInfo> branchInfo))
-                                    {
-                                        documents[doc.Path][branch.Class][branch.Method].Branches[branch.Number].Add(new BranchInfo
-                                            { Hits = branch.Hits, Offset = branch.Offset, EndOffset = branch.EndOffset, Path = branch.Path, Ordinal = branch.Ordinal }
-                                        );
-                                    }
-                                    else
-                                    {
-                                        documents[doc.Path][branch.Class][branch.Method].Branches.Add(branch.Number, new List<BranchInfo>());
-                                        documents[doc.Path][branch.Class][branch.Method].Branches[branch.Number].Add(new BranchInfo
-                                            { Hits = branch.Hits, Offset = branch.Offset, EndOffset = branch.EndOffset, Path = branch.Path, Ordinal = branch.Ordinal }
-                                        );
-                                    }
+                                    documents[doc.Path][branch.Class][branch.Method].Branches[key] = new HitInfo { Hits = branch.Hits };
                                 }
                                 else
                                 {
                                     documents[doc.Path][branch.Class].Add(branch.Method, new Method());
-                                    documents[doc.Path][branch.Class][branch.Method].Branches.Add(branch.Number, new List<BranchInfo>());
-                                    documents[doc.Path][branch.Class][branch.Method].Branches[branch.Number].Add(new BranchInfo
-                                        { Hits = branch.Hits, Offset = branch.Offset, EndOffset = branch.EndOffset, Path = branch.Path, Ordinal = branch.Ordinal }
-                                    );
+                                    documents[doc.Path][branch.Class][branch.Method].Branches[key] = new HitInfo { Hits = branch.Hits };
                                 }
                             }
                             else
                             {
                                 documents[doc.Path].Add(branch.Class, new Methods());
                                 documents[doc.Path][branch.Class].Add(branch.Method, new Method());
-                                documents[doc.Path][branch.Class][branch.Method].Branches.Add(branch.Number, new List<BranchInfo>());
-                                documents[doc.Path][branch.Class][branch.Method].Branches[branch.Number].Add(new BranchInfo
-                                    { Hits = branch.Hits, Offset = branch.Offset, EndOffset = branch.EndOffset, Path = branch.Path, Ordinal = branch.Ordinal }
-                                );
+                                documents[doc.Path][branch.Class][branch.Method].Branches[key] = new HitInfo { Hits = branch.Hits };
                             }
                         }
                         else
@@ -137,10 +121,7 @@ namespace Coverlet.Core
                             documents.Add(doc.Path, new Classes());
                             documents[doc.Path].Add(branch.Class, new Methods());
                             documents[doc.Path][branch.Class].Add(branch.Method, new Method());
-                            documents[doc.Path][branch.Class][branch.Method].Branches.Add(branch.Number, new List<BranchInfo>());
-                            documents[doc.Path][branch.Class][branch.Method].Branches[branch.Number].Add(new BranchInfo
-                                { Hits = branch.Hits, Offset = branch.Offset, EndOffset = branch.EndOffset, Path = branch.Path, Ordinal = branch.Ordinal }
-                            );
+                            documents[doc.Path][branch.Class][branch.Method].Branches[key] = new HitInfo { Hits = branch.Hits };
                         }
                     }
                 }

--- a/src/coverlet.core/Coverage.cs
+++ b/src/coverlet.core/Coverage.cs
@@ -126,7 +126,8 @@ namespace Coverlet.Core
                     }
                 }
 
-                modules.Add(result.ModulePath, documents);
+                // TODO: Module path is not generic across multiple projects referencing the same assemblies.
+                modules.Add(Path.GetFileName(result.ModulePath), documents);
                 InstrumentationHelper.RestoreOriginalModule(result.ModulePath, _identifier);
             }
 

--- a/src/coverlet.core/CoverageResult.cs
+++ b/src/coverlet.core/CoverageResult.cs
@@ -1,8 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.IO;
-
-using Jil;
 
 namespace Coverlet.Core
 {

--- a/src/coverlet.core/CoverageResult.cs
+++ b/src/coverlet.core/CoverageResult.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 
@@ -5,21 +6,13 @@ using Jil;
 
 namespace Coverlet.Core
 {
-    public class LineInfo
+    public class HitInfo
     {
         public int Hits { get; set; }
     }
 
-    public class BranchInfo : LineInfo
-    {
-        public int Offset { get; set; }
-        public int EndOffset { get; set; }
-        public int Path { get; set; }
-        public uint Ordinal { get; set; }
-    }
-
-    public class Lines : SortedDictionary<int, LineInfo> { }
-    public class Branches : SortedDictionary<int, List<BranchInfo>> { }
+    public class Lines : SortedDictionary<int, HitInfo> { }
+    public class Branches : SortedDictionary<(int Number, int Offset, int EndOffset, int Path, uint Ordinal), HitInfo> { }
     public class Method
     {
         internal Method()

--- a/src/coverlet.core/CoverageSummary.cs
+++ b/src/coverlet.core/CoverageSummary.cs
@@ -62,19 +62,19 @@ namespace Coverlet.Core
             return details;
         }
 
-        public CoverageDetails CalculateBranchCoverage(List<BranchInfo> branchInfo)
+        public CoverageDetails CalculateBranchCoverage(List<KeyValuePair<(int Number, int Offset, int EndOffset, int Path, uint Ordinal), HitInfo>> branches)
         {
             var details = new CoverageDetails();
-            details.Covered = branchInfo.Count(bi => bi.Hits > 0);
-            details.Total = branchInfo.Count;
+            details.Covered = branches.Count(kv => kv.Value.Hits > 0);
+            details.Total = branches.Count;
             return details;
         }
 
         public CoverageDetails CalculateBranchCoverage(Branches branches)
         {
             var details = new CoverageDetails();
-            details.Covered = branches.Sum(b => b.Value.Where(bi => bi.Hits > 0).Count());
-            details.Total = branches.Sum(b => b.Value.Count());
+            details.Covered = branches.Count(kv => kv.Value.Hits > 0);
+            details.Total = branches.Count;
             return details;
         }
 

--- a/src/coverlet.core/Extensions/CoverageResultExtensions.cs
+++ b/src/coverlet.core/Extensions/CoverageResultExtensions.cs
@@ -1,0 +1,108 @@
+﻿using Coverlet.Core;
+
+namespace coverlet.core.Extensions
+{
+    public static class CoverageResultHelper
+    {
+        public static void Merge(this CoverageResult result, CoverageResult other)
+        {
+            MergeModules(result.Modules, other.Modules);
+        }
+
+        private static void MergeModules(Modules result, Modules other)
+        {
+            foreach (var keyValuePair in other)
+            {
+                if (!result.ContainsKey(keyValuePair.Key))
+                {
+                    result[keyValuePair.Key] = keyValuePair.Value;
+                }
+                else
+                {
+                    MergeDocuments(result[keyValuePair.Key], keyValuePair.Value);
+                }
+            }
+        }
+
+        private static void MergeDocuments(Documents result, Documents other)
+        {
+            foreach (var keyValuePair in other)
+            {
+                if (!result.ContainsKey(keyValuePair.Key))
+                {
+                    result[keyValuePair.Key] = keyValuePair.Value;
+                }
+                else
+                {
+                    MergeClasses(result[keyValuePair.Key], keyValuePair.Value);
+                }
+            }
+        }
+
+        private static void MergeClasses(Classes result, Classes other)
+        {
+            foreach (var keyValuePair in other)
+            {
+                if (!result.ContainsKey(keyValuePair.Key))
+                {
+                    result[keyValuePair.Key] = keyValuePair.Value;
+                }
+                else
+                {
+                    MergeMethods(result[keyValuePair.Key], keyValuePair.Value);
+                }
+            }
+        }
+
+        private static void MergeMethods(Methods result, Methods other)
+        {
+            foreach (var keyValuePair in other)
+            {
+                if (!result.ContainsKey(keyValuePair.Key))
+                {
+                    result[keyValuePair.Key] = keyValuePair.Value;
+                }
+                else
+                {
+                    MergeMethod(result[keyValuePair.Key], keyValuePair.Value);
+                }
+            }
+        }
+
+        private static void MergeMethod(Method result, Method other)
+        {
+            MergeLines(result.Lines, other.Lines);
+            MergeBranches(result.Branches, other.Branches);
+        }
+
+        private static void MergeBranches(Branches result, Branches other)
+        {
+            foreach (var keyValuePair in other)
+            {
+                if (!result.ContainsKey(keyValuePair.Key))
+                {
+                    result[keyValuePair.Key] = keyValuePair.Value;
+                }
+                else
+                {
+                    result[keyValuePair.Key].Hits += keyValuePair.Value.Hits;
+                }
+            }
+        }
+
+        private static void MergeLines(Lines result, Lines other)
+        {
+            foreach (var keyValuePair in other)
+            {
+                if (!result.ContainsKey(keyValuePair.Key))
+                {
+                    result[keyValuePair.Key] = keyValuePair.Value;
+                }
+                else
+                {
+                    result[keyValuePair.Key].Hits += keyValuePair.Value.Hits;
+                }
+            }
+        }
+    }
+}

--- a/src/coverlet.core/Reporters/CoberturaReporter.cs
+++ b/src/coverlet.core/Reporters/CoberturaReporter.cs
@@ -72,16 +72,18 @@ namespace Coverlet.Core.Reporters
                             foreach (var ln in meth.Value.Lines)
                             {
                                 XElement line = new XElement("line");
+                                var branches = meth.Value.Branches.Where(kv => kv.Key.Number == ln.Key).ToList();
+
                                 line.Add(new XAttribute("number", ln.Key.ToString()));
                                 line.Add(new XAttribute("hits", ln.Value.Hits.ToString()));
-                                line.Add(new XAttribute("branch", meth.Value.Branches.ContainsKey(ln.Key).ToString()));
+                                line.Add(new XAttribute("branch", branches.Any().ToString()));
 
-                                if (meth.Value.Branches.TryGetValue(ln.Key, out List<BranchInfo> branches))
+                                if (branches.Any())
                                 {
                                     var branchInfoCoverage = summary.CalculateBranchCoverage(branches);
                                     line.Add(new XAttribute("condition-coverage", $"{branchInfoCoverage.Percent*100}% ({branchInfoCoverage.Covered}/{branchInfoCoverage.Total})"));
                                     XElement conditions = new XElement("conditions");
-                                    var byOffset = branches.GroupBy(b => b.Offset).ToDictionary(b => b.Key, b => b.ToList());
+                                    var byOffset = branches.GroupBy(kv => kv.Key.Offset).ToDictionary(b => b.Key, b => b.ToList());
                                     foreach (var entry in byOffset)
                                     {
                                         XElement condition = new XElement("condition");

--- a/src/coverlet.core/Reporters/CoberturaReporter.cs
+++ b/src/coverlet.core/Reporters/CoberturaReporter.cs
@@ -130,6 +130,11 @@ namespace Coverlet.Core.Reporters
             return Encoding.UTF8.GetString(stream.ToArray());
         }
 
+        public CoverageResult Read(string data)
+        {
+            throw new NotSupportedException("Not supported by this reporter.");
+        }
+
         private string GetBasePath(Modules modules)
         {
             List<string> sources = new List<string>();

--- a/src/coverlet.core/Reporters/IReporter.cs
+++ b/src/coverlet.core/Reporters/IReporter.cs
@@ -5,5 +5,6 @@ namespace Coverlet.Core.Reporters
         string Format { get; }
         string Extension { get; }
         string Report(CoverageResult result);
+        CoverageResult Read(string data);
     }
 }

--- a/src/coverlet.core/Reporters/JsonReporter.cs
+++ b/src/coverlet.core/Reporters/JsonReporter.cs
@@ -1,4 +1,6 @@
+using System;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Coverlet.Core.Reporters
 {
@@ -10,7 +12,119 @@ namespace Coverlet.Core.Reporters
 
         public string Report(CoverageResult result)
         {
-            return JsonConvert.SerializeObject(result.Modules, Formatting.Indented);
+            return JsonConvert.SerializeObject(result.Modules, Formatting.Indented, new LinesConverter(), new BranchesConverter());
+        }
+
+        public CoverageResult Read(string data)
+        {
+            return new CoverageResult
+            {
+                Identifier = Guid.NewGuid().ToString(),
+                Modules = JsonConvert.DeserializeObject<Modules>(data, new LinesConverter(), new BranchesConverter())
+            };
+        }
+
+        private class BranchesConverter : JsonConverter
+        {
+            public override bool CanConvert(Type objectType)
+            {
+                return objectType == typeof(Branches);
+            }
+
+            public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+            {
+                var array = JArray.Load(reader);
+                var branches = new Branches();
+
+                foreach (var item in array)
+                {
+                    var obj = (JObject)item;
+
+                    var key = (
+                        (int)obj["Key"]["Number"],
+                        (int)obj["Key"]["Offset"],
+                        (int)obj["Key"]["EndOffset"],
+                        (int)obj["Key"]["Path"],
+                        (uint)obj["Key"]["Ordinal"]);
+                    var value = new HitInfo { Hits = (int)obj["Value"]["Hits"] };
+
+                    branches.Add(key, value);
+                }
+
+                return branches;
+            }
+
+            public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+            {
+                var branches = (Branches) value;
+                var array = new JArray();
+
+                foreach (var kv in branches)
+                {
+                    dynamic obj = new JObject();
+
+                    obj.Key = new JObject();
+                    obj.Key.Number = kv.Key.Number;
+                    obj.Key.Offset = kv.Key.Offset;
+                    obj.Key.EndOffset = kv.Key.EndOffset;
+                    obj.Key.Path = kv.Key.Path;
+                    obj.Key.Ordinal = kv.Key.Ordinal;
+
+                    obj.Value = new JObject();
+                    obj.Value.Hits = kv.Value.Hits;
+
+                    array.Add(obj);
+                }
+
+                array.WriteTo(writer);
+            }
+        }
+
+        private class LinesConverter : JsonConverter
+        {
+            public override bool CanConvert(Type objectType)
+            {
+                return objectType == typeof(Lines);
+            }
+
+            public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+            {
+                var array = JArray.Load(reader);
+                var lines = new Lines();
+
+                foreach (var item in array)
+                {
+                    var obj = (JObject) item;
+
+                    var key = (int)obj["Key"]["Line"];
+                    var value = new HitInfo { Hits = (int)obj["Value"]["Hits"] };
+
+                    lines.Add(key, value);
+                }
+
+                return lines;
+            }
+
+            public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+            {
+                var lines = (Lines)value;
+                var array = new JArray();
+
+                foreach (var kv in lines)
+                {
+                    dynamic obj = new JObject();
+
+                    obj.Key = new JObject();
+                    obj.Key.Line = kv.Key;
+
+                    obj.Value = new JObject();
+                    obj.Value.Hits = kv.Value.Hits;
+
+                    array.Add(obj);
+                }
+
+                array.WriteTo(writer);
+            }
         }
     }
 }

--- a/src/coverlet.core/Reporters/JsonReporter.cs
+++ b/src/coverlet.core/Reporters/JsonReporter.cs
@@ -1,5 +1,4 @@
-using System.IO;
-using Jil;
+using Newtonsoft.Json;
 
 namespace Coverlet.Core.Reporters
 {
@@ -11,11 +10,7 @@ namespace Coverlet.Core.Reporters
 
         public string Report(CoverageResult result)
         {
-            using (var writer = new StringWriter())
-            {
-                JSON.Serialize(result.Modules, writer, Options.PrettyPrint);
-                return writer.ToString();
-            }
+            return JsonConvert.SerializeObject(result.Modules, Formatting.Indented);
         }
     }
 }

--- a/src/coverlet.core/Reporters/LcovReporter.cs
+++ b/src/coverlet.core/Reporters/LcovReporter.cs
@@ -60,5 +60,10 @@ namespace Coverlet.Core.Reporters
 
             return string.Join(Environment.NewLine, lcov);
         }
+
+        public CoverageResult Read(string data)
+        {
+            throw new NotSupportedException("Not supported by this reporter.");
+        }
     }
 }

--- a/src/coverlet.core/Reporters/LcovReporter.cs
+++ b/src/coverlet.core/Reporters/LcovReporter.cs
@@ -38,10 +38,9 @@ namespace Coverlet.Core.Reporters
                             foreach (var line in method.Value.Lines)
                                 lcov.Add($"DA:{line.Key},{line.Value.Hits}");
 
-                            foreach (var branchs in method.Value.Branches)
+                            foreach (var branch in method.Value.Branches)
                             {
-                                foreach (var branch in branchs.Value)
-                                    lcov.Add($"BRDA:{branchs.Key},{branch.Offset},{branch.Path},{branch.Hits}");
+                                lcov.Add($"BRDA:{branch.Key},{branch.Key.Offset},{branch.Key.Path},{branch.Value.Hits}");
                             }
                         }
                     }

--- a/src/coverlet.core/Reporters/OpenCoverReporter.cs
+++ b/src/coverlet.core/Reporters/OpenCoverReporter.cs
@@ -233,5 +233,10 @@ namespace Coverlet.Core.Reporters
 
             return Encoding.UTF8.GetString(stream.ToArray());
         }
+
+        public CoverageResult Read(string data)
+        {
+            throw new NotSupportedException("Not supported by this reporter.");
+        }
     }
 }

--- a/src/coverlet.core/Reporters/OpenCoverReporter.cs
+++ b/src/coverlet.core/Reporters/OpenCoverReporter.cs
@@ -133,20 +133,17 @@ namespace Coverlet.Core.Reporters
 
                             foreach (var branches in meth.Value.Branches)
                             {
-                                foreach (var branch in branches.Value)
-                                {
-                                    XElement branchPoint = new XElement("BranchPoint");
-                                    branchPoint.Add(new XAttribute("vc", branch.Hits.ToString()));
-                                    branchPoint.Add(new XAttribute("upsid", branches.Key.ToString()));
-                                    branchPoint.Add(new XAttribute("ordinal", branch.Ordinal.ToString()));
-                                    branchPoint.Add(new XAttribute("path", branch.Path.ToString()));
-                                    branchPoint.Add(new XAttribute("offset", branch.Offset.ToString()));
-                                    branchPoint.Add(new XAttribute("offsetend", branch.EndOffset.ToString()));
-                                    branchPoint.Add(new XAttribute("sl", branches.Key.ToString()));
-                                    branchPoint.Add(new XAttribute("fileid", i.ToString()));
-                                    branchPoints.Add(branchPoint);
-                                    kBr++;
-                                }
+                                XElement branchPoint = new XElement("BranchPoint");
+                                branchPoint.Add(new XAttribute("vc", branches.Value.Hits.ToString()));
+                                branchPoint.Add(new XAttribute("upsid", branches.Key.Number.ToString()));
+                                branchPoint.Add(new XAttribute("ordinal", branches.Key.Ordinal.ToString()));
+                                branchPoint.Add(new XAttribute("path", branches.Key.Path.ToString()));
+                                branchPoint.Add(new XAttribute("offset", branches.Key.Offset.ToString()));
+                                branchPoint.Add(new XAttribute("offsetend", branches.Key.EndOffset.ToString()));
+                                branchPoint.Add(new XAttribute("sl", branches.Key.Number.ToString()));
+                                branchPoint.Add(new XAttribute("fileid", i.ToString()));
+                                branchPoints.Add(branchPoint);
+                                kBr++;
                             }
 
                             numMethods++;

--- a/src/coverlet.core/coverlet.core.csproj
+++ b/src/coverlet.core/coverlet.core.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jil" Version="2.15.4" />
     <PackageReference Include="Mono.Cecil" Version="0.10.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="System.Reflection.Metadata" Version="1.5.0" />
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="2.0.1" />
   </ItemGroup>

--- a/src/coverlet.msbuild/coverlet.msbuild.targets
+++ b/src/coverlet.msbuild/coverlet.msbuild.targets
@@ -22,6 +22,7 @@
   <Target Name="GenerateCoverageResult" AfterTargets="VSTest">
     <Coverlet.MSbuild.Tasks.CoverageResultTask
       Condition="$(CollectCoverage) == 'true'"
+      IntermediateResult="$(CoverletIntermediateResult)"
       Output="$(CoverletOutput)"
       OutputFormat="$(CoverletOutputFormat)"
       Threshold="$(Threshold)"

--- a/test/coverlet.core.tests/CoverageSummaryTests.cs
+++ b/test/coverlet.core.tests/CoverageSummaryTests.cs
@@ -15,12 +15,12 @@ namespace Coverlet.Core.Tests
         public CoverageSummaryTests()
         {
             Lines lines = new Lines();
-            lines.Add(1, new LineInfo { Hits = 1 });
-            lines.Add(2, new LineInfo { Hits = 0 });
+            lines.Add(1, new HitInfo { Hits = 1 });
+            lines.Add(2, new HitInfo { Hits = 0 });
             Branches branches = new Branches();
-            branches.Add(1, new List<BranchInfo>());
-            branches[1].Add(new BranchInfo { Hits = 1, Offset = 1, Path = 0, Ordinal = 1 });
-            branches[1].Add(new BranchInfo { Hits = 1, Offset = 1, Path = 1, Ordinal = 2 });
+
+            branches[(Number: 1, Offset: 1, EndOffset: 1, Path: 0, Ordinal: 1)] = new HitInfo { Hits = 1 };
+            branches[(Number: 2, Offset: 1, EndOffset: 1, Path: 0, Ordinal: 2)] = new HitInfo { Hits = 1 };
 
             Methods methods = new Methods();
             var methodString = "System.Void Coverlet.Core.Tests.CoverageSummaryTests::TestCalculateSummary()";

--- a/test/coverlet.core.tests/Extensions/CoverageResultExtensionsTests.cs
+++ b/test/coverlet.core.tests/Extensions/CoverageResultExtensionsTests.cs
@@ -1,0 +1,176 @@
+using System;
+using Xunit;
+using System.Collections.Generic;
+using coverlet.core.Extensions;
+
+namespace Coverlet.Core.Extensions.Tests
+{
+    public class CoverageResultExtensionsTests
+    {
+        [Fact]
+        public void TestMergeTwoDifferent()
+        {
+            var first = CreateResult("ResultA()");
+            var second = CreateResult("ResultB()");
+
+            first.Merge(second);
+
+            Assert.Equal(1, first.Modules["Module"]["Doc.cs"]["Class"]["ResultA()"].Branches[(Number: 1, Offset: 1, EndOffset: 2, Path: 0, Ordinal: 1)].Hits);
+            Assert.Equal(1, first.Modules["Module"]["Doc.cs"]["Class"]["ResultA()"].Branches[(Number: 1, Offset: 1, EndOffset: 2, Path: 1, Ordinal: 2)].Hits);
+            Assert.Equal(1, first.Modules["Module"]["Doc.cs"]["Class"]["ResultA()"].Lines[1].Hits);
+            Assert.Equal(0, first.Modules["Module"]["Doc.cs"]["Class"]["ResultA()"].Lines[2].Hits);
+
+            Assert.Equal(1, first.Modules["Module"]["Doc.cs"]["Class"]["ResultB()"].Branches[(Number: 1, Offset: 1, EndOffset: 2, Path: 0, Ordinal: 1)].Hits);
+            Assert.Equal(1, first.Modules["Module"]["Doc.cs"]["Class"]["ResultB()"].Branches[(Number: 1, Offset: 1, EndOffset: 2, Path: 1, Ordinal: 2)].Hits);
+            Assert.Equal(1, first.Modules["Module"]["Doc.cs"]["Class"]["ResultB()"].Lines[1].Hits);
+            Assert.Equal(0, first.Modules["Module"]["Doc.cs"]["Class"]["ResultB()"].Lines[2].Hits);
+        }
+
+        [Fact]
+        public void TestMergeTwoSimilar()
+        {
+            var first = CreateResult("Result()");
+            var second = CreateResult("Result()");
+
+            first.Merge(second);
+
+            Assert.Equal(2, first.Modules["Module"]["Doc.cs"]["Class"]["Result()"].Branches[(Number: 1, Offset: 1, EndOffset: 2, Path: 0, Ordinal: 1)].Hits);
+            Assert.Equal(2, first.Modules["Module"]["Doc.cs"]["Class"]["Result()"].Branches[(Number: 1, Offset: 1, EndOffset: 2, Path: 1, Ordinal: 2)].Hits);
+            Assert.Equal(2, first.Modules["Module"]["Doc.cs"]["Class"]["Result()"].Lines[1].Hits);
+            Assert.Equal(0, first.Modules["Module"]["Doc.cs"]["Class"]["Result()"].Lines[2].Hits);
+        }
+
+        [Fact]
+        public void TestMergeThreeDifferent()
+        {
+            var first = CreateResult("ResultA()");
+            var second = CreateResult("ResultB()");
+            var third = CreateResult("ResultC()");
+
+            first.Merge(second);
+            first.Merge(third);
+
+            Assert.Equal(1, first.Modules["Module"]["Doc.cs"]["Class"]["ResultA()"].Branches[(Number: 1, Offset: 1, EndOffset: 2, Path: 0, Ordinal: 1)].Hits);
+            Assert.Equal(1, first.Modules["Module"]["Doc.cs"]["Class"]["ResultA()"].Branches[(Number: 1, Offset: 1, EndOffset: 2, Path: 1, Ordinal: 2)].Hits);
+            Assert.Equal(1, first.Modules["Module"]["Doc.cs"]["Class"]["ResultA()"].Lines[1].Hits);
+            Assert.Equal(0, first.Modules["Module"]["Doc.cs"]["Class"]["ResultA()"].Lines[2].Hits);
+
+            Assert.Equal(1, first.Modules["Module"]["Doc.cs"]["Class"]["ResultB()"].Branches[(Number: 1, Offset: 1, EndOffset: 2, Path: 0, Ordinal: 1)].Hits);
+            Assert.Equal(1, first.Modules["Module"]["Doc.cs"]["Class"]["ResultB()"].Branches[(Number: 1, Offset: 1, EndOffset: 2, Path: 1, Ordinal: 2)].Hits);
+            Assert.Equal(1, first.Modules["Module"]["Doc.cs"]["Class"]["ResultB()"].Lines[1].Hits);
+            Assert.Equal(0, first.Modules["Module"]["Doc.cs"]["Class"]["ResultB()"].Lines[2].Hits);
+
+            Assert.Equal(1, first.Modules["Module"]["Doc.cs"]["Class"]["ResultC()"].Branches[(Number: 1, Offset: 1, EndOffset: 2, Path: 0, Ordinal: 1)].Hits);
+            Assert.Equal(1, first.Modules["Module"]["Doc.cs"]["Class"]["ResultC()"].Branches[(Number: 1, Offset: 1, EndOffset: 2, Path: 1, Ordinal: 2)].Hits);
+            Assert.Equal(1, first.Modules["Module"]["Doc.cs"]["Class"]["ResultC()"].Lines[1].Hits);
+            Assert.Equal(0, first.Modules["Module"]["Doc.cs"]["Class"]["ResultC()"].Lines[2].Hits);
+        }
+
+        [Fact]
+        public void TestMergeThreeSimilar()
+        {
+            var first = CreateResult("Result()");
+            var second = CreateResult("Result()");
+            var third = CreateResult("Result()");
+
+            first.Merge(second);
+            first.Merge(third);
+
+            Assert.Equal(3, first.Modules["Module"]["Doc.cs"]["Class"]["Result()"].Branches[(Number: 1, Offset: 1, EndOffset: 2, Path: 0, Ordinal: 1)].Hits);
+            Assert.Equal(3, first.Modules["Module"]["Doc.cs"]["Class"]["Result()"].Branches[(Number: 1, Offset: 1, EndOffset: 2, Path: 1, Ordinal: 2)].Hits);
+            Assert.Equal(3, first.Modules["Module"]["Doc.cs"]["Class"]["Result()"].Lines[1].Hits);
+            Assert.Equal(0, first.Modules["Module"]["Doc.cs"]["Class"]["Result()"].Lines[2].Hits);
+        }
+
+        [Fact]
+        public void TestMergeBothEmpty()
+        {
+            var first = CreateResultEmpty();
+            var second = CreateResultEmpty();
+
+            first.Merge(second);
+
+            Assert.Empty(first.Modules);
+        }
+
+        [Fact]
+        public void TestMergeOneEmpty()
+        {
+            var first = CreateResultEmpty();
+            var second = CreateResult("Result()");
+
+            first.Merge(second);
+
+            Assert.Equal(1, first.Modules["Module"]["Doc.cs"]["Class"]["Result()"].Branches[(Number: 1, Offset: 1, EndOffset: 2, Path: 0, Ordinal: 1)].Hits);
+            Assert.Equal(1, first.Modules["Module"]["Doc.cs"]["Class"]["Result()"].Branches[(Number: 1, Offset: 1, EndOffset: 2, Path: 1, Ordinal: 2)].Hits);
+            Assert.Equal(1, first.Modules["Module"]["Doc.cs"]["Class"]["Result()"].Lines[1].Hits);
+            Assert.Equal(0, first.Modules["Module"]["Doc.cs"]["Class"]["Result()"].Lines[2].Hits);
+        }
+
+        [Fact]
+        public void TestMergeUnmodified()
+        {
+            var first = CreateResult("Result()");
+            var second = CreateResultEmpty();
+
+            first.Merge(second);
+
+            Assert.Empty(second.Modules);
+        }
+
+        [Fact]
+        public void TestMergeIdentifier()
+        {
+            var first = CreateResult("ResultA()");
+            var second = CreateResult("ResultA()");
+
+            var beforeFirst = first.Identifier;
+            var beforeSecond = second.Identifier;
+
+            first.Merge(second);
+
+            Assert.Equal(beforeFirst, first.Identifier);
+            Assert.Equal(beforeSecond, second.Identifier);
+        }
+
+        private CoverageResult CreateResultEmpty()
+        {
+            return new CoverageResult()
+            {
+                Identifier = Guid.NewGuid().ToString(),
+                Modules = new Modules()
+            };
+        }
+
+        private CoverageResult CreateResult(string methodString)
+        {
+            Lines lines = new Lines();
+            lines.Add(1, new HitInfo { Hits = 1 });
+            lines.Add(2, new HitInfo { Hits = 0 });
+
+            Branches branches = new Branches();
+            branches[(Number: 1, Offset: 1, EndOffset: 2, Path: 0, Ordinal: 1)] = new HitInfo { Hits = 1 };
+            branches[(Number: 1, Offset: 1, EndOffset: 2, Path: 1, Ordinal: 2)] = new HitInfo { Hits = 1 };
+
+            Methods methods = new Methods();
+            methods.Add(methodString, new Method());
+            methods[methodString].Lines = lines;
+            methods[methodString].Branches = branches;
+
+            Classes classes = new Classes();
+            classes.Add("Class", methods);
+
+            Documents documents = new Documents();
+            documents.Add("Doc.cs", classes);
+
+            Modules modules = new Modules();
+            modules.Add("Module", documents);
+
+            return new CoverageResult()
+            {
+                Identifier = Guid.NewGuid().ToString(),
+                Modules = modules
+            };
+        }
+    }
+}

--- a/test/coverlet.core.tests/Reporters/CoberturaReporterTests.cs
+++ b/test/coverlet.core.tests/Reporters/CoberturaReporterTests.cs
@@ -12,13 +12,11 @@ namespace Coverlet.Core.Reporters.Tests
             CoverageResult result = new CoverageResult();
             result.Identifier = Guid.NewGuid().ToString();
             Lines lines = new Lines();
-            lines.Add(1, new LineInfo { Hits = 1 });
-            lines.Add(2, new LineInfo { Hits = 0 });
+            lines.Add(1, new HitInfo { Hits = 1 });
+            lines.Add(2, new HitInfo { Hits = 0 });
             Branches branches = new Branches();
-            branches.Add(1, new List<BranchInfo> {
-                new BranchInfo{ Hits = 1, Offset = 23, EndOffset = 24, Path = 0, Ordinal = 1 },
-                new BranchInfo{ Hits = 0, Offset = 23, EndOffset = 27, Path = 1, Ordinal = 2 }
-            });
+            branches[(Number: 1, Offset: 23, EndOffset: 24, Path: 0, Ordinal: 1)] = new HitInfo { Hits = 1 };
+            branches[(Number: 1, Offset: 23, EndOffset: 27, Path: 0, Ordinal: 2)] = new HitInfo { Hits = 0 };
             Methods methods = new Methods();
             var methodString = "System.Void Coverlet.Core.Reporters.Tests.CoberturaReporterTests::TestReport()";
             methods.Add(methodString, new Method());

--- a/test/coverlet.core.tests/Reporters/JsonReporterTests.cs
+++ b/test/coverlet.core.tests/Reporters/JsonReporterTests.cs
@@ -5,11 +5,12 @@ namespace Coverlet.Core.Reporters.Tests
 {
     public class JsonReporterTests
     {
-        [Fact]
-        public void TestReport()
+        private CoverageResult _result;
+
+        public JsonReporterTests()
         {
-            CoverageResult result = new CoverageResult();
-            result.Identifier = Guid.NewGuid().ToString();
+            _result = new CoverageResult();
+            _result.Identifier = Guid.NewGuid().ToString();
             Lines lines = new Lines();
             lines.Add(1, new HitInfo { Hits = 1 });
             lines.Add(2, new HitInfo { Hits = 0 });
@@ -21,12 +22,29 @@ namespace Coverlet.Core.Reporters.Tests
             classes.Add("Coverlet.Core.Reporters.Tests.JsonReporterTests", methods);
             Documents documents = new Documents();
             documents.Add("doc.cs", classes);
-            result.Modules = new Modules();
-            result.Modules.Add("module", documents);
+            _result.Modules = new Modules();
+            _result.Modules.Add("module", documents);
+        }
 
+        [Fact]
+        public void TestReport()
+        {
             JsonReporter reporter = new JsonReporter();
-            Assert.NotEqual("{\n}", reporter.Report(result));
-            Assert.NotEqual(string.Empty, reporter.Report(result));
+            Assert.NotEqual("{\n}", reporter.Report(_result));
+            Assert.NotEqual(string.Empty, reporter.Report(_result));
+        }
+
+        [Fact]
+        public void TestRead()
+        {
+            JsonReporter reporter = new JsonReporter();
+
+            var json = reporter.Report(_result);
+            var result = reporter.Read(json);
+
+            Assert.Equal(1, result.Modules["module"]["doc.cs"]["Coverlet.Core.Reporters.Tests.JsonReporterTests"]["System.Void Coverlet.Core.Reporters.Tests.JsonReporterTests.TestReport()"].Lines[1].Hits);
+            Assert.Equal(0, result.Modules["module"]["doc.cs"]["Coverlet.Core.Reporters.Tests.JsonReporterTests"]["System.Void Coverlet.Core.Reporters.Tests.JsonReporterTests.TestReport()"].Lines[2].Hits);
+            Assert.NotEqual(_result.Identifier, result.Identifier);
         }
     }
 }

--- a/test/coverlet.core.tests/Reporters/JsonReporterTests.cs
+++ b/test/coverlet.core.tests/Reporters/JsonReporterTests.cs
@@ -11,8 +11,8 @@ namespace Coverlet.Core.Reporters.Tests
             CoverageResult result = new CoverageResult();
             result.Identifier = Guid.NewGuid().ToString();
             Lines lines = new Lines();
-            lines.Add(1, new LineInfo { Hits = 1 });
-            lines.Add(2, new LineInfo { Hits = 0 });
+            lines.Add(1, new HitInfo { Hits = 1 });
+            lines.Add(2, new HitInfo { Hits = 0 });
             Methods methods = new Methods();
             var methodString = "System.Void Coverlet.Core.Reporters.Tests.JsonReporterTests.TestReport()";
             methods.Add(methodString, new Method());

--- a/test/coverlet.core.tests/Reporters/LcovReporterTests.cs
+++ b/test/coverlet.core.tests/Reporters/LcovReporterTests.cs
@@ -12,13 +12,11 @@ namespace Coverlet.Core.Reporters.Tests
             CoverageResult result = new CoverageResult();
             result.Identifier = Guid.NewGuid().ToString();
             Lines lines = new Lines();
-            lines.Add(1, new LineInfo { Hits = 1 });
-            lines.Add(2, new LineInfo { Hits = 0 });
+            lines.Add(1, new HitInfo { Hits = 1 });
+            lines.Add(2, new HitInfo { Hits = 0 });
             Branches branches = new Branches();
-            branches.Add(1, new List<BranchInfo> {
-                new BranchInfo{ Hits = 1, Offset = 23, EndOffset = 24, Path = 0, Ordinal = 1 },
-                new BranchInfo{ Hits = 0, Offset = 23, EndOffset = 27, Path = 1, Ordinal = 2 }
-            });
+            branches[(Number: 1, Offset: 23, EndOffset: 24, Path: 0, Ordinal: 1)] = new HitInfo { Hits = 1 };
+            branches[(Number: 1, Offset: 23, EndOffset: 27, Path: 0, Ordinal: 2)] = new HitInfo { Hits = 0 };
             Methods methods = new Methods();
             var methodString = "System.Void Coverlet.Core.Reporters.Tests.LcovReporterTests.TestReport()";
             methods.Add(methodString, new Method());

--- a/test/coverlet.core.tests/Reporters/OpenCoverReporterTests.cs
+++ b/test/coverlet.core.tests/Reporters/OpenCoverReporterTests.cs
@@ -40,13 +40,11 @@ namespace Coverlet.Core.Reporters.Tests
         private static Documents CreateFirstDocuments()
         {
             Lines lines = new Lines();
-            lines.Add(1, new LineInfo { Hits = 1 });
-            lines.Add(2, new LineInfo { Hits = 0 });
+            lines.Add(1, new HitInfo { Hits = 1 });
+            lines.Add(2, new HitInfo { Hits = 0 });
             Branches branches = new Branches();
-            branches.Add(1, new List<BranchInfo> {
-                new BranchInfo{ Hits = 1, Offset = 23, EndOffset = 24, Path = 0, Ordinal = 1 },
-                new BranchInfo{ Hits = 0, Offset = 23, EndOffset = 27, Path = 1, Ordinal = 2 }
-            });
+            branches[(Number: 1, Offset: 23, EndOffset: 24, Path: 0, Ordinal: 1)] = new HitInfo { Hits = 1 };
+            branches[(Number: 1, Offset: 23, EndOffset: 27, Path: 0, Ordinal: 2)] = new HitInfo { Hits = 0 };
             Methods methods = new Methods();
             var methodString = "System.Void Coverlet.Core.Reporters.Tests.OpenCoverReporterTests.TestReport()";
             methods.Add(methodString, new Method());
@@ -62,8 +60,8 @@ namespace Coverlet.Core.Reporters.Tests
         private static Documents CreateSecondDocuments()
         {            
             Lines lines = new Lines();
-            lines.Add(1, new LineInfo { Hits = 1 });
-            lines.Add(2, new LineInfo { Hits = 0 });
+            lines.Add(1, new HitInfo { Hits = 1 });
+            lines.Add(2, new HitInfo { Hits = 0 });
 
             Methods methods = new Methods();
             var methodString = "System.Void Some.Other.Module.TestClass.TestMethod()";


### PR DESCRIPTION
This PR adds support for merging results of multiple projects. It is similar to how OpenCover supports this.

It is as simple as adding `/p:CoverletIntermediateResult=intermediate.json` to the arguments. Just ensure that this file doesn't exist when you would record the test results of multiple projects.

I have created [this](https://github.com/basilfx/Coverlet-Test) test project (you have to fix reference to Coverlet package), which demonstrates how two projects that both cover 50% will yield 100% when merging the intermediate results. I have also verified that the report generated by ReportGenerator looks as expected.

```
Calculating coverage result...

Merging with intermediate result...
  Intermediate result written to '../intermediate.json'

Writing report(s)...
  Generating report 'C:\Projects\GitHub\Coverlet-Test\tests\CoverletTests.FooTests\coverage.opencover.xml'
  Generating report 'C:\Projects\GitHub\Coverlet-Test\tests\CoverletTests.FooTests\coverage.cobertura.xml'

+--------------+--------+--------+--------+
| Module       | Line   | Branch | Method |
+--------------+--------+--------+--------+
| CoverletTest | 100%   | 100%   | 100%   |
+--------------+--------+--------+--------+

+---------+--------+--------+--------+
|         | Line   | Branch | Method |
+---------+--------+--------+--------+
| Average | 100%   | 100%   | 100%   |
+---------+--------+--------+--------+
```

References:
#36 