### PR TITLE
Merging should not fail if file doesn't exist

### DIFF
--- a/src/coverlet.core/Coverage.cs
+++ b/src/coverlet.core/Coverage.cs
@@ -151,7 +151,7 @@ namespace Coverlet.Core
             }
 
             var coverageResult = new CoverageResult { Identifier = _identifier, Modules = modules };
-            if (!string.IsNullOrEmpty(_mergeWith) && !string.IsNullOrWhiteSpace(_mergeWith))
+            if (!string.IsNullOrEmpty(_mergeWith) && !string.IsNullOrWhiteSpace(_mergeWith) && File.Exists(_mergeWith))
             {
                 string json = File.ReadAllText(_mergeWith);
                 coverageResult.Merge(JsonConvert.DeserializeObject<Modules>(json));


### PR DESCRIPTION
Changed merging behavior: merges the result of the current test coverage with the specified file only if the file exists.