### PR TITLE
Performance improvement during run of instrumented code

### DIFF
--- a/src/coverlet.core/Coverage.cs
+++ b/src/coverlet.core/Coverage.cs
@@ -161,6 +161,8 @@ namespace Coverlet.Core
                     continue;
                 }
 
+                List<Document> documents = result.Documents.Values.ToList();
+
                 using (var fs = new FileStream(result.HitsFilePath, FileMode.Open))
                 using (var sr = new StreamReader(fs))
                 {
@@ -173,7 +175,7 @@ namespace Coverlet.Core
                             continue;
 
                         bool isBranch = info[0] == "B";
-                        var document = result.Documents.ElementAt(int.Parse(info[1])).Value;
+                        var document = documents[int.Parse(info[1])];
 
                         int start = int.Parse(info[2]);
                         int hits = int.Parse(info[4]);

--- a/src/coverlet.core/Instrumentation/Instrumenter.cs
+++ b/src/coverlet.core/Instrumentation/Instrumenter.cs
@@ -175,16 +175,11 @@ namespace Coverlet.Core.Instrumentation
 
         private Instruction AddInstrumentationCode(MethodDefinition method, ILProcessor processor, Instruction instruction, SequencePoint sequencePoint)
         {
-            int documentIndex = 0;
             if (!_result.Documents.TryGetValue(sequencePoint.Document.Url, out var document))
             {
                 document = new Document { Path = sequencePoint.Document.Url };
-                documentIndex = _result.Documents.Count;
+                document.Index = _result.Documents.Count;
                 _result.Documents.Add(document.Path, document);
-            }
-            else
-            {
-                documentIndex = _result.Documents.Keys.ToList().IndexOf(document.Path);
             }
 
             for (int i = sequencePoint.StartLine; i <= sequencePoint.EndLine; i++)
@@ -193,7 +188,7 @@ namespace Coverlet.Core.Instrumentation
                     document.Lines.Add(i, new Line { Number = i, Class = method.DeclaringType.FullName, Method = method.FullName });
             }
 
-            string marker = $"L,{documentIndex},{sequencePoint.StartLine},{sequencePoint.EndLine}";
+            string marker = $"L,{document.Index},{sequencePoint.StartLine},{sequencePoint.EndLine}";
 
             var pathInstr = Instruction.Create(OpCodes.Ldstr, _result.HitsFilePath);
             var markInstr = Instruction.Create(OpCodes.Ldstr, marker);
@@ -208,16 +203,11 @@ namespace Coverlet.Core.Instrumentation
 
         private Instruction AddInstrumentationCode(MethodDefinition method, ILProcessor processor, Instruction instruction, BranchPoint branchPoint)
         {
-            int documentIndex = 0;
             if (!_result.Documents.TryGetValue(branchPoint.Document, out var document))
             {
                 document = new Document { Path = branchPoint.Document };
-                documentIndex = _result.Documents.Count;
+                document.Index = _result.Documents.Count;
                 _result.Documents.Add(document.Path, document);
-            }
-            else
-            {
-                documentIndex = _result.Documents.Keys.ToList().IndexOf(document.Path);
             }
 
             var key = (branchPoint.StartLine, (int)branchPoint.Ordinal);
@@ -235,7 +225,7 @@ namespace Coverlet.Core.Instrumentation
                     }
                 );
 
-            string marker = $"B,{documentIndex},{branchPoint.StartLine},{branchPoint.Ordinal}";
+            string marker = $"B,{document.Index},{branchPoint.StartLine},{branchPoint.Ordinal}";
 
             var pathInstr = Instruction.Create(OpCodes.Ldstr, _result.HitsFilePath);
             var markInstr = Instruction.Create(OpCodes.Ldstr, marker);

--- a/src/coverlet.core/Instrumentation/InstrumenterResult.cs
+++ b/src/coverlet.core/Instrumentation/InstrumenterResult.cs
@@ -27,6 +27,7 @@ namespace Coverlet.Core.Instrumentation
         }
 
         public string Path;
+        public int Index;
 
         public Dictionary<int, Line> Lines { get; private set; }
         public Dictionary<(int Line, int Ordinal), Branch> Branches { get; private set; }

--- a/src/coverlet.tracker/CoverageTracker.cs
+++ b/src/coverlet.tracker/CoverageTracker.cs
@@ -8,6 +8,7 @@ namespace Coverlet.Tracker
     public static class CoverageTracker
     {
         private static List<Dictionary<string, Dictionary<string, int>>> _events;
+        private static readonly StringHashSuffixComparer _stringHashSuffixComparer = new StringHashSuffixComparer();
 
         [ThreadStatic]
         private static Dictionary<string, Dictionary<string, int>> t_events;
@@ -25,7 +26,7 @@ namespace Coverlet.Tracker
         {
             if (t_events == null)
             {
-                t_events = new Dictionary<string, Dictionary<string, int>>();
+                t_events = new Dictionary<string, Dictionary<string, int>>(_stringHashSuffixComparer);
                 lock (_events)
                 {
                     _events.Add(t_events);
@@ -38,7 +39,7 @@ namespace Coverlet.Tracker
             {
                 if (!t_events.TryGetValue(file, out var fileEvents))
                 {
-                    fileEvents = new Dictionary<string, int>();
+                    fileEvents = new Dictionary<string, int>(_stringHashSuffixComparer);
                     t_events.Add(file, fileEvents);
                 }
 

--- a/src/coverlet.tracker/StringHashSuffixComparer.cs
+++ b/src/coverlet.tracker/StringHashSuffixComparer.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.Generic;
+
+namespace Coverlet.Tracker
+{
+    internal class StringHashSuffixComparer : IEqualityComparer<string>
+    {
+        public bool Equals(string x, string y) => string.Equals(x, y);
+
+        public int GetHashCode(string s)
+        {
+            if (s == null || s.Length == 0)
+                return 0;
+
+            // Hash calculation based on the old implementation of NameTable used in System.Xml
+            const int SuffixLength = 8;
+            const int Seed = 1031880390;
+            int hashCode;
+            unchecked
+            {
+                hashCode = s.Length + Seed;
+                int i = s.Length > SuffixLength ? s.Length - SuffixLength : 0;
+                for (; i<s.Length; ++i)
+                {
+                    hashCode += (hashCode << 7) ^ s[i];
+                }
+
+                hashCode -= hashCode >> 17;
+                hashCode -= hashCode >> 11;
+                hashCode -= hashCode >> 5;
+            }
+
+            return hashCode;
+        }
+    }
+}


### PR DESCRIPTION
This PR has a set of small set of low risk optimizations. Coverlet can do much better than this PR by using indexes when calling the tracker code instead of relying on strings and dictionaries, however, that is a much more risky change and needs to be carefully tested and validated. I'm putting this PR up so we can ensure that on next release at least these performance gains are in place, hopefully, me or somebody has a chance to go for this more complete optimization.

The performance effects were measured against the test project System.Text.Encodings.Web.Tests in dotnet/corefx repo. This project was selected for optimization because it takes around 6 seconds to run it without instrumentation but was taking almost 300 seconds using coverlet 2.1.1. Recent changes to fix BadImageFormatException brought this down already to ~170 seconds in release 2.2.1. This PR brings it down a bit further to down to ~115 seconds.  

| Version | RunTestsForProject (ms) | % reduction from previous | From 2.1.1 |
| ------- | -----------------------:| -------------------------:| ----------:|
| 2.1.1 | 295,168 | N/A | N/A |
| 2.2.1 | 168,524 | 42.91% | 42.91% |
| This PR | 113,427 | 32.69% | 61.57% |

The main performance gain comes from a custom comparer for the strings used in the code to track execution. Since these strings typically differ only on the end (e.g.: prefix for temp folder of hits file is always the same), using a comparer that generates hashes based only on the final chars of the strings saves considerable amount of work.

Some of the changes affect `InstrumentationTask` and `CoverageResultTask`. However, for the targeted project the times of `InstrumentationTask` (~1,250 msec) and `CoverageResultTask` (less than 200 msec) were too small in relation to the test execution time and as such I didn't focus on improving them, just ensuring no regression on them. The changes regarding these two tasks were expected to have effect only if a large number of source or hit files were being used by the targeted project.
