### PR TITLE
Explorative PR to solve bug #122[NO MERGE]

### DIFF
--- a/src/coverlet.core/Coverage.cs
+++ b/src/coverlet.core/Coverage.cs
@@ -34,7 +34,8 @@ namespace Coverlet.Core
         public void PrepareModules()
         {
             string[] modules = InstrumentationHelper.GetCoverableModules(_module);
-            string[] excludes =  InstrumentationHelper.GetExcludedFiles(_excludes);
+            //var ef = InstrumentationHelper.GetExcludedFiles(_excludes);
+            var excludedFilesHelper = new ExcludedFilesHelper(_excludes);
             _filters = _filters?.Where(f => InstrumentationHelper.IsValidFilterExpression(f)).ToArray();
 
             foreach (var module in modules)
@@ -42,7 +43,7 @@ namespace Coverlet.Core
                 if (InstrumentationHelper.IsModuleExcluded(module, _filters))
                     continue;
 
-                var instrumenter = new Instrumenter(module, _identifier, _filters, excludes);
+                var instrumenter = new Instrumenter(module, _identifier, _filters, excludedFilesHelper);
                 if (instrumenter.CanInstrument())
                 {
                     InstrumentationHelper.BackupOriginalModule(module, _identifier);

--- a/src/coverlet.core/Helpers/InstrumentationHelper.cs
+++ b/src/coverlet.core/Helpers/InstrumentationHelper.cs
@@ -246,5 +246,50 @@ namespace Coverlet.Core.Helpers
             }
         }
     }
+
+    internal class ExcludedFilesHelper
+    {
+        const string RELATIVE_KEY = nameof(RELATIVE_KEY);
+        Dictionary<string, Matcher> _matcherDict;
+        public ExcludedFilesHelper(string[] excludes)
+        {
+            if (excludes != null && excludes.Length > 0)
+            {
+                _matcherDict = new Dictionary<string, Matcher>() { { RELATIVE_KEY, new Matcher() } };
+                foreach (var excludeRule in excludes)
+                {
+                    if (Path.IsPathRooted(excludeRule))
+                    {
+                        var root = Path.GetPathRoot(excludeRule);
+                        if (!_matcherDict.ContainsKey(root))
+                        {
+                            _matcherDict.Add(root, new Matcher());
+                        }
+                        _matcherDict[root].AddInclude(excludeRule.Substring(root.Length));
+                    }
+                    else
+                    {
+                        _matcherDict[RELATIVE_KEY].AddInclude(excludeRule);
+                    }
+                }
+            }
+        }
+
+        public bool Exclude(string sourceFile)
+        {
+            if (_matcherDict == null)
+                return false;
+
+            foreach (var entry in _matcherDict)
+            {
+                if (entry.Value.Match(Path.IsPathRooted(sourceFile) ?
+                    sourceFile.Substring(Path.GetPathRoot(sourceFile).Length) :
+                    sourceFile).HasMatches)
+                    return true;
+            }
+
+            return false;
+        }
+    }
 }
 

--- a/src/coverlet.core/Instrumentation/Instrumenter.cs
+++ b/src/coverlet.core/Instrumentation/Instrumenter.cs
@@ -20,16 +20,16 @@ namespace Coverlet.Core.Instrumentation
         private readonly string _module;
         private readonly string _identifier;
         private readonly string[] _filters;
-        private readonly string[] _excludedFiles;
         private readonly static Lazy<MethodInfo> _markExecutedMethodLoader = new Lazy<MethodInfo>(GetMarkExecutedMethod);
+        private readonly ExcludedFilesHelper _excludedFilesHelper;
         private InstrumenterResult _result;
 
-        public Instrumenter(string module, string identifier, string[] filters, string[] excludedFiles)
+        public Instrumenter(string module, string identifier, string[] filters, ExcludedFilesHelper excludedFilesHelper)
         {
             _module = module;
             _identifier = identifier;
             _filters = filters;
-            _excludedFiles = excludedFiles ?? Array.Empty<string>();
+            _excludedFilesHelper = excludedFilesHelper ?? new ExcludedFilesHelper(null);
         }
 
         public bool CanInstrument() => InstrumentationHelper.HasPdb(_module);
@@ -102,7 +102,7 @@ namespace Coverlet.Core.Instrumentation
         private void InstrumentMethod(MethodDefinition method)
         {
             var sourceFile = method.DebugInformation.SequencePoints.Select(s => s.Document.Url).FirstOrDefault();
-            if (!string.IsNullOrEmpty(sourceFile) && _excludedFiles.Contains(sourceFile))
+            if (!string.IsNullOrEmpty(sourceFile) && _excludedFilesHelper.Exclude(sourceFile))
                 return;
 
             var methodBody = GetMethodBody(method);

--- a/src/coverlet.msbuild.tasks/InstrumentationTask.cs
+++ b/src/coverlet.msbuild.tasks/InstrumentationTask.cs
@@ -40,6 +40,7 @@ namespace Coverlet.MSbuild.Tasks
         {
             try
             {
+                //System.Diagnostics.Debugger.Launch();
                 var excludes = _excludeByFile?.Split(',');
                 var filters = _exclude?.Split(',');
 

--- a/test/coverlet.core.tests/Instrumentation/InstrumenterTests.cs
+++ b/test/coverlet.core.tests/Instrumentation/InstrumenterTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Xunit;
 using Coverlet.Core.Instrumentation;
 using Coverlet.Core.Samples.Tests;
+using Coverlet.Core.Helpers;
 
 namespace Coverlet.Core.Instrumentation.Tests
 {
@@ -51,7 +52,7 @@ namespace Coverlet.Core.Instrumentation.Tests
             File.Copy(pdb, Path.Combine(directory.FullName, Path.GetFileName(pdb)), true);
 
             module = Path.Combine(directory.FullName, Path.GetFileName(module));
-            Instrumenter instrumenter = new Instrumenter(module, identifier, Array.Empty<string>(), Array.Empty<string>());
+            Instrumenter instrumenter = new Instrumenter(module, identifier, Array.Empty<string>(), new ExcludedFilesHelper(null));
             return new InstrumenterTest
             {
                 Instrumenter = instrumenter,


### PR DESCRIPTION
This is an explorative PR to understand how to fix bug reported by @hack2root on https://github.com/tonerdo/coverlet/issues/122

After some debugging i think the issue is on `InstrumentationHelper.GetExcludedFiles` implementation.
`InstrumentationHelper.GetExcludedFiles` load a list of cs files to exclude from coverage, but this files are searched only starting from [msbuild starting path](https://github.com/tonerdo/coverlet/blob/master/src/coverlet.core/Helpers/InstrumentationHelper.cs#L199)(` Directory.GetCurrentDirectory()`) for "relative" filters.
I'm able to reproduce issue with simple test like(from CoverletTest folder):
```
dotnet test --configuration Release "...\CoverletTest\CoverletTest.csproj"  /p:CollectCoverage=true /p:CoverletOutputFormat=opencover  /v:m  /p:ExcludeByFile=\"**/*Attribute*.cs\,**/*.cs"
```
and with this directory structure
```
CoverletSampleLib
CoverletTest
bugTest.sln
```

So my idea is to test exclusion directly for every source file processed(maybe could perf better for big projects with lot of source files).
I'm not sure if this behaviour was expected or not, let me know if it makes sense and i can go on with my proposal and cleanup code and add some tests.

/cc @tonerdo  @ido-namely
