### PR TITLE
Fix/merge modules

### DIFF
--- a/src/coverlet.core/Coverage.cs
+++ b/src/coverlet.core/Coverage.cs
@@ -145,7 +145,7 @@ namespace Coverlet.Core
                     }
                 }
 
-                modules.Add(result.ModulePath, documents);
+                modules.Add(Path.GetFileName(result.ModulePath), documents);
                 InstrumentationHelper.RestoreOriginalModule(result.ModulePath, _identifier);
             }
 

--- a/src/coverlet.core/CoverageResult.cs
+++ b/src/coverlet.core/CoverageResult.cs
@@ -45,53 +45,52 @@ namespace Coverlet.Core
         {
             foreach (var module in modules)
             {
-                var moduleKey = Path.GetFileName(module.Key ?? throw new InvalidOperationException());
-                if (!this.Modules.Keys.Select(Path.GetFileName).Contains(moduleKey))
+                if (!this.Modules.Keys.Select(Path.GetFileName).Contains(module.Key))
                 {
-                    this.Modules.Add(moduleKey, module.Value);
+                    this.Modules.Add(module.Key, module.Value);
                 }
                 else
                 {
                     foreach (var document in module.Value)
                     {
                         
-                        if (!this.Modules[moduleKey].ContainsKey(document.Key))
+                        if (!this.Modules[module.Key].ContainsKey(document.Key))
                         {
-                            this.Modules[moduleKey].Add(document.Key, document.Value);
+                            this.Modules[module.Key].Add(document.Key, document.Value);
                         }
                         else
                         {
                             foreach (var @class in document.Value)
                             {
-                                if (!this.Modules[moduleKey][document.Key].ContainsKey(@class.Key))
+                                if (!this.Modules[module.Key][document.Key].ContainsKey(@class.Key))
                                 {
-                                    this.Modules[moduleKey][document.Key].Add(@class.Key, @class.Value);
+                                    this.Modules[module.Key][document.Key].Add(@class.Key, @class.Value);
                                 }
                                 else
                                 {
                                     foreach (var method in @class.Value)
                                     {
-                                        if (!this.Modules[moduleKey][document.Key][@class.Key].ContainsKey(method.Key))
+                                        if (!this.Modules[module.Key][document.Key][@class.Key].ContainsKey(method.Key))
                                         {
-                                            this.Modules[moduleKey][document.Key][@class.Key].Add(method.Key, method.Value);
+                                            this.Modules[module.Key][document.Key][@class.Key].Add(method.Key, method.Value);
                                         }
                                         else
                                         {
                                             foreach (var line in method.Value.Lines)
                                             {
-                                                if (!this.Modules[moduleKey][document.Key][@class.Key][method.Key].Lines.ContainsKey(line.Key))
+                                                if (!this.Modules[module.Key][document.Key][@class.Key][method.Key].Lines.ContainsKey(line.Key))
                                                 {
-                                                    this.Modules[moduleKey][document.Key][@class.Key][method.Key].Lines.Add(line.Key, line.Value);
+                                                    this.Modules[module.Key][document.Key][@class.Key][method.Key].Lines.Add(line.Key, line.Value);
                                                 }
                                                 else
                                                 {
-                                                    this.Modules[moduleKey][document.Key][@class.Key][method.Key].Lines[line.Key] += line.Value;
+                                                    this.Modules[module.Key][document.Key][@class.Key][method.Key].Lines[line.Key] += line.Value;
                                                 }
                                             }
 
                                             foreach (var branch in method.Value.Branches)
                                             {
-                                                var branches = this.Modules[moduleKey][document.Key][@class.Key][method.Key].Branches;
+                                                var branches = this.Modules[module.Key][document.Key][@class.Key][method.Key].Branches;
                                                 var branchInfo = branches.FirstOrDefault(b => b.EndOffset == branch.EndOffset && b.Line == branch.Line && b.Offset == branch.Offset && b.Ordinal == branch.Ordinal && b.Path == branch.Path);
                                                 if (branchInfo == null)
                                                     branches.Add(branch);

--- a/src/coverlet.core/CoverageResult.cs
+++ b/src/coverlet.core/CoverageResult.cs
@@ -45,7 +45,7 @@ namespace Coverlet.Core
         {
             foreach (var module in modules)
             {
-                if (!this.Modules.Keys.Select(Path.GetFileName).Contains(module.Key))
+                if (!this.Modules.Keys.Contains(module.Key))
                 {
                     this.Modules.Add(module.Key, module.Value);
                 }
@@ -53,7 +53,6 @@ namespace Coverlet.Core
                 {
                     foreach (var document in module.Value)
                     {
-                        
                         if (!this.Modules[module.Key].ContainsKey(document.Key))
                         {
                             this.Modules[module.Key].Add(document.Key, document.Value);

--- a/src/coverlet.core/CoverageResult.cs
+++ b/src/coverlet.core/CoverageResult.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -44,51 +45,53 @@ namespace Coverlet.Core
         {
             foreach (var module in modules)
             {
-                if (!this.Modules.Keys.Select(Path.GetFileName).Contains(Path.GetFileName(module.Key)))
+                var moduleKey = Path.GetFileName(module.Key ?? throw new InvalidOperationException());
+                if (!this.Modules.Keys.Select(Path.GetFileName).Contains(moduleKey))
                 {
-                    this.Modules.Add(module.Key, module.Value);
+                    this.Modules.Add(moduleKey, module.Value);
                 }
                 else
                 {
                     foreach (var document in module.Value)
                     {
-                        if (!this.Modules[module.Key].ContainsKey(document.Key))
+                        
+                        if (!this.Modules[moduleKey].ContainsKey(document.Key))
                         {
-                            this.Modules[module.Key].Add(document.Key, document.Value);
+                            this.Modules[moduleKey].Add(document.Key, document.Value);
                         }
                         else
                         {
                             foreach (var @class in document.Value)
                             {
-                                if (!this.Modules[module.Key][document.Key].ContainsKey(@class.Key))
+                                if (!this.Modules[moduleKey][document.Key].ContainsKey(@class.Key))
                                 {
-                                    this.Modules[module.Key][document.Key].Add(@class.Key, @class.Value);
+                                    this.Modules[moduleKey][document.Key].Add(@class.Key, @class.Value);
                                 }
                                 else
                                 {
                                     foreach (var method in @class.Value)
                                     {
-                                        if (!this.Modules[module.Key][document.Key][@class.Key].ContainsKey(method.Key))
+                                        if (!this.Modules[moduleKey][document.Key][@class.Key].ContainsKey(method.Key))
                                         {
-                                            this.Modules[module.Key][document.Key][@class.Key].Add(method.Key, method.Value);
+                                            this.Modules[moduleKey][document.Key][@class.Key].Add(method.Key, method.Value);
                                         }
                                         else
                                         {
                                             foreach (var line in method.Value.Lines)
                                             {
-                                                if (!this.Modules[module.Key][document.Key][@class.Key][method.Key].Lines.ContainsKey(line.Key))
+                                                if (!this.Modules[moduleKey][document.Key][@class.Key][method.Key].Lines.ContainsKey(line.Key))
                                                 {
-                                                    this.Modules[module.Key][document.Key][@class.Key][method.Key].Lines.Add(line.Key, line.Value);
+                                                    this.Modules[moduleKey][document.Key][@class.Key][method.Key].Lines.Add(line.Key, line.Value);
                                                 }
                                                 else
                                                 {
-                                                    this.Modules[module.Key][document.Key][@class.Key][method.Key].Lines[line.Key] += line.Value;
+                                                    this.Modules[moduleKey][document.Key][@class.Key][method.Key].Lines[line.Key] += line.Value;
                                                 }
                                             }
 
                                             foreach (var branch in method.Value.Branches)
                                             {
-                                                var branches = this.Modules[module.Key][document.Key][@class.Key][method.Key].Branches;
+                                                var branches = this.Modules[moduleKey][document.Key][@class.Key][method.Key].Branches;
                                                 var branchInfo = branches.FirstOrDefault(b => b.EndOffset == branch.EndOffset && b.Line == branch.Line && b.Offset == branch.Offset && b.Ordinal == branch.Ordinal && b.Path == branch.Path);
                                                 if (branchInfo == null)
                                                     branches.Add(branch);


### PR DESCRIPTION
Fixes Merge #204 !

@tonerdo  So after playing a bit more around with my last change (which is already merged #204) , I realized I made a fuck-up because despite i was comparing by filename, you were already storing the keys for the ```Modules``` dictionary as complete paths in ```Coverage.cs```. 

This caused the comparison I modified in #204 to asume the keys for ```modules``` and ```Modules``` were the same. But i didn't change the values of these keys to be only the file name too, so they still had the complete path on it (and therefore, were different) . 
As it tries to access  the dictionary with the wrong key (asuming they were the same in both ```modules``` and ```Modules```) it crashes. 
If you see the different commits maybe it helps to understand what I was aiming to achieve.

The solution was much simpler. Now I just store the module keys with ```Path.GetFileName``` in ```Coverage.cs```, so they can be correctly matched in ```CoverageResult.cs``` as it was done before my change.

I already tested it locally and worked for me for the example on issue #203 

Hope this is clear enough!

Here's the output. Please merge!

```
Calculating coverage result...
  Generating report '\results\coverage.opencover.xml'

+----------------------+--------+--------+--------+
| Module               | Line   | Branch | Method |
+----------------------+--------+--------+--------+
| Rtl.ProjectName.Api         | 59.4%  | 66.7%  | 66.7%  |
+----------------------+--------+--------+--------+
| Rtl.ProjectName.Application | 100%   | 60%    | 100%   |
+----------------------+--------+--------+--------+
| Rtl.ProjectName.Data        | 24.8%  | 38.5%  | 54.5%  |
+----------------------+--------+--------+--------+

```