### PR TITLE
Cyclomatic complexity computation

### DIFF
--- a/src/coverlet.core/CoverageSummary.cs
+++ b/src/coverlet.core/CoverageSummary.cs
@@ -70,6 +70,46 @@ namespace Coverlet.Core
             return details;
         }
 
+        public int CalculateCyclomaticComplexity(IList<BranchInfo> branches)
+        {
+            return Math.Max(1, branches.Count);
+        }
+
+        public int CalculateCyclomaticComplexity(Methods methods)
+        {
+            return methods.Values.Select(m => CalculateCyclomaticComplexity(m.Branches)).Sum();
+        }
+
+        public int CalculateMaxCyclomaticComplexity(Methods methods)
+        {
+            return methods.Values.Select(m => CalculateCyclomaticComplexity(m.Branches)).DefaultIfEmpty(1).Max();
+        }
+
+        public int CalculateMinCyclomaticComplexity(Methods methods)
+        {
+            return methods.Values.Select(m => CalculateCyclomaticComplexity(m.Branches)).DefaultIfEmpty(1).Min();
+        }
+
+        public int CalculateCyclomaticComplexity(Modules modules)
+        {
+            return modules.Values.Select(CalculateCyclomaticComplexity).Sum();
+        }
+
+        public int CalculateMaxCyclomaticComplexity(Modules modules)
+        {
+            return modules.Values.Select(CalculateCyclomaticComplexity).DefaultIfEmpty(1).Max();
+        }
+
+        public int CalculateMinCyclomaticComplexity(Modules modules)
+        {
+            return modules.Values.Select(CalculateCyclomaticComplexity).DefaultIfEmpty(1).Min();
+        }
+
+        public int CalculateCyclomaticComplexity(Documents documents)
+        {
+            return documents.Values.SelectMany(c => c.Values.Select(CalculateCyclomaticComplexity)).Sum();
+        }
+
         public CoverageDetails CalculateBranchCoverage(Methods methods)
         {
             var details = new CoverageDetails();

--- a/src/coverlet.core/Reporters/CoberturaReporter.cs
+++ b/src/coverlet.core/Reporters/CoberturaReporter.cs
@@ -39,7 +39,7 @@ namespace Coverlet.Core.Reporters
                 package.Add(new XAttribute("name", Path.GetFileNameWithoutExtension(module.Key)));
                 package.Add(new XAttribute("line-rate", summary.CalculateLineCoverage(module.Value).Percent.ToString()));
                 package.Add(new XAttribute("branch-rate", summary.CalculateBranchCoverage(module.Value).Percent.ToString()));
-                package.Add(new XAttribute("complexity", "0"));
+                package.Add(new XAttribute("complexity", summary.CalculateCyclomaticComplexity(module.Value).ToString()));
 
                 XElement classes = new XElement("classes");
                 foreach (var document in module.Value)
@@ -51,7 +51,7 @@ namespace Coverlet.Core.Reporters
                         @class.Add(new XAttribute("filename", GetRelativePathFromBase(basePath, document.Key)));
                         @class.Add(new XAttribute("line-rate", summary.CalculateLineCoverage(cls.Value).Percent.ToString()));
                         @class.Add(new XAttribute("branch-rate", summary.CalculateBranchCoverage(cls.Value).Percent.ToString()));
-                        @class.Add(new XAttribute("complexity", "0"));
+                        @class.Add(new XAttribute("complexity", summary.CalculateCyclomaticComplexity(cls.Value).ToString()));
 
                         XElement classLines = new XElement("lines");
                         XElement methods = new XElement("methods");

--- a/src/coverlet.core/Reporters/OpenCoverReporter.cs
+++ b/src/coverlet.core/Reporters/OpenCoverReporter.cs
@@ -68,10 +68,11 @@ namespace Coverlet.Core.Reporters
 
                             var methLineCoverage = summary.CalculateLineCoverage(meth.Value.Lines);
                             var methBranchCoverage = summary.CalculateBranchCoverage(meth.Value.Branches);
+                            var methCyclomaticComplexity = summary.CalculateCyclomaticComplexity(meth.Value.Branches);
                             
                             XElement method = new XElement("Method");
 
-                            method.Add(new XAttribute("cyclomaticComplexity", "0"));
+                            method.Add(new XAttribute("cyclomaticComplexity", methCyclomaticComplexity.ToString()));
                             method.Add(new XAttribute("nPathComplexity", "0"));
                             method.Add(new XAttribute("sequenceCoverage", methLineCoverage.Percent.ToString()));
                             method.Add(new XAttribute("branchCoverage", methBranchCoverage.Percent.ToString()));
@@ -156,8 +157,8 @@ namespace Coverlet.Core.Reporters
                             methodSummary.Add(new XAttribute("visitedBranchPoints", methBranchCoverage.Covered.ToString()));
                             methodSummary.Add(new XAttribute("sequenceCoverage", methLineCoverage.Percent.ToString()));
                             methodSummary.Add(new XAttribute("branchCoverage", methBranchCoverage.Percent.ToString()));
-                            methodSummary.Add(new XAttribute("maxCyclomaticComplexity", "0"));
-                            methodSummary.Add(new XAttribute("minCyclomaticComplexity", "0"));
+                            methodSummary.Add(new XAttribute("maxCyclomaticComplexity", methCyclomaticComplexity.ToString()));
+                            methodSummary.Add(new XAttribute("minCyclomaticComplexity", methCyclomaticComplexity.ToString()));
                             methodSummary.Add(new XAttribute("visitedClasses", "0"));
                             methodSummary.Add(new XAttribute("numClasses", "0"));
                             methodSummary.Add(new XAttribute("visitedMethods", methodVisited ? "1" : "0"));
@@ -181,6 +182,8 @@ namespace Coverlet.Core.Reporters
                         var classLineCoverage = summary.CalculateLineCoverage(cls.Value);
                         var classBranchCoverage = summary.CalculateBranchCoverage(cls.Value);
                         var classMethodCoverage = summary.CalculateMethodCoverage(cls.Value);
+                        var classMaxCyclomaticComplexity = summary.CalculateMaxCyclomaticComplexity(cls.Value);
+                        var classMinCyclomaticComplexity = summary.CalculateMinCyclomaticComplexity(cls.Value);
 
                         classSummary.Add(new XAttribute("numSequencePoints", classLineCoverage.Total.ToString()));
                         classSummary.Add(new XAttribute("visitedSequencePoints", classLineCoverage.Covered.ToString()));
@@ -188,8 +191,8 @@ namespace Coverlet.Core.Reporters
                         classSummary.Add(new XAttribute("visitedBranchPoints", classBranchCoverage.Covered.ToString()));
                         classSummary.Add(new XAttribute("sequenceCoverage", classLineCoverage.Percent.ToString()));
                         classSummary.Add(new XAttribute("branchCoverage", classBranchCoverage.Percent.ToString()));
-                        classSummary.Add(new XAttribute("maxCyclomaticComplexity", "0"));
-                        classSummary.Add(new XAttribute("minCyclomaticComplexity", "0"));
+                        classSummary.Add(new XAttribute("maxCyclomaticComplexity", classMaxCyclomaticComplexity.ToString()));
+                        classSummary.Add(new XAttribute("minCyclomaticComplexity", classMinCyclomaticComplexity.ToString()));
                         classSummary.Add(new XAttribute("visitedClasses", classVisited ? "1" : "0"));
                         classSummary.Add(new XAttribute("numClasses", "1"));
                         classSummary.Add(new XAttribute("visitedMethods", classMethodCoverage.Covered.ToString()));
@@ -210,6 +213,8 @@ namespace Coverlet.Core.Reporters
 
             var moduleLineCoverage = summary.CalculateLineCoverage(result.Modules);
             var moduleBranchCoverage = summary.CalculateLineCoverage(result.Modules);
+            var moduleMaxCyclomaticComplexity = summary.CalculateMaxCyclomaticComplexity(result.Modules);
+            var moduleMinCyclomaticComplexity = summary.CalculateMinCyclomaticComplexity(result.Modules);
 
             coverageSummary.Add(new XAttribute("numSequencePoints", moduleLineCoverage.Total.ToString()));
             coverageSummary.Add(new XAttribute("visitedSequencePoints", moduleLineCoverage.Covered.ToString()));
@@ -217,8 +222,8 @@ namespace Coverlet.Core.Reporters
             coverageSummary.Add(new XAttribute("visitedBranchPoints", moduleBranchCoverage.Covered.ToString()));
             coverageSummary.Add(new XAttribute("sequenceCoverage", moduleLineCoverage.Percent.ToString()));
             coverageSummary.Add(new XAttribute("branchCoverage", moduleBranchCoverage.Percent.ToString()));
-            coverageSummary.Add(new XAttribute("maxCyclomaticComplexity", "0"));
-            coverageSummary.Add(new XAttribute("minCyclomaticComplexity", "0"));
+            coverageSummary.Add(new XAttribute("maxCyclomaticComplexity", moduleMaxCyclomaticComplexity.ToString()));
+            coverageSummary.Add(new XAttribute("minCyclomaticComplexity", moduleMinCyclomaticComplexity.ToString()));
             coverageSummary.Add(new XAttribute("visitedClasses", visitedClasses.ToString()));
             coverageSummary.Add(new XAttribute("numClasses", numClasses.ToString()));
             coverageSummary.Add(new XAttribute("visitedMethods", visitedMethods.ToString()));


### PR DESCRIPTION
As discussed in #132, this will enable cyclomatic complexity to be computed and emited to Cobertura and OpenCover reports.