### PR TITLE
Add System.Private.CoreLib support

### DIFF
--- a/test/coverlet.core.performancetest/PerformanceTest.cs
+++ b/test/coverlet.core.performancetest/PerformanceTest.cs
@@ -14,8 +14,7 @@ namespace coverlet.core.performancetest
     /// </summary>
     public class PerformanceTest
     {
-        [Theory(/*Skip = "Only enabled when explicitly testing performance."*/)]
-        // [InlineData(150)]
+        [Theory]
         [InlineData(20_000)]
         public void TestPerformance(int iterations)
         {

--- a/test/coverlet.core.tests/Instrumentation/InstrumenterTests.cs
+++ b/test/coverlet.core.tests/Instrumentation/InstrumenterTests.cs
@@ -12,6 +12,7 @@ namespace Coverlet.Core.Instrumentation.Tests
         [Fact(Skip = "To be used only validating System.Private.CoreLib instrumentation")]
         public void TestCoreLibInstrumentation()
         {
+            // Attention: to run this test adjust the paths and copy the IL only version of corelib
             const string OriginalFilesDir = @"c:\s\tmp\Coverlet-CoreLib\Original\";
             const string TestFilesDir = @"c:\s\tmp\Coverlet-CoreLib\Test\";
 

--- a/test/coverlet.core.tests/Instrumentation/InstrumenterTests.cs
+++ b/test/coverlet.core.tests/Instrumentation/InstrumenterTests.cs
@@ -9,6 +9,29 @@ namespace Coverlet.Core.Instrumentation.Tests
 {
     public class InstrumenterTests
     {
+        [Fact(Skip = "To be used only validating System.Private.CoreLib instrumentation")]
+        public void TestCoreLibInstrumentation()
+        {
+            const string OriginalFilesDir = @"c:\s\tmp\Coverlet-CoreLib\Original\";
+            const string TestFilesDir = @"c:\s\tmp\Coverlet-CoreLib\Test\";
+
+            Directory.CreateDirectory(TestFilesDir);
+
+            string[] files = new[]
+            {
+                "System.Private.CoreLib.dll",
+                "System.Private.CoreLib.pdb"
+            };
+
+            foreach (var file in files)
+                File.Copy(Path.Combine(OriginalFilesDir, file), Path.Combine(TestFilesDir, file), overwrite: true);
+
+            Instrumenter instrumenter = new Instrumenter(Path.Combine(TestFilesDir, files[0]), "_coverlet_instrumented", Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>());
+            Assert.True(instrumenter.CanInstrument());
+            var result = instrumenter.Instrument();
+            Assert.NotNull(result);
+        }
+
         [Fact]
         public void TestInstrument()
         {

--- a/test/coverlet.core.tests/Instrumentation/ModuleTrackerTemplateTests.cs
+++ b/test/coverlet.core.tests/Instrumentation/ModuleTrackerTemplateTests.cs
@@ -49,7 +49,7 @@ namespace coverlet.core.tests.Instrumentation
         {
             WriteHitsFile(new[] { 1, 2, 3 });
             ModuleTrackerTemplate.HitsArray = new[] { 1 };
-            Assert.Throws<InvalidDataException>(() => ModuleTrackerTemplate.UnloadModule(null, null));
+            Assert.Throws<InvalidOperationException>(() => ModuleTrackerTemplate.UnloadModule(null, null));
         }
 
         [Fact]


### PR DESCRIPTION
This is a special case needed to make coverlet the official code coverage tool on CoreFx repo (see https://github.com/dotnet/corefx/issues/31281).

The change didn't cause any noticeable performance penalty and basically has a custom "metada importer processor" to deal with System.Private.CoreLib.