### PR TITLE
Merges by fileName (dll's name) instead of the complete path.

### DIFF
--- a/src/coverlet.core/CoverageResult.cs
+++ b/src/coverlet.core/CoverageResult.cs
@@ -44,7 +44,7 @@ namespace Coverlet.Core
         {
             foreach (var module in modules)
             {
-                if (!this.Modules.ContainsKey(module.Key))
+                if (!this.Modules.Keys.Select(Path.GetFileName).Contains(Path.GetFileName(module.Key)))
                 {
                     this.Modules.Add(module.Key, module.Value);
                 }


### PR DESCRIPTION
Merges by fileName (dll's name) instead of the complete path. So the same dlls are merged regardless of which test project references
them, when having multiple test projects.