### PR TITLE
Removes the not instrumented/unused instrumenter results so coverage file doesn't get polluted with unused modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Options:
   --include          Filter expressions to include specific modules and types.
   --exclude-by-file  Glob patterns specifying source files to exclude.
   --merge-with       Path to existing coverage result to merge.
+  --exclude-non-called-files	Exclude non called/non instrumented files from coverage.
 ```
 
 #### Code Coverage

--- a/src/coverlet.console/Program.cs
+++ b/src/coverlet.console/Program.cs
@@ -35,6 +35,7 @@ namespace Coverlet.Console
             CommandOption includeFilters = app.Option("--include", "Filter expressions to include only specific modules and types.", CommandOptionType.MultipleValue);
             CommandOption excludedSourceFiles = app.Option("--exclude-by-file", "Glob patterns specifying source files to exclude.", CommandOptionType.MultipleValue);
             CommandOption mergeWith = app.Option("--merge-with", "Path to existing coverage result to merge.", CommandOptionType.SingleValue);
+            CommandOption excludeNonCalledFiles = app.Option("--exclude-non-called-files", "Exclude non called/non instrumented files from coverage report", CommandOptionType.NoValue);
 
             app.OnExecute(() =>
             {
@@ -44,7 +45,7 @@ namespace Coverlet.Console
                 if (!target.HasValue())
                     throw new CommandParsingException(app, "Target must be specified.");
 
-                Coverage coverage = new Coverage(module.Value, excludeFilters.Values.ToArray(), includeFilters.Values.ToArray(), excludedSourceFiles.Values.ToArray(), mergeWith.Value());
+                Coverage coverage = new Coverage(module.Value, excludeFilters.Values.ToArray(), includeFilters.Values.ToArray(), excludedSourceFiles.Values.ToArray(), mergeWith.Value(), excludeNonCalledFiles.HasValue());
                 coverage.PrepareModules();
 
                 Process process = new Process();

--- a/src/coverlet.core/Coverage.cs
+++ b/src/coverlet.core/Coverage.cs
@@ -162,11 +162,14 @@ namespace Coverlet.Core
 
         private void CalculateCoverage()
         {
+            var resultsToRemove = new List<InstrumenterResult>();
             foreach (var result in _results)
             {
                 if (!File.Exists(result.HitsFilePath))
                 {
-                    // File not instrumented, or nothing in it called.  Warn about this?
+                    // File not instrumented, or nothing in it called.
+                    // Mark to be removed so no non used modules are included in coverage file
+                    resultsToRemove.Add(result);
                     continue;
                 }
 
@@ -231,6 +234,11 @@ namespace Coverlet.Core
                 }
 
                 InstrumentationHelper.DeleteHitsFile(result.HitsFilePath);
+            }
+
+            foreach (var resultToRemove in resultsToRemove)
+            {
+                _results.Remove(resultToRemove);
             }
         }
     }

--- a/src/coverlet.msbuild.tasks/InstrumentationTask.cs
+++ b/src/coverlet.msbuild.tasks/InstrumentationTask.cs
@@ -13,6 +13,7 @@ namespace Coverlet.MSbuild.Tasks
         private string _include;
         private string _excludeByFile;
         private string _mergeWith;
+        private bool _excludeNonCalledFiles;
 
         internal static Coverage Coverage
         {
@@ -50,6 +51,12 @@ namespace Coverlet.MSbuild.Tasks
             set { _mergeWith = value; }
         }
 
+        public bool ExcludeNonCalledFiles
+        {
+            get { return _excludeNonCalledFiles; }
+            set { _excludeNonCalledFiles = value;  }
+        }
+
         public override bool Execute()
         {
             try
@@ -57,8 +64,7 @@ namespace Coverlet.MSbuild.Tasks
                 var excludedSourceFiles = _excludeByFile?.Split(',');
                 var excludeFilters = _exclude?.Split(',');
                 var includeFilters = _include?.Split(',');
-
-                _coverage = new Coverage(_path, excludeFilters, includeFilters, excludedSourceFiles, _mergeWith);
+                _coverage = new Coverage(_path, excludeFilters, includeFilters, excludedSourceFiles, _mergeWith, _excludeNonCalledFiles);
                 _coverage.PrepareModules();
             }
             catch (Exception ex)

--- a/src/coverlet.msbuild/coverlet.msbuild.props
+++ b/src/coverlet.msbuild/coverlet.msbuild.props
@@ -9,5 +9,6 @@
     <MergeWith Condition="$(MergeWith) == ''"></MergeWith>
     <Threshold Condition="$(Threshold) == ''">0</Threshold>
     <ThresholdType Condition="$(ThresholdType) == ''">line,branch,method</ThresholdType>
+	<ExcludeNonCalledFiles Condition="$(ExcludeNonCalledFiles) == ''">false</ExcludeNonCalledFiles>
   </PropertyGroup>
 </Project>

--- a/src/coverlet.msbuild/coverlet.msbuild.targets
+++ b/src/coverlet.msbuild/coverlet.msbuild.targets
@@ -10,6 +10,7 @@
       Exclude="$(Exclude)"
       ExcludeByFile="$(ExcludeByFile)"
       MergeWith="$(MergeWith)"
+	  ExcludeNonCalledFiles="$(ExcludeNonCalledFiles)"
       Path="$(TargetPath)" />
   </Target>
 
@@ -20,6 +21,7 @@
       Exclude="$(Exclude)"
       ExcludeByFile="$(ExcludeByFile)"
       MergeWith="$(MergeWith)"
+	  ExcludeNonCalledFiles="$(ExcludeNonCalledFiles)"
       Path="$(TargetPath)" />
   </Target>
 

--- a/test/coverlet.core.tests/CoverageTests.cs
+++ b/test/coverlet.core.tests/CoverageTests.cs
@@ -1,11 +1,6 @@
 using System;
 using System.IO;
-
 using Xunit;
-using Moq;
-
-using Coverlet.Core;
-using System.Collections.Generic;
 
 namespace Coverlet.Core.Tests
 {
@@ -22,9 +17,9 @@ namespace Coverlet.Core.Tests
             File.Copy(module, Path.Combine(directory.FullName, Path.GetFileName(module)), true);
             File.Copy(pdb, Path.Combine(directory.FullName, Path.GetFileName(pdb)), true);
 
-            // TODO: Find a way to mimick hits
+            // TODO: Find a way to mimic hits
 
-            // Since Coverage only instruments dependancies, we need a fake module here
+            // Since Coverage only instruments dependencies, we need a fake module here
             var testModule = Path.Combine(directory.FullName, "test.module.dll");
 
             var coverage = new Coverage(testModule, Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>(), string.Empty);
@@ -32,7 +27,7 @@ namespace Coverlet.Core.Tests
 
             var result = coverage.GetCoverageResult();
 
-            Assert.NotEmpty(result.Modules);
+            Assert.Empty(result.Modules);
 
             directory.Delete(true);
         }

--- a/test/coverlet.core.tests/CoverageTests.cs
+++ b/test/coverlet.core.tests/CoverageTests.cs
@@ -6,8 +6,10 @@ namespace Coverlet.Core.Tests
 {
     public class CoverageTests
     {
-        [Fact]
-        public void TestCoverage()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void TestCoverage(bool excludeNonCalledFilesValue)
         {
             string module = GetType().Assembly.Location;
             string pdb = Path.Combine(Path.GetDirectoryName(module), Path.GetFileNameWithoutExtension(module) + ".pdb");
@@ -22,12 +24,19 @@ namespace Coverlet.Core.Tests
             // Since Coverage only instruments dependencies, we need a fake module here
             var testModule = Path.Combine(directory.FullName, "test.module.dll");
 
-            var coverage = new Coverage(testModule, Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>(), string.Empty);
+            var coverage = new Coverage(testModule, Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>(), string.Empty, excludeNonCalledFilesValue);
             coverage.PrepareModules();
 
             var result = coverage.GetCoverageResult();
 
-            Assert.Empty(result.Modules);
+            if (excludeNonCalledFilesValue)
+            {
+                Assert.Empty(result.Modules);
+            }
+            else
+            {
+                Assert.NotEmpty(result.Modules);
+            }
 
             directory.Delete(true);
         }


### PR DESCRIPTION
@tonerdo for when you have a sec to review :)

Sorry for the easy fix on the test though. I could not quickly think in a more clever way for fixing and testing that.

This addresses #223 in which I describe that sometimes unused instrumented results introduce new branches with hits=0 , polluting the final coverage and making the branch coverage to go down when it's not supposed to.

The actual tests that reference and use that instrumented result don't include such branches, so when the final result is produced using ```MergeWith```, those branches will always remain with hits=0, lowering coverage, which is not correct.

With this change, only actually used instrumented results will be included in the output coverage file. And when using ```MergeWith``` the output will be as expected and described in #223 