### PR TITLE
Improve performance and memory usage during report file generation

### DIFF
--- a/src/coverlet.console/Program.cs
+++ b/src/coverlet.console/Program.cs
@@ -77,7 +77,9 @@ namespace Coverlet.Console
 
                     var report = Path.Combine(directory, filename);
                     logger.LogInformation($"  Generating report '{report}'");
-                    File.WriteAllText(report, reporter.Report(result));
+                    using (var fileStream = new FileStream(report, FileMode.Create, FileAccess.Write, FileShare.Read))
+                    using (var streamWriter = new StreamWriter(fileStream, Encoding.UTF8))
+                        reporter.Report(result, streamWriter);
                 }
 
                 var summary = new CoverageSummary();

--- a/src/coverlet.console/Program.cs
+++ b/src/coverlet.console/Program.cs
@@ -77,8 +77,7 @@ namespace Coverlet.Console
 
                     var report = Path.Combine(directory, filename);
                     logger.LogInformation($"  Generating report '{report}'");
-                    using (var fileStream = new FileStream(report, FileMode.Create, FileAccess.Write, FileShare.Read))
-                    using (var streamWriter = new StreamWriter(fileStream, Encoding.UTF8))
+                    using (var streamWriter = File.CreateText(report))
                         reporter.Report(result, streamWriter);
                 }
 

--- a/src/coverlet.core/Reporters/CoberturaReporter.cs
+++ b/src/coverlet.core/Reporters/CoberturaReporter.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Xml;
 using System.Xml.Linq;
 
@@ -14,7 +13,7 @@ namespace Coverlet.Core.Reporters
 
         public string Extension => "cobertura.xml";
 
-        public string Report(CoverageResult result)
+        public void Report(CoverageResult result, StreamWriter streamWriter)
         {
             CoverageSummary summary = new CoverageSummary();
 
@@ -123,11 +122,7 @@ namespace Coverlet.Core.Reporters
             coverage.Add(sources);
             coverage.Add(packages);
             xml.Add(coverage);
-
-            var stream = new MemoryStream();
-            xml.Save(stream);
-
-            return Encoding.UTF8.GetString(stream.ToArray());
+            xml.Save(streamWriter);
         }
 
         private string GetBasePath(Modules modules)

--- a/src/coverlet.core/Reporters/IReporter.cs
+++ b/src/coverlet.core/Reporters/IReporter.cs
@@ -1,9 +1,11 @@
+using System.IO;
+
 namespace Coverlet.Core.Reporters
 {
     public interface IReporter
     {
         string Format { get; }
         string Extension { get; }
-        string Report(CoverageResult result);
+        void Report(CoverageResult result, StreamWriter stream);
     }
 }

--- a/src/coverlet.core/Reporters/JsonReporter.cs
+++ b/src/coverlet.core/Reporters/JsonReporter.cs
@@ -1,16 +1,19 @@
+using System.IO;
 using Newtonsoft.Json;
 
 namespace Coverlet.Core.Reporters
 {
     public class JsonReporter : IReporter
     {
+        private static readonly JsonSerializer _jsonSerializer = JsonSerializer.CreateDefault(new JsonSerializerSettings { Formatting = Formatting.Indented });
+
         public string Format => "json";
 
         public string Extension => "json";
 
-        public string Report(CoverageResult result)
+        public void Report(CoverageResult result, StreamWriter streamWriter)
         {
-            return JsonConvert.SerializeObject(result.Modules, Formatting.Indented);
+            _jsonSerializer.Serialize(streamWriter, result.Modules);
         }
     }
 }

--- a/src/coverlet.core/Reporters/LcovReporter.cs
+++ b/src/coverlet.core/Reporters/LcovReporter.cs
@@ -1,6 +1,5 @@
-using System;
 using System.Linq;
-using System.Collections.Generic;
+using System.IO;
 
 namespace Coverlet.Core.Reporters
 {
@@ -10,10 +9,9 @@ namespace Coverlet.Core.Reporters
 
         public string Extension => "info";
 
-        public string Report(CoverageResult result)
+        public void Report(CoverageResult result, StreamWriter streamWriter)
         {
             CoverageSummary summary = new CoverageSummary();
-            List<string> lcov = new List<string>();
 
             foreach (var module in result.Modules)
             {
@@ -23,7 +21,7 @@ namespace Coverlet.Core.Reporters
                     var docBranchCoverage = summary.CalculateBranchCoverage(doc.Value);
                     var docMethodCoverage = summary.CalculateMethodCoverage(doc.Value);
 
-                    lcov.Add("SF:" + doc.Key);
+                    streamWriter.WriteLine("SF:" + doc.Key);
                     foreach (var @class in doc.Value)
                     {
                         foreach (var method in @class.Value)
@@ -32,33 +30,31 @@ namespace Coverlet.Core.Reporters
                             if (method.Value.Lines.Count == 0)
                                 continue;
 
-                            lcov.Add($"FN:{method.Value.Lines.First().Key - 1},{method.Key}");
-                            lcov.Add($"FNDA:{method.Value.Lines.First().Value},{method.Key}");
+                            streamWriter.WriteLine($"FN:{method.Value.Lines.First().Key - 1},{method.Key}");
+                            streamWriter.WriteLine($"FNDA:{method.Value.Lines.First().Value},{method.Key}");
 
                             foreach (var line in method.Value.Lines)
-                                lcov.Add($"DA:{line.Key},{line.Value}");
+                                streamWriter.WriteLine($"DA:{line.Key},{line.Value}");
 
                             foreach (var branch in method.Value.Branches)
                             {
-                                lcov.Add($"BRDA:{branch.Line},{branch.Offset},{branch.Path},{branch.Hits}");
+                                streamWriter.WriteLine($"BRDA:{branch.Line},{branch.Offset},{branch.Path},{branch.Hits}");
                             }
                         }
                     }
 
-                    lcov.Add($"LF:{docLineCoverage.Total}");
-                    lcov.Add($"LH:{docLineCoverage.Covered}");
+                    streamWriter.WriteLine($"LF:{docLineCoverage.Total}");
+                    streamWriter.WriteLine($"LH:{docLineCoverage.Covered}");
 
-                    lcov.Add($"BRF:{docBranchCoverage.Total}");
-                    lcov.Add($"BRH:{docBranchCoverage.Covered}");
+                    streamWriter.WriteLine($"BRF:{docBranchCoverage.Total}");
+                    streamWriter.WriteLine($"BRH:{docBranchCoverage.Covered}");
 
-                    lcov.Add($"FNF:{docMethodCoverage.Total}");
-                    lcov.Add($"FNH:{docMethodCoverage.Covered}");
+                    streamWriter.WriteLine($"FNF:{docMethodCoverage.Total}");
+                    streamWriter.WriteLine($"FNH:{docMethodCoverage.Covered}");
 
-                    lcov.Add("end_of_record");
+                    streamWriter.WriteLine("end_of_record");
                 }
             }
-
-            return string.Join(Environment.NewLine, lcov);
         }
     }
 }

--- a/src/coverlet.core/Reporters/OpenCoverReporter.cs
+++ b/src/coverlet.core/Reporters/OpenCoverReporter.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Xml.Linq;
 
 namespace Coverlet.Core.Reporters
@@ -13,7 +12,7 @@ namespace Coverlet.Core.Reporters
 
         public string Extension => "opencover.xml";
 
-        public string Report(CoverageResult result)
+        public void Report(CoverageResult result, StreamWriter streamWriter)
         {
             CoverageSummary summary = new CoverageSummary();
             XDocument xml = new XDocument();
@@ -227,11 +226,7 @@ namespace Coverlet.Core.Reporters
             coverage.Add(coverageSummary);
             coverage.Add(modules);
             xml.Add(coverage);
-
-            var stream = new MemoryStream();
-            xml.Save(stream);
-
-            return Encoding.UTF8.GetString(stream.ToArray());
+            xml.Save(streamWriter);
         }
     }
 }

--- a/src/coverlet.msbuild.tasks/CoverageResultTask.cs
+++ b/src/coverlet.msbuild.tasks/CoverageResultTask.cs
@@ -71,7 +71,9 @@ namespace Coverlet.MSbuild.Tasks
 
                     var report = Path.Combine(directory, filename);
                     Console.WriteLine($"  Generating report '{report}'");
-                    File.WriteAllText(report, reporter.Report(result));
+                    using (var fileStream = new FileStream(report, FileMode.Create, FileAccess.Write, FileShare.Read))
+                    using (var streamWriter = new StreamWriter(fileStream, Encoding.UTF8))
+                        reporter.Report(result, streamWriter);
                 }
 
                 var thresholdFailed = false;

--- a/src/coverlet.msbuild.tasks/CoverageResultTask.cs
+++ b/src/coverlet.msbuild.tasks/CoverageResultTask.cs
@@ -71,8 +71,7 @@ namespace Coverlet.MSbuild.Tasks
 
                     var report = Path.Combine(directory, filename);
                     Console.WriteLine($"  Generating report '{report}'");
-                    using (var fileStream = new FileStream(report, FileMode.Create, FileAccess.Write, FileShare.Read))
-                    using (var streamWriter = new StreamWriter(fileStream, Encoding.UTF8))
+                    using (var streamWriter = File.CreateText(report))
                         reporter.Report(result, streamWriter);
                 }
 

--- a/test/coverlet.core.tests/Reporters/CoberturaReporterTests.cs
+++ b/test/coverlet.core.tests/Reporters/CoberturaReporterTests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Text;
 using Xunit;
 
 namespace Coverlet.Core.Reporters.Tests
@@ -36,7 +38,14 @@ namespace Coverlet.Core.Reporters.Tests
             result.Modules.Add("module", documents);
 
             CoberturaReporter reporter = new CoberturaReporter();
-            Assert.NotEqual(string.Empty, reporter.Report(result));
+            using (var memoryStream = new MemoryStream())
+            {
+                using (var streamWriter = new StreamWriter(memoryStream))
+                    reporter.Report(result, streamWriter);
+
+                var reportString = Encoding.UTF8.GetString(memoryStream.ToArray());
+                Assert.NotEqual(string.Empty, reportString);
+            }
         }
     }
 }

--- a/test/coverlet.core.tests/Reporters/JsonReporterTests.cs
+++ b/test/coverlet.core.tests/Reporters/JsonReporterTests.cs
@@ -1,4 +1,6 @@
 using System;
+using System.IO;
+using System.Text;
 using Xunit;
 
 namespace Coverlet.Core.Reporters.Tests
@@ -30,8 +32,15 @@ namespace Coverlet.Core.Reporters.Tests
             result.Modules.Add("module", documents);
 
             JsonReporter reporter = new JsonReporter();
-            Assert.NotEqual("{\n}", reporter.Report(result));
-            Assert.NotEqual(string.Empty, reporter.Report(result));
+            using (var memoryStream = new MemoryStream())
+            {
+                using (var streamWriter = new StreamWriter(memoryStream))
+                    reporter.Report(result, streamWriter);
+
+                var reportString = Encoding.UTF8.GetString(memoryStream.ToArray());
+                Assert.NotEqual("{\n}", reportString);
+                Assert.NotEqual(string.Empty, reportString);
+            }
         }
     }
 }

--- a/test/coverlet.core.tests/Reporters/LcovReporterTests.cs
+++ b/test/coverlet.core.tests/Reporters/LcovReporterTests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Text;
 using Xunit;
 
 namespace Coverlet.Core.Reporters.Tests
@@ -35,10 +37,15 @@ namespace Coverlet.Core.Reporters.Tests
             result.Modules.Add("module", documents);
 
             LcovReporter reporter = new LcovReporter();
-            string report = reporter.Report(result);
+            using (var memoryStream = new MemoryStream())
+            {
+                using (var streamWriter = new StreamWriter(memoryStream))
+                    reporter.Report(result, streamWriter);
 
-            Assert.NotEmpty(report);
-            Assert.Equal("SF:doc.cs", report.Split(Environment.NewLine)[0]);
+                var reportString = Encoding.UTF8.GetString(memoryStream.ToArray());
+                Assert.NotEmpty(reportString);
+                Assert.Equal("SF:doc.cs", reportString.Split(Environment.NewLine)[0]);
+            }
         }
     }
 }

--- a/test/coverlet.core.tests/Reporters/OpenCoverReporterTests.cs
+++ b/test/coverlet.core.tests/Reporters/OpenCoverReporterTests.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Text;
 using Xunit;
 
 namespace Coverlet.Core.Reporters.Tests
@@ -16,7 +18,14 @@ namespace Coverlet.Core.Reporters.Tests
             result.Modules.Add("Coverlet.Core.Reporters.Tests", CreateFirstDocuments());
 
             OpenCoverReporter reporter = new OpenCoverReporter();
-            Assert.NotEqual(string.Empty, reporter.Report(result));
+            using (var memoryStream = new MemoryStream())
+            {
+                using (var streamWriter = new StreamWriter(memoryStream))
+                    reporter.Report(result, streamWriter);
+
+                var reportString = Encoding.UTF8.GetString(memoryStream.ToArray());
+                Assert.NotEqual(string.Empty, reportString);
+            }
         }
 
         [Fact]
@@ -30,11 +39,16 @@ namespace Coverlet.Core.Reporters.Tests
             result.Modules.Add("Some.Other.Module", CreateSecondDocuments());
 
             OpenCoverReporter reporter = new OpenCoverReporter();
-            var xml = reporter.Report(result);
-            Assert.NotEqual(string.Empty, xml);
+            using (var memoryStream = new MemoryStream())
+            {
+                using (var streamWriter = new StreamWriter(memoryStream))
+                    reporter.Report(result, streamWriter);
 
-            Assert.Contains(@"<FileRef uid=""1"" />", xml);
-            Assert.Contains(@"<FileRef uid=""2"" />", xml);
+                var reportString = Encoding.UTF8.GetString(memoryStream.ToArray());
+                Assert.NotEqual(string.Empty, reportString);
+                Assert.Contains(@"<FileRef uid=""1"" />", reportString);
+                Assert.Contains(@"<FileRef uid=""2"" />", reportString);
+            }
         }
 
         private static Documents CreateFirstDocuments()


### PR DESCRIPTION
The PR improves performance and memory usage during report file generation by the following changes:

1. Remove additional allocation of  `MemoryStream`, `List<T>`, `byte[]`, and `string` objects.
2. Change reporters to write content directly to a `StreamWriter` instance.