### PR TITLE
Support MSBuild item group separator for multi-value task properties

### DIFF
--- a/src/coverlet.msbuild.tasks/CoverageResultTask.cs
+++ b/src/coverlet.msbuild.tasks/CoverageResultTask.cs
@@ -12,6 +12,7 @@ namespace Coverlet.MSbuild.Tasks
 {
     public class CoverageResultTask : Task
     {
+        private static readonly char[] _separators = new[] { ',', ';' };
         private string _output;
         private string _format;
         private int _threshold;
@@ -58,7 +59,7 @@ namespace Coverlet.MSbuild.Tasks
                 if (!Directory.Exists(directory))
                     Directory.CreateDirectory(directory);
 
-                var formats = _format.Split(',');
+                var formats = _format.Split(_separators);
                 foreach (var format in formats)
                 {
                     var reporter = new ReporterFactory(format).CreateReporter();
@@ -75,7 +76,7 @@ namespace Coverlet.MSbuild.Tasks
                 }
 
                 var thresholdFailed = false;
-                var thresholdTypes = _thresholdType.Split(',').Select(t => t.Trim());
+                var thresholdTypes = _thresholdType.Split(_separators).Select(t => t.Trim());
                 var summary = new CoverageSummary();
                 var exceptionBuilder = new StringBuilder();
                 var coverageTable = new ConsoleTable("Module", "Line", "Branch", "Method");

--- a/src/coverlet.msbuild.tasks/InstrumentationTask.cs
+++ b/src/coverlet.msbuild.tasks/InstrumentationTask.cs
@@ -7,6 +7,7 @@ namespace Coverlet.MSbuild.Tasks
 {
     public class InstrumentationTask : Task
     {
+        private static readonly char[] _separators = new[] { ',', ';' };
         private static Coverage _coverage;
         private string _path;
         private string _exclude;
@@ -40,8 +41,8 @@ namespace Coverlet.MSbuild.Tasks
         {
             try
             {
-                var excludes = _excludeByFile?.Split(',');
-                var filters = _exclude?.Split(',');
+                var excludes = _excludeByFile?.Split(_separators);
+                var filters = _exclude?.Split(_separators);
 
                 _coverage = new Coverage(_path, filters, excludes);
                 _coverage.PrepareModules();


### PR DESCRIPTION
The PR adds support of MSBuild item group separator `;` for these multi-value task properties:

1. `Exclude`
2. `ExcludeByFile`
3. `Include`
4. `OutputFormat`
5. `ThresholdType`