### PR TITLE
Allow relative output path for console runner

### DIFF
--- a/src/coverlet.console/Program.cs
+++ b/src/coverlet.console/Program.cs
@@ -63,8 +63,14 @@ namespace Coverlet.Console
 
                 var result = coverage.GetCoverageResult();
                 var directory = Path.GetDirectoryName(dOutput);
-                if (!Directory.Exists(directory))
+                if (directory == string.Empty)
+                {
+                    directory = Directory.GetCurrentDirectory();
+                }
+                else if (!Directory.Exists(directory))
+                {
                     Directory.CreateDirectory(directory);
+                }
 
                 foreach (var format in (formats.HasValue() ? formats.Values : new List<string>(new string[] { "json" })))
                 {

--- a/src/coverlet.msbuild.tasks/CoverageResultTask.cs
+++ b/src/coverlet.msbuild.tasks/CoverageResultTask.cs
@@ -55,8 +55,14 @@ namespace Coverlet.MSbuild.Tasks
                 var result = coverage.GetCoverageResult();
 
                 var directory = Path.GetDirectoryName(_output);
-                if (!Directory.Exists(directory))
+                if (directory == string.Empty)
+                {
+                    directory = Directory.GetCurrentDirectory();
+                }
+                else if (!Directory.Exists(directory))
+                {
                     Directory.CreateDirectory(directory);
+                }
 
                 var formats = _format.Split(',');
                 foreach (var format in formats)


### PR DESCRIPTION
Allows supplying a relative output parameter without a directory name, i.e. `coverage.xml`. Before you had to either pass in a full or relative path, i.e. `.\coverage.xml`.

cc @tonerdo 