### PR TITLE
Allow integration testing measurement

### DIFF
--- a/src/coverlet.core/Coverage.cs
+++ b/src/coverlet.core/Coverage.cs
@@ -15,6 +15,7 @@ namespace Coverlet.Core
         private string[] _excludeFilters;
         private string[] _includeFilters;
         private string[] _excludedSourceFiles;
+        private readonly bool _excludeModuleItself;
         private List<InstrumenterResult> _results;
 
         public string Identifier
@@ -22,19 +23,20 @@ namespace Coverlet.Core
             get { return _identifier; }
         }
 
-        public Coverage(string module, string[] excludeFilters, string[] includeFilters, string[] excludedSourceFiles)
+        public Coverage(string module, string[] excludeFilters, string[] includeFilters, string[] excludedSourceFiles, bool excludeModuleItself)
         {
             _module = module;
             _excludeFilters = excludeFilters;
             _includeFilters = includeFilters;
             _excludedSourceFiles = excludedSourceFiles;
+            _excludeModuleItself = excludeModuleItself;
             _identifier = Guid.NewGuid().ToString();
             _results = new List<InstrumenterResult>();
         }
 
         public void PrepareModules()
         {
-            string[] modules = InstrumentationHelper.GetCoverableModules(_module);
+            string[] modules = InstrumentationHelper.GetCoverableModules(_module, _excludeModuleItself);
             string[] excludes =  InstrumentationHelper.GetExcludedFiles(_excludedSourceFiles);
             _excludeFilters = _excludeFilters?.Where(f => InstrumentationHelper.IsValidFilterExpression(f)).ToArray();
             _includeFilters = _includeFilters?.Where(f => InstrumentationHelper.IsValidFilterExpression(f)).ToArray();

--- a/src/coverlet.core/Helpers/InstrumentationHelper.cs
+++ b/src/coverlet.core/Helpers/InstrumentationHelper.cs
@@ -14,10 +14,14 @@ namespace Coverlet.Core.Helpers
 {
     internal static class InstrumentationHelper
     {
-        public static string[] GetCoverableModules(string module)
+        public static string[] GetCoverableModules(string module, bool excludeModuleItself = true)
         {
             IEnumerable<string> modules = Directory.EnumerateFiles(Path.GetDirectoryName(module)).Where(f => f.EndsWith(".exe") || f.EndsWith(".dll"));
-            modules = modules.Where(m => IsAssembly(m) && Path.GetFileName(m) != Path.GetFileName(module));
+            modules = modules.Where(IsAssembly);
+            if (excludeModuleItself)
+            {
+                modules = modules.Where(m => Path.GetFileName(m) != Path.GetFileName(module));
+            }
             return modules.ToArray();
         }
 

--- a/src/coverlet.msbuild.tasks/InstrumentationTask.cs
+++ b/src/coverlet.msbuild.tasks/InstrumentationTask.cs
@@ -51,7 +51,7 @@ namespace Coverlet.MSbuild.Tasks
                 var excludeFilters = _exclude?.Split(',');
                 var includeFilters = _include?.Split(',');
 
-                _coverage = new Coverage(_path, excludeFilters, includeFilters, excludedSourceFiles);
+                _coverage = new Coverage(_path, excludeFilters, includeFilters, excludedSourceFiles, true);
                 _coverage.PrepareModules();
             }
             catch (Exception ex)

--- a/test/coverlet.core.tests/CoverageTests.cs
+++ b/test/coverlet.core.tests/CoverageTests.cs
@@ -27,7 +27,7 @@ namespace Coverlet.Core.Tests
             // Since Coverage only instruments dependancies, we need a fake module here
             var testModule = Path.Combine(directory.FullName, "test.module.dll");
 
-            var coverage = new Coverage(testModule, Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>());
+            var coverage = new Coverage(testModule, Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>(), true);
             coverage.PrepareModules();
 
             var result = coverage.GetCoverageResult();


### PR DESCRIPTION
*This PR is not finished yet, I have one problem*

Overall I would like to allow measurements of integration tests coverage. Tests scenario are written in Postman and checks if API behaves as expected.

I would like to achieve it by running tested assembly first then running target, After finished tests I kill app. Currently tested app crashes because it cannot find coverlet.tracker.dll. Can you help me with fixing this problem?