### PR TITLE
ExcludeByFile add traversal support when full path specified.

### DIFF
--- a/src/coverlet.core/Helpers/InstrumentationHelper.cs
+++ b/src/coverlet.core/Helpers/InstrumentationHelper.cs
@@ -200,7 +200,7 @@ namespace Coverlet.Core.Helpers
                     {
                         matcherDict.Add(root, new Matcher());
                     }
-                    matcherDict[root].AddInclude(excludeRule.Substring(root.Length));
+                    matcherDict[root].AddInclude(Path.GetFullPath(excludeRule).Substring(root.Length));
                 }
                 else
                 {


### PR DESCRIPTION
Fixes 
`System.ArgumentException: ".." can be only added at the beginning of the pattern.`
when specifying full path with path traversal:
`<ExcludeByFile>$(MSBuildThisFileDirectory)../**/*.Designer.cs</ExcludeByFile>`
