### PR TITLE
Make enumeration-based MSBuild properties case-insensitive

### DIFF
--- a/src/coverlet.core/Reporters/ReporterFactory.cs
+++ b/src/coverlet.core/Reporters/ReporterFactory.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Collections.Generic;
 
@@ -18,6 +19,6 @@ namespace Coverlet.Core.Reporters
         }
 
         public IReporter CreateReporter()
-            => _reporters.FirstOrDefault(r => r.Format == _format);
+            => _reporters.FirstOrDefault(r => string.Equals(r.Format, _format, StringComparison.OrdinalIgnoreCase));
     }
 }

--- a/src/coverlet.msbuild.tasks/CoverageResultTask.cs
+++ b/src/coverlet.msbuild.tasks/CoverageResultTask.cs
@@ -90,19 +90,19 @@ namespace Coverlet.MSbuild.Tasks
 
                     if (_threshold > 0)
                     {
-                        if (linePercent < _threshold && thresholdTypes.Contains("line"))
+                        if (linePercent < _threshold && thresholdTypes.Contains("line", StringComparer.OrdinalIgnoreCase))
                         {
                             exceptionBuilder.AppendLine($"'{Path.GetFileNameWithoutExtension(module.Key)}' has a line coverage '{linePercent}%' below specified threshold '{_threshold}%'");
                             thresholdFailed = true;
                         }
 
-                        if (branchPercent < _threshold && thresholdTypes.Contains("branch"))
+                        if (branchPercent < _threshold && thresholdTypes.Contains("branch", StringComparer.OrdinalIgnoreCase))
                         {
                             exceptionBuilder.AppendLine($"'{Path.GetFileNameWithoutExtension(module.Key)}' has a branch coverage '{branchPercent}%' below specified threshold '{_threshold}%'");
                             thresholdFailed = true;
                         }
 
-                        if (methodPercent < _threshold && thresholdTypes.Contains("method"))
+                        if (methodPercent < _threshold && thresholdTypes.Contains("method", StringComparer.OrdinalIgnoreCase))
                         {
                             exceptionBuilder.AppendLine($"'{Path.GetFileNameWithoutExtension(module.Key)}' has a method coverage '{methodPercent}%' below specified threshold '{_threshold}%'");
                             thresholdFailed = true;


### PR DESCRIPTION
The PR makes these enumeration-based MSBuild properties case-insensitive:

1. `OutputFormat`
2. `ThresholdType`

MSBuild has case-insensitive string comparison. And thus, any task which working with strings should support case-insensitive string processing for common scenarios.