### PR TITLE
Add include option

### DIFF
--- a/src/coverlet.console/Program.cs
+++ b/src/coverlet.console/Program.cs
@@ -31,8 +31,9 @@ namespace Coverlet.Console
             CommandOption formats = app.Option("-f|--format", "Format of the generated coverage report.", CommandOptionType.MultipleValue);
             CommandOption threshold = app.Option("--threshold", "Exits with error if the coverage % is below value.", CommandOptionType.SingleValue);
             CommandOption thresholdTypes = app.Option("--threshold-type", "Coverage type to apply the threshold to.", CommandOptionType.MultipleValue);
-            CommandOption filters = app.Option("--exclude", "Filter expressions to exclude specific modules and types.", CommandOptionType.MultipleValue);
-            CommandOption excludes = app.Option("--exclude-by-file", "Glob patterns specifying source files to exclude.", CommandOptionType.MultipleValue);
+            CommandOption excludeFilters = app.Option("--exclude", "Filter expressions to exclude specific modules and types.", CommandOptionType.MultipleValue);
+            CommandOption includeFilters = app.Option("--include", "Filter expressions to include only specific modules and types.", CommandOptionType.MultipleValue);
+            CommandOption excludedSourceFiles = app.Option("--exclude-by-file", "Glob patterns specifying source files to exclude.", CommandOptionType.MultipleValue);
 
             app.OnExecute(() =>
             {
@@ -42,7 +43,7 @@ namespace Coverlet.Console
                 if (!target.HasValue())
                     throw new CommandParsingException(app, "Target must be specified.");
 
-                Coverage coverage = new Coverage(module.Value, filters.Values.ToArray(), excludes.Values.ToArray());
+                Coverage coverage = new Coverage(module.Value, excludeFilters.Values.ToArray(), includeFilters.Values.ToArray(), excludedSourceFiles.Values.ToArray());
                 coverage.PrepareModules();
 
                 Process process = new Process();

--- a/src/coverlet.core/Helpers/InstrumentationHelper.cs
+++ b/src/coverlet.core/Helpers/InstrumentationHelper.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -111,22 +112,49 @@ namespace Coverlet.Core.Helpers
             return true;
         }
 
-        public static bool IsModuleExcluded(string module, string[] filters)
+        public static bool IsModuleExcluded(string module, string[] excludeFilters)
         {
-            if (filters == null)
+            if (excludeFilters == null || excludeFilters.Length == 0)
                 return false;
 
             module = Path.GetFileNameWithoutExtension(module);
             if (module == null)
                 return false;
 
-            foreach (var filter in filters)
+            foreach (var filter in excludeFilters)
             {
-                string modulePattern = filter.Substring(1, filter.IndexOf(']') - 1);
                 string typePattern = filter.Substring(filter.IndexOf(']') + 1);
 
                 if (typePattern != "*")
                     continue;
+
+                string modulePattern = filter.Substring(1, filter.IndexOf(']') - 1);
+                modulePattern = WildcardToRegex(modulePattern);
+
+                var regex = new Regex(modulePattern);
+
+                if (regex.IsMatch(module))
+                    return true;
+            }
+
+            return false;
+        }
+
+        public static bool IsModuleIncluded(string module, string[] includeFilters)
+        {
+            if (includeFilters == null || includeFilters.Length == 0)
+                return true;
+
+            module = Path.GetFileNameWithoutExtension(module);
+            if (module == null)
+                return false;
+
+            foreach (var filter in includeFilters)
+            {
+                string modulePattern = filter.Substring(1, filter.IndexOf(']') - 1);
+
+                if (modulePattern == "*")
+                    return true;
 
                 modulePattern = WildcardToRegex(modulePattern);
 
@@ -139,28 +167,28 @@ namespace Coverlet.Core.Helpers
             return false;
         }
 
-        public static bool IsTypeExcluded(string module, string type, string[] filters)
+        public static bool IsTypeExcluded(string module, string type, string[] excludeFilters)
         {
-            if (filters == null)
+            if (excludeFilters == null || excludeFilters.Length == 0)
                 return false;
 
             module = Path.GetFileNameWithoutExtension(module);
             if (module == null)
                 return false;
 
-            foreach (var filter in filters)
-            {
-                string typePattern = filter.Substring(filter.IndexOf(']') + 1);
-                string modulePattern = filter.Substring(1, filter.IndexOf(']') - 1);
+            return IsTypeFilterMatch(module, type, excludeFilters);
+        }
 
-                typePattern = WildcardToRegex(typePattern);
-                modulePattern = WildcardToRegex(modulePattern);
+        public static bool IsTypeIncluded(string module, string type, string[] includeFilters)
+        {
+            if (includeFilters == null || includeFilters.Length == 0)
+                return true;
 
-                if (new Regex(typePattern).IsMatch(type) && new Regex(modulePattern).IsMatch(module))
-                    return true;
-            }
+            module = Path.GetFileNameWithoutExtension(module);
+            if (module == null)
+                return true;
 
-            return false;
+            return IsTypeFilterMatch(module, type, includeFilters);
         }
 
         public static bool IsLocalMethod(string method)
@@ -204,6 +232,26 @@ namespace Coverlet.Core.Helpers
             }
 
             return files.Distinct().ToArray();
+        }
+
+        private static bool IsTypeFilterMatch(string module, string type, string[] filters)
+        {
+            Debug.Assert(module != null);
+            Debug.Assert(filters != null);
+
+            foreach (var filter in filters)
+            {
+                string typePattern = filter.Substring(filter.IndexOf(']') + 1);
+                string modulePattern = filter.Substring(1, filter.IndexOf(']') - 1);
+
+                typePattern = WildcardToRegex(typePattern);
+                modulePattern = WildcardToRegex(modulePattern);
+
+                if (new Regex(typePattern).IsMatch(type) && new Regex(modulePattern).IsMatch(module))
+                    return true;
+            }
+
+            return false;
         }
 
         private static string GetBackupPath(string module, string identifier)

--- a/src/coverlet.core/Instrumentation/Instrumenter.cs
+++ b/src/coverlet.core/Instrumentation/Instrumenter.cs
@@ -19,16 +19,18 @@ namespace Coverlet.Core.Instrumentation
     {
         private readonly string _module;
         private readonly string _identifier;
-        private readonly string[] _filters;
+        private readonly string[] _excludeFilters;
+        private readonly string[] _includeFilters;
         private readonly string[] _excludedFiles;
         private readonly static Lazy<MethodInfo> _markExecutedMethodLoader = new Lazy<MethodInfo>(GetMarkExecutedMethod);
         private InstrumenterResult _result;
 
-        public Instrumenter(string module, string identifier, string[] filters, string[] excludedFiles)
+        public Instrumenter(string module, string identifier, string[] excludeFilters, string[] includeFilters, string[] excludedFiles)
         {
             _module = module;
             _identifier = identifier;
-            _filters = filters;
+            _excludeFilters = excludeFilters;
+            _includeFilters = includeFilters;
             _excludedFiles = excludedFiles ?? Array.Empty<string>();
         }
 
@@ -69,7 +71,8 @@ namespace Coverlet.Core.Instrumentation
                     {
                         var actualType = type.DeclaringType ?? type;
                         if (!actualType.CustomAttributes.Any(IsExcludeAttribute)
-                            && !InstrumentationHelper.IsTypeExcluded(_module, actualType.FullName, _filters))
+                            && !InstrumentationHelper.IsTypeExcluded(_module, actualType.FullName, _excludeFilters)
+                            && InstrumentationHelper.IsTypeIncluded(_module, actualType.FullName, _includeFilters))
                             InstrumentType(type);
                     }
 

--- a/src/coverlet.msbuild.tasks/InstrumentationTask.cs
+++ b/src/coverlet.msbuild.tasks/InstrumentationTask.cs
@@ -10,6 +10,7 @@ namespace Coverlet.MSbuild.Tasks
         private static Coverage _coverage;
         private string _path;
         private string _exclude;
+        private string _include;
         private string _excludeByFile;
 
         internal static Coverage Coverage
@@ -30,6 +31,12 @@ namespace Coverlet.MSbuild.Tasks
             set { _exclude = value; }
         }
 
+        public string Include
+        {
+            get { return _include; }
+            set { _include = value; }
+        }
+
         public string ExcludeByFile
         {
             get { return _excludeByFile; }
@@ -40,10 +47,11 @@ namespace Coverlet.MSbuild.Tasks
         {
             try
             {
-                var excludes = _excludeByFile?.Split(',');
-                var filters = _exclude?.Split(',');
+                var excludedSourceFiles = _excludeByFile?.Split(',');
+                var excludeFilters = _exclude?.Split(',');
+                var includeFilters = _include?.Split(',');
 
-                _coverage = new Coverage(_path, filters, excludes);
+                _coverage = new Coverage(_path, excludeFilters, includeFilters, excludedSourceFiles);
                 _coverage.PrepareModules();
             }
             catch (Exception ex)

--- a/test/coverlet.core.performancetest/PerformanceTest.cs
+++ b/test/coverlet.core.performancetest/PerformanceTest.cs
@@ -9,7 +9,7 @@ namespace coverlet.core.performancetest
     /// Test the performance of coverlet by running a unit test that calls a reasonably big and complex test class.
     /// Enable the test, compile, then run the test in the command line:
     /// <code>
-    /// dotnet test -p:CollectCoverage=true -p:CoverletOutputFormat=opencover test/coverlet.core.performa ncetest/
+    /// dotnet test -p:CollectCoverage=true -p:CoverletOutputFormat=opencover test/coverlet.core.performancetest/
     /// </code>
     /// </summary>
     public class PerformanceTest

--- a/test/coverlet.core.tests/CoverageTests.cs
+++ b/test/coverlet.core.tests/CoverageTests.cs
@@ -27,7 +27,7 @@ namespace Coverlet.Core.Tests
             // Since Coverage only instruments dependancies, we need a fake module here
             var testModule = Path.Combine(directory.FullName, "test.module.dll");
 
-            var coverage = new Coverage(testModule, Array.Empty<string>(), Array.Empty<string>());
+            var coverage = new Coverage(testModule, Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>());
             coverage.PrepareModules();
 
             var result = coverage.GetCoverageResult();

--- a/test/coverlet.core.tests/Helpers/InstrumentationHelperTests.cs
+++ b/test/coverlet.core.tests/Helpers/InstrumentationHelperTests.cs
@@ -149,6 +149,14 @@ namespace Coverlet.Core.Helpers.Tests
             Assert.False(result);
         }
 
+        [Fact]
+        public void TestIsModuleIncludedWithoutFilter()
+        {
+            var result = InstrumentationHelper.IsModuleIncluded("Module.dll", new string[0]);
+
+            Assert.True(result);
+        }
+
         [Theory]
         [InlineData("[Module]mismatch")]
         [InlineData("[Mismatch]*")]
@@ -159,23 +167,35 @@ namespace Coverlet.Core.Helpers.Tests
             Assert.False(result);
         }
 
+        [Fact]
+        public void TestIsModuleIncludedWithSingleMismatchFilter()
+        {
+            var result = InstrumentationHelper.IsModuleIncluded("Module.dll", new[] { "[Mismatch]*" });
+
+            Assert.False(result);
+        }
+
         [Theory]
         [MemberData(nameof(ValidModuleFilterData))]
-        public void TestIsModuleExcludedWithFilter(string filter)
+        public void TestIsModuleExcludedAndIncludedWithFilter(string filter)
         {
             var result = InstrumentationHelper.IsModuleExcluded("Module.dll", new[] { filter });
+            Assert.True(result);
 
+            result = InstrumentationHelper.IsModuleIncluded("Module.dll", new[] { filter });
             Assert.True(result);
         }
 
         [Theory]
         [MemberData(nameof(ValidModuleFilterData))]
-        public void TestIsModuleExcludedWithMatchingAndMismatchingFilter(string filter)
+        public void TestIsModuleExcludedAndIncludedWithMatchingAndMismatchingFilter(string filter)
         {
             var filters = new[] { "[Mismatch]*", filter, "[Mismatch]*" };
 
             var result = InstrumentationHelper.IsModuleExcluded("Module.dll", filters);
+            Assert.True(result);
 
+            result = InstrumentationHelper.IsModuleIncluded("Module.dll", filters);
             Assert.True(result);
         }
 
@@ -187,34 +207,48 @@ namespace Coverlet.Core.Helpers.Tests
             Assert.False(result);
         }
 
-        [Theory]
-        [InlineData("[Module]mismatch")]
-        [InlineData("[Mismatch]*")]
-        [InlineData("[Mismatch]a.b.Dto")]
-        public void TestIsTypeExcludedWithSingleMismatchFilter(string filter)
+        [Fact]
+        public void TestIsTypeIncludedWithoutFilter()
         {
-            var result = InstrumentationHelper.IsTypeExcluded("Module.dll", "a.b.Dto", new[] { filter });
-
-            Assert.False(result);
-        }
-
-        [Theory]
-        [MemberData(nameof(ValidModuleAndNamespaceFilterData))]
-        public void TestIsTypeExcludedWithFilter(string filter)
-        {
-            var result = InstrumentationHelper.IsTypeExcluded("Module.dll", "a.b.Dto", new[] { filter });
+            var result = InstrumentationHelper.IsTypeIncluded("Module.dll", "a.b.Dto", new string[0]);
 
             Assert.True(result);
         }
 
         [Theory]
+        [InlineData("[Module]mismatch")]
+        [InlineData("[Mismatch]*")]
+        [InlineData("[Mismatch]a.b.Dto")]
+        public void TestIsTypeExcludedAndIncludedWithSingleMismatchFilter(string filter)
+        {
+            var result = InstrumentationHelper.IsTypeExcluded("Module.dll", "a.b.Dto", new[] { filter });
+            Assert.False(result);
+
+            result = InstrumentationHelper.IsTypeIncluded("Module.dll", "a.b.Dto", new[] { filter });
+            Assert.False(result);
+        }
+
+        [Theory]
         [MemberData(nameof(ValidModuleAndNamespaceFilterData))]
-        public void TestIsTypeExcludedWithMatchingAndMismatchingFilter(string filter)
+        public void TestIsTypeExcludedAndIncludedWithFilter(string filter)
+        {
+            var result = InstrumentationHelper.IsTypeExcluded("Module.dll", "a.b.Dto", new[] { filter });
+            Assert.True(result);
+
+            result = InstrumentationHelper.IsTypeIncluded("Module.dll", "a.b.Dto", new[] { filter });
+            Assert.True(result);
+        }
+
+        [Theory]
+        [MemberData(nameof(ValidModuleAndNamespaceFilterData))]
+        public void TestIsTypeExcludedAndIncludedWithMatchingAndMismatchingFilter(string filter)
         {
             var filters = new[] { "[Mismatch]*", filter, "[Mismatch]*" };
 
             var result = InstrumentationHelper.IsTypeExcluded("Module.dll", "a.b.Dto", filters);
+            Assert.True(result);
 
+            result = InstrumentationHelper.IsTypeIncluded("Module.dll", "a.b.Dto", filters);
             Assert.True(result);
         }
 

--- a/test/coverlet.core.tests/Instrumentation/InstrumenterTests.cs
+++ b/test/coverlet.core.tests/Instrumentation/InstrumenterTests.cs
@@ -51,7 +51,7 @@ namespace Coverlet.Core.Instrumentation.Tests
             File.Copy(pdb, Path.Combine(directory.FullName, Path.GetFileName(pdb)), true);
 
             module = Path.Combine(directory.FullName, Path.GetFileName(module));
-            Instrumenter instrumenter = new Instrumenter(module, identifier, Array.Empty<string>(), Array.Empty<string>());
+            Instrumenter instrumenter = new Instrumenter(module, identifier, Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>());
             return new InstrumenterTest
             {
                 Instrumenter = instrumenter,


### PR DESCRIPTION
Fixes #163. 

Assuming that users typically won't be using both, if they do exclude filter takes precedence. Notice the defaults:

* Default exclude: nothing is excluded
* Default include: everything is included

I felt tempted to avoid some allocations on the filters but opted to keep the code clear as it is, e.g.: I could have avoid some string allocations by batching the creation of substrings etc. Perhaps we can look at this later as separate optimization.

For the tests the include filters are almost symmetrical to the exclude ones so I put some of them under the same test method.