### PR TITLE
Global tool

### DIFF
--- a/src/coverlet.console/Logging/ConsoleLogger.cs
+++ b/src/coverlet.console/Logging/ConsoleLogger.cs
@@ -1,0 +1,39 @@
+using System;
+using static System.Console;
+
+namespace Coverlet.Console.Logging
+{
+    class ConsoleLogger : ILogger
+    {
+        public void LogError(string message)
+        {
+            ForegroundColor = ConsoleColor.Red;
+            WriteLine(message);
+            ForegroundColor = ConsoleColor.White;
+        }
+
+        public void LogInformation(string message)
+        {
+            WriteLine(message);
+        }
+
+        public void LogSuccess(string message)
+        {
+            ForegroundColor = ConsoleColor.Green;
+            WriteLine(message);
+            ForegroundColor = ConsoleColor.White;
+        }
+
+        public void LogVerbose(string message)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void LogWarning(string message)
+        {
+            ForegroundColor = ConsoleColor.Yellow;
+            WriteLine(message);
+            ForegroundColor = ConsoleColor.White;
+        }
+    }
+}

--- a/src/coverlet.console/Logging/ILogger.cs
+++ b/src/coverlet.console/Logging/ILogger.cs
@@ -1,0 +1,11 @@
+namespace Coverlet.Console.Logging
+{
+    interface ILogger
+    {
+        void LogSuccess(string message);
+        void LogVerbose(string message);
+        void LogInformation(string message);
+        void LogWarning(string message);
+        void LogError(string message);
+    }
+}

--- a/src/coverlet.console/Program.cs
+++ b/src/coverlet.console/Program.cs
@@ -1,55 +1,55 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
+
+using Coverlet.Console.Logging;
+using Coverlet.Core;
+using Coverlet.Core.Reporters;
 
 using Microsoft.Extensions.CommandLineUtils;
 
-namespace coverlet.console
+namespace Coverlet.Console
 {
     class Program
     {
         static int Main(string[] args)
         {
+            var logger = new ConsoleLogger();
             var app = new CommandLineApplication();
             app.Name = "coverlet";
             app.FullName = "Cross platform .NET Core code coverage tool";
             app.HelpOption("-h|--help");
             app.VersionOption("-v|--version", GetAssemblyVersion());
 
-            CommandArgument project = app.Argument("<PROJECT>", "The project to test. Defaults to the current directory.");
-            CommandOption config = app.Option("-c|--configuration", "Configuration to use for building the project.", CommandOptionType.SingleValue);
-            CommandOption output = app.Option("-o|--coverage-output", "The output path of the generated coverage report", CommandOptionType.SingleValue);
-            CommandOption format = app.Option("-f|--coverage-format", "The format of the coverage report", CommandOptionType.SingleValue);
+            CommandArgument module = app.Argument("<ASSEMBLY>", "Path to the test assembly.");
+            CommandOption target = app.Option("-t|--target", "Path to the test runner application.", CommandOptionType.SingleValue);
+            CommandOption targs = app.Option("-a|--targetargs", "Arguments to be passed to the test runner.", CommandOptionType.SingleValue);
+            CommandOption output = app.Option("-o|--output", "Output of the generated coverage report", CommandOptionType.SingleValue);
+            CommandOption format = app.Option("-f|--format", "Format of the generated coverage report.", CommandOptionType.MultipleValue);
+            CommandOption threshold = app.Option("--threshold", "Exits with error if the coverage % is below value.", CommandOptionType.SingleValue);
+            CommandOption thresholdType = app.Option("--threshold-type", "Coverage type to apply the threshold to.", CommandOptionType.MultipleValue);
+            CommandOption filters = app.Option("--exclude", "Filter expressions to exclude specific modules and types.", CommandOptionType.MultipleValue);
+            CommandOption excludes = app.Option("--exclude-by-file", "Glob patterns specifying source files to exclude.", CommandOptionType.MultipleValue);
 
             app.OnExecute(() =>
             {
-                var dotnetTestArgs = new List<string>();
+                if (string.IsNullOrEmpty(module.Value) || string.IsNullOrWhiteSpace(module.Value))
+                    throw new CommandParsingException(app, "No test assembly specified.");
 
-                dotnetTestArgs.Add("test");
+                if (!target.HasValue())
+                    throw new CommandParsingException(app, "Target must be specified.");
 
-                if (project.Value != string.Empty)
-                    dotnetTestArgs.Add(project.Value);
-
-                if (config.HasValue())
-                    dotnetTestArgs.Add($"-c {config.Value()}");
-
-                dotnetTestArgs.Add("/p:CollectCoverage=true");
-
-                if (output.HasValue())
-                    dotnetTestArgs.Add($"/p:CoverletOutput={output.Value()}");
-
-                if (format.HasValue())
-                    dotnetTestArgs.Add($"/p:CoverletOutputFormat={format.Value()}");
+                Coverage coverage = new Coverage(module.Value, filters.Values.ToArray(), excludes.Values.ToArray());
+                coverage.PrepareModules();
 
                 Process process = new Process();
-                process.StartInfo.FileName = "dotnet";
-                process.StartInfo.Arguments = string.Join(" ", dotnetTestArgs);
+                process.StartInfo.FileName = target.Value();
+                process.StartInfo.Arguments = targs.HasValue() ? targs.Value() : string.Empty;
                 process.StartInfo.CreateNoWindow = true;
-
                 process.Start();
                 process.WaitForExit();
 
-                return process.ExitCode;
+                return 0;
             });
 
             try
@@ -58,7 +58,7 @@ namespace coverlet.console
             }
             catch (CommandParsingException ex)
             {
-                Console.WriteLine(ex.Message);
+                logger.LogError(ex.Message);
                 app.ShowHelp();
                 return 1;
             }

--- a/src/coverlet.console/coverlet.console.csproj
+++ b/src/coverlet.console/coverlet.console.csproj
@@ -13,4 +13,8 @@
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.1.1" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\coverlet.core\coverlet.core.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/coverlet.console/coverlet.console.csproj
+++ b/src/coverlet.console/coverlet.console.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="ConsoleTables" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.1.1" />
   </ItemGroup>
 

--- a/src/coverlet.console/coverlet.console.csproj
+++ b/src/coverlet.console/coverlet.console.csproj
@@ -6,7 +6,7 @@
     <ToolCommandName>coverlet</ToolCommandName>
     <PackAsTool>true</PackAsTool>
     <AssemblyTitle>Coverlet</AssemblyTitle>
-    <AssemblyVersion>0.1.0</AssemblyVersion>
+    <AssemblyVersion>1.0.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR adds the possibility to use Coverlet as a standalone global tool and removes the need to include it in your msbuild pipeline.

Example usage:

```shell
coverlet /path/to/test-assembly --target "dotnet" --targetargs "test /path/to/test-project --no-build"
```

```shell
coverlet /path/to/test-assembly --target "dotnet" --targetargs "test /path/to/test-project --no-build" --threshold 90
```

```shell
coverlet /path/to/test-assembly --target "dotnet" --targetargs "test /path/to/test-project --no-build" --format lcov --format opencover
```

```shell
coverlet /path/to/test-assembly --target "dotnet" --targetargs "test /path/to/test-project --no-build" -o ./output/
```