### PR TITLE
Add total line coverage for badge generators

### DIFF
--- a/src/coverlet.console/Program.cs
+++ b/src/coverlet.console/Program.cs
@@ -85,6 +85,7 @@ namespace Coverlet.Console
                 var exceptionBuilder = new StringBuilder();
                 var coverageTable = new ConsoleTable("Module", "Line", "Branch", "Method");
                 var thresholdFailed = false;
+                var overallLineCoverage = summary.CalculateLineCoverage(result.Modules).Percent * 100;
 
                 foreach (var _module in result.Modules)
                 {
@@ -118,6 +119,8 @@ namespace Coverlet.Console
 
                 logger.LogInformation(string.Empty);
                 logger.LogInformation(coverageTable.ToStringAlternative());
+                logger.LogInformation(string.Empty);
+                logger.LogInformation($"Total {overallLineCoverage}%");
 
                 if (thresholdFailed)
                     throw new Exception(exceptionBuilder.ToString().TrimEnd(Environment.NewLine.ToCharArray()));

--- a/src/coverlet.console/Program.cs
+++ b/src/coverlet.console/Program.cs
@@ -86,6 +86,8 @@ namespace Coverlet.Console
                 var coverageTable = new ConsoleTable("Module", "Line", "Branch", "Method");
                 var thresholdFailed = false;
                 var overallLineCoverage = summary.CalculateLineCoverage(result.Modules).Percent * 100;
+                var overallBranchCoverage = summary.CalculateBranchCoverage(result.Modules).Percent * 100;
+                var overallMethodCoverage = summary.CalculateMethodCoverage(result.Modules).Percent * 100;
 
                 foreach (var _module in result.Modules)
                 {
@@ -120,7 +122,9 @@ namespace Coverlet.Console
                 logger.LogInformation(string.Empty);
                 logger.LogInformation(coverageTable.ToStringAlternative());
                 logger.LogInformation(string.Empty);
-                logger.LogInformation($"Total {overallLineCoverage}%");
+                logger.LogInformation($"Total Line {overallLineCoverage}%");
+                logger.LogInformation($"Total Branch {overallBranchCoverage}%");
+                logger.LogInformation($"Total Method {overallMethodCoverage}%");
 
                 if (thresholdFailed)
                     throw new Exception(exceptionBuilder.ToString().TrimEnd(Environment.NewLine.ToCharArray()));

--- a/src/coverlet.msbuild.tasks/CoverageResultTask.cs
+++ b/src/coverlet.msbuild.tasks/CoverageResultTask.cs
@@ -80,6 +80,8 @@ namespace Coverlet.MSbuild.Tasks
                 var exceptionBuilder = new StringBuilder();
                 var coverageTable = new ConsoleTable("Module", "Line", "Branch", "Method");
                 var overallLineCoverage = summary.CalculateLineCoverage(result.Modules).Percent * 100;
+                var overallBranchCoverage = summary.CalculateBranchCoverage(result.Modules).Percent * 100;
+                var overallMethodCoverage = summary.CalculateMethodCoverage(result.Modules).Percent * 100;
 
                 foreach (var module in result.Modules)
                 {
@@ -114,7 +116,9 @@ namespace Coverlet.MSbuild.Tasks
                 Console.WriteLine();
                 Console.WriteLine(coverageTable.ToStringAlternative());
                 Console.WriteLine();
-                Console.WriteLine($"Total {overallLineCoverage}%");
+                Console.WriteLine($"Total Line {overallLineCoverage}%");
+                Console.WriteLine($"Total Branch {overallBranchCoverage}%");
+                Console.WriteLine($"Total Method {overallMethodCoverage}%");
 
                 if (thresholdFailed)
                     throw new Exception(exceptionBuilder.ToString().TrimEnd(Environment.NewLine.ToCharArray()));

--- a/src/coverlet.msbuild.tasks/CoverageResultTask.cs
+++ b/src/coverlet.msbuild.tasks/CoverageResultTask.cs
@@ -79,6 +79,7 @@ namespace Coverlet.MSbuild.Tasks
                 var summary = new CoverageSummary();
                 var exceptionBuilder = new StringBuilder();
                 var coverageTable = new ConsoleTable("Module", "Line", "Branch", "Method");
+                var overallLineCoverage = summary.CalculateLineCoverage(result.Modules).Percent * 100;
 
                 foreach (var module in result.Modules)
                 {
@@ -112,6 +113,8 @@ namespace Coverlet.MSbuild.Tasks
 
                 Console.WriteLine();
                 Console.WriteLine(coverageTable.ToStringAlternative());
+                Console.WriteLine();
+                Console.WriteLine($"Total {overallLineCoverage}%");
 
                 if (thresholdFailed)
                     throw new Exception(exceptionBuilder.ToString().TrimEnd(Environment.NewLine.ToCharArray()));


### PR DESCRIPTION
Should solve #178 and #148 with regex: 
/Total.*?([0-9]{1,3})(,[0-9]{1,2})?%/