### PR TITLE
Include ObsoleteAttribute in Attributes to exclude fixes #175

### DIFF
--- a/src/coverlet.core/Instrumentation/Instrumenter.cs
+++ b/src/coverlet.core/Instrumentation/Instrumenter.cs
@@ -388,7 +388,9 @@ namespace Coverlet.Core.Instrumentation
                 nameof(ExcludeFromCoverageAttribute),
                 "ExcludeFromCoverage",
                 nameof(ExcludeFromCodeCoverageAttribute),
-                "ExcludeFromCodeCoverage"
+                "ExcludeFromCodeCoverage",
+                nameof(ObsoleteAttribute),
+                "Obsolete"
             };
 
             var attributeName = customAttribute.AttributeType.Name;

--- a/test/coverlet.core.tests/Samples/Samples.cs
+++ b/test/coverlet.core.tests/Samples/Samples.cs
@@ -10,7 +10,7 @@ using Coverlet.Core.Attributes;
 namespace Coverlet.Core.Samples.Tests
 {
     class ConstructorNotDeclaredClass
-    {        
+    {
     }
     class DeclaredConstructorClass
     {
@@ -20,7 +20,7 @@ namespace Coverlet.Core.Samples.Tests
         {
             if (input.Contains("test")) return true;
             return false;
-        }        
+        }
 
         public bool HasTwoDecisions(string input)
         {
@@ -109,7 +109,7 @@ namespace Coverlet.Core.Samples.Tests
             string value;
             try
             {
-                
+
             }
             finally
             {
@@ -161,7 +161,7 @@ namespace Coverlet.Core.Samples.Tests
         {
             yield return "one";
             yield return "two";
-        } 
+        }
     }
 
     [ExcludeFromCoverage]
@@ -184,6 +184,19 @@ namespace Coverlet.Core.Samples.Tests
         public string Method(string input)
         {
             if (string.IsNullOrEmpty(input))
+                throw new ArgumentException("Cannot be empty", nameof(input));
+
+            return input;
+        }
+    }
+
+    [Obsolete]
+    public class ClassExcludedByObsoleteAttr
+    {
+
+        public string Method(string input)
+        {
+            if(string.IsNullOrEmpty(input))
                 throw new ArgumentException("Cannot be empty", nameof(input));
 
             return input;


### PR DESCRIPTION
I can try to add another config property to disable this, but it seems logical to exclude obsolete things from coverage.