### PR TITLE
Add option for additional assembly probe dirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,19 +56,19 @@ Arguments:
   <ASSEMBLY>  Path to the test assembly.
 
 Options:
-  -h|--help              Show help information
-  -v|--version           Show version information
-  -t|--target            Path to the test runner application.
-  -a|--targetargs        Arguments to be passed to the test runner.
-  -o|--output            Output of the generated coverage report
-  -f|--format            Format of the generated coverage report.
-  --threshold            Exits with error if the coverage % is below value.
-  --threshold-type       Coverage type to apply the threshold to.
-  --exclude              Filter expressions to exclude specific modules and types.
-  --include              Filter expressions to include specific modules and types.
-  --include-directories  Include directories containing additional assemblies to be instrumented.
-  --exclude-by-file      Glob patterns specifying source files to exclude.
-  --merge-with           Path to existing coverage result to merge.
+  -h|--help            Show help information
+  -v|--version         Show version information
+  -t|--target          Path to the test runner application.
+  -a|--targetargs      Arguments to be passed to the test runner.
+  -o|--output          Output of the generated coverage report
+  -f|--format          Format of the generated coverage report.
+  --threshold          Exits with error if the coverage % is below value.
+  --threshold-type     Coverage type to apply the threshold to.
+  --exclude            Filter expressions to exclude specific modules and types.
+  --include            Filter expressions to include specific modules and types.
+  --include-directory  Include directories containing additional assemblies to be instrumented.
+  --exclude-by-file    Glob patterns specifying source files to exclude.
+  --merge-with         Path to existing coverage result to merge.
 ```
 
 #### Code Coverage

--- a/README.md
+++ b/README.md
@@ -56,18 +56,19 @@ Arguments:
   <ASSEMBLY>  Path to the test assembly.
 
 Options:
-  -h|--help          Show help information
-  -v|--version       Show version information
-  -t|--target        Path to the test runner application.
-  -a|--targetargs    Arguments to be passed to the test runner.
-  -o|--output        Output of the generated coverage report
-  -f|--format        Format of the generated coverage report.
-  --threshold        Exits with error if the coverage % is below value.
-  --threshold-type   Coverage type to apply the threshold to.
-  --exclude          Filter expressions to exclude specific modules and types.
-  --include          Filter expressions to include specific modules and types.
-  --exclude-by-file  Glob patterns specifying source files to exclude.
-  --merge-with       Path to existing coverage result to merge.
+  -h|--help              Show help information
+  -v|--version           Show version information
+  -t|--target            Path to the test runner application.
+  -a|--targetargs        Arguments to be passed to the test runner.
+  -o|--output            Output of the generated coverage report
+  -f|--format            Format of the generated coverage report.
+  --threshold            Exits with error if the coverage % is below value.
+  --threshold-type       Coverage type to apply the threshold to.
+  --exclude              Filter expressions to exclude specific modules and types.
+  --include              Filter expressions to include specific modules and types.
+  --include-directories  Include directories containing additional assemblies to be instrumented.
+  --exclude-by-file      Glob patterns specifying source files to exclude.
+  --merge-with           Path to existing coverage result to merge.
 ```
 
 #### Code Coverage

--- a/src/coverlet.console/Program.cs
+++ b/src/coverlet.console/Program.cs
@@ -32,6 +32,7 @@ namespace Coverlet.Console
             CommandOption thresholdTypes = app.Option("--threshold-type", "Coverage type to apply the threshold to.", CommandOptionType.MultipleValue);
             CommandOption excludeFilters = app.Option("--exclude", "Filter expressions to exclude specific modules and types.", CommandOptionType.MultipleValue);
             CommandOption includeFilters = app.Option("--include", "Filter expressions to include only specific modules and types.", CommandOptionType.MultipleValue);
+            CommandOption includeDirectories = app.Option("--include-directories", "Include directories containing additional assemblies to be instrumented.", CommandOptionType.MultipleValue);
             CommandOption excludedSourceFiles = app.Option("--exclude-by-file", "Glob patterns specifying source files to exclude.", CommandOptionType.MultipleValue);
             CommandOption mergeWith = app.Option("--merge-with", "Path to existing coverage result to merge.", CommandOptionType.SingleValue);
 
@@ -43,7 +44,7 @@ namespace Coverlet.Console
                 if (!target.HasValue())
                     throw new CommandParsingException(app, "Target must be specified.");
 
-                Coverage coverage = new Coverage(module.Value, excludeFilters.Values.ToArray(), includeFilters.Values.ToArray(), excludedSourceFiles.Values.ToArray(), mergeWith.Value());
+                Coverage coverage = new Coverage(module.Value, excludeFilters.Values.ToArray(), includeFilters.Values.ToArray(), includeDirectories.Values.ToArray(), excludedSourceFiles.Values.ToArray(), mergeWith.Value());
                 coverage.PrepareModules();
 
                 Process process = new Process();

--- a/src/coverlet.console/Program.cs
+++ b/src/coverlet.console/Program.cs
@@ -32,7 +32,7 @@ namespace Coverlet.Console
             CommandOption thresholdTypes = app.Option("--threshold-type", "Coverage type to apply the threshold to.", CommandOptionType.MultipleValue);
             CommandOption excludeFilters = app.Option("--exclude", "Filter expressions to exclude specific modules and types.", CommandOptionType.MultipleValue);
             CommandOption includeFilters = app.Option("--include", "Filter expressions to include only specific modules and types.", CommandOptionType.MultipleValue);
-            CommandOption includeDirectories = app.Option("--include-directories", "Include directories containing additional assemblies to be instrumented.", CommandOptionType.MultipleValue);
+            CommandOption includeDirectories = app.Option("--include-directory", "Include directories containing additional assemblies to be instrumented.", CommandOptionType.MultipleValue);
             CommandOption excludedSourceFiles = app.Option("--exclude-by-file", "Glob patterns specifying source files to exclude.", CommandOptionType.MultipleValue);
             CommandOption mergeWith = app.Option("--merge-with", "Path to existing coverage result to merge.", CommandOptionType.SingleValue);
 

--- a/src/coverlet.core/Coverage.cs
+++ b/src/coverlet.core/Coverage.cs
@@ -17,6 +17,7 @@ namespace Coverlet.Core
         private string _identifier;
         private string[] _excludeFilters;
         private string[] _includeFilters;
+        private string[] _includeDirectories;
         private string[] _excludedSourceFiles;
         private string _mergeWith;
         private List<InstrumenterResult> _results;
@@ -26,11 +27,13 @@ namespace Coverlet.Core
             get { return _identifier; }
         }
 
-        public Coverage(string module, string[] excludeFilters, string[] includeFilters, string[] excludedSourceFiles, string mergeWith)
+        public Coverage(string module, string[] excludeFilters, string[] includeFilters, string[] includeDirectories, string[] excludedSourceFiles, string mergeWith)
         {
+            Console.WriteLine(module);
             _module = module;
             _excludeFilters = excludeFilters;
             _includeFilters = includeFilters;
+            _includeDirectories = includeDirectories;
             _excludedSourceFiles = excludedSourceFiles;
             _mergeWith = mergeWith;
 
@@ -40,7 +43,7 @@ namespace Coverlet.Core
 
         public void PrepareModules()
         {
-            string[] modules = InstrumentationHelper.GetCoverableModules(_module);
+            string[] modules = InstrumentationHelper.GetCoverableModules(_module, _includeDirectories);
             string[] excludes =  InstrumentationHelper.GetExcludedFiles(_excludedSourceFiles);
             _excludeFilters = _excludeFilters?.Where(f => InstrumentationHelper.IsValidFilterExpression(f)).ToArray();
             _includeFilters = _includeFilters?.Where(f => InstrumentationHelper.IsValidFilterExpression(f)).ToArray();

--- a/src/coverlet.core/Coverage.cs
+++ b/src/coverlet.core/Coverage.cs
@@ -66,8 +66,8 @@ namespace Coverlet.Core
                     }
                     catch (Exception)
                     {
+                        // TODO: With verbose logging we should note that instrumentation failed.
                         InstrumentationHelper.RestoreOriginalModule(module, _identifier);
-                        throw;
                     }
                 }
             }

--- a/src/coverlet.core/Coverage.cs
+++ b/src/coverlet.core/Coverage.cs
@@ -148,7 +148,7 @@ namespace Coverlet.Core
                     }
                 }
 
-                modules.Add(Path.GetFileName(result.ModulePath), documents);
+                modules.Add(result.ModulePath, documents);
                 InstrumentationHelper.RestoreOriginalModule(result.ModulePath, _identifier);
             }
 

--- a/src/coverlet.core/Coverage.cs
+++ b/src/coverlet.core/Coverage.cs
@@ -29,7 +29,6 @@ namespace Coverlet.Core
 
         public Coverage(string module, string[] excludeFilters, string[] includeFilters, string[] includeDirectories, string[] excludedSourceFiles, string mergeWith)
         {
-            Console.WriteLine(module);
             _module = module;
             _excludeFilters = excludeFilters;
             _includeFilters = includeFilters;
@@ -153,8 +152,10 @@ namespace Coverlet.Core
                 InstrumentationHelper.RestoreOriginalModule(result.ModulePath, _identifier);
             }
 
-            var coverageResult = new CoverageResult { Identifier = _identifier, Modules = modules };
-            if (!string.IsNullOrEmpty(_mergeWith) && !string.IsNullOrWhiteSpace(_mergeWith) && File.Exists(_mergeWith))
+            var coverageResult = new CoverageResult { Identifier = _identifier, Modules = new Modules() };
+            coverageResult.Merge(modules);
+
+            if (!string.IsNullOrEmpty(_mergeWith) && !string.IsNullOrWhiteSpace(_mergeWith))
             {
                 string json = File.ReadAllText(_mergeWith);
                 coverageResult.Merge(JsonConvert.DeserializeObject<Modules>(json));

--- a/src/coverlet.core/Coverage.cs
+++ b/src/coverlet.core/Coverage.cs
@@ -155,7 +155,7 @@ namespace Coverlet.Core
             var coverageResult = new CoverageResult { Identifier = _identifier, Modules = new Modules() };
             coverageResult.Merge(modules);
 
-            if (!string.IsNullOrEmpty(_mergeWith) && !string.IsNullOrWhiteSpace(_mergeWith))
+            if (!string.IsNullOrEmpty(_mergeWith) && !string.IsNullOrWhiteSpace(_mergeWith) && File.Exists(_mergeWith))
             {
                 string json = File.ReadAllText(_mergeWith);
                 coverageResult.Merge(JsonConvert.DeserializeObject<Modules>(json));

--- a/src/coverlet.core/CoverageResult.cs
+++ b/src/coverlet.core/CoverageResult.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -45,7 +44,9 @@ namespace Coverlet.Core
         {
             foreach (var module in modules)
             {
-                if (!this.Modules.Keys.Contains(module.Key))
+                var existingKey = Modules.Keys.SingleOrDefault(key => Path.GetFileName(key) == Path.GetFileName(module.Key));
+
+                if (existingKey == null)
                 {
                     this.Modules.Add(module.Key, module.Value);
                 }
@@ -53,43 +54,43 @@ namespace Coverlet.Core
                 {
                     foreach (var document in module.Value)
                     {
-                        if (!this.Modules[module.Key].ContainsKey(document.Key))
+                        if (!this.Modules[existingKey].ContainsKey(document.Key))
                         {
-                            this.Modules[module.Key].Add(document.Key, document.Value);
+                            this.Modules[existingKey].Add(document.Key, document.Value);
                         }
                         else
                         {
                             foreach (var @class in document.Value)
                             {
-                                if (!this.Modules[module.Key][document.Key].ContainsKey(@class.Key))
+                                if (!this.Modules[existingKey][document.Key].ContainsKey(@class.Key))
                                 {
-                                    this.Modules[module.Key][document.Key].Add(@class.Key, @class.Value);
+                                    this.Modules[existingKey][document.Key].Add(@class.Key, @class.Value);
                                 }
                                 else
                                 {
                                     foreach (var method in @class.Value)
                                     {
-                                        if (!this.Modules[module.Key][document.Key][@class.Key].ContainsKey(method.Key))
+                                        if (!this.Modules[existingKey][document.Key][@class.Key].ContainsKey(method.Key))
                                         {
-                                            this.Modules[module.Key][document.Key][@class.Key].Add(method.Key, method.Value);
+                                            this.Modules[existingKey][document.Key][@class.Key].Add(method.Key, method.Value);
                                         }
                                         else
                                         {
                                             foreach (var line in method.Value.Lines)
                                             {
-                                                if (!this.Modules[module.Key][document.Key][@class.Key][method.Key].Lines.ContainsKey(line.Key))
+                                                if (!this.Modules[existingKey][document.Key][@class.Key][method.Key].Lines.ContainsKey(line.Key))
                                                 {
-                                                    this.Modules[module.Key][document.Key][@class.Key][method.Key].Lines.Add(line.Key, line.Value);
+                                                    this.Modules[existingKey][document.Key][@class.Key][method.Key].Lines.Add(line.Key, line.Value);
                                                 }
                                                 else
                                                 {
-                                                    this.Modules[module.Key][document.Key][@class.Key][method.Key].Lines[line.Key] += line.Value;
+                                                    this.Modules[existingKey][document.Key][@class.Key][method.Key].Lines[line.Key] += line.Value;
                                                 }
                                             }
 
                                             foreach (var branch in method.Value.Branches)
                                             {
-                                                var branches = this.Modules[module.Key][document.Key][@class.Key][method.Key].Branches;
+                                                var branches = this.Modules[existingKey][document.Key][@class.Key][method.Key].Branches;
                                                 var branchInfo = branches.FirstOrDefault(b => b.EndOffset == branch.EndOffset && b.Line == branch.Line && b.Offset == branch.Offset && b.Ordinal == branch.Ordinal && b.Path == branch.Path);
                                                 if (branchInfo == null)
                                                     branches.Add(branch);

--- a/src/coverlet.core/CoverageResult.cs
+++ b/src/coverlet.core/CoverageResult.cs
@@ -53,43 +53,43 @@ namespace Coverlet.Core
                 {
                     foreach (var document in module.Value)
                     {
-                        if (!this.Modules[module.Key].ContainsKey(document.Key))
+                        if (!this.Modules[existingKey].ContainsKey(document.Key))
                         {
-                            this.Modules[module.Key].Add(document.Key, document.Value);
+                            this.Modules[existingKey].Add(document.Key, document.Value);
                         }
                         else
                         {
                             foreach (var @class in document.Value)
                             {
-                                if (!this.Modules[module.Key][document.Key].ContainsKey(@class.Key))
+                                if (!this.Modules[existingKey][document.Key].ContainsKey(@class.Key))
                                 {
-                                    this.Modules[module.Key][document.Key].Add(@class.Key, @class.Value);
+                                    this.Modules[existingKey][document.Key].Add(@class.Key, @class.Value);
                                 }
                                 else
                                 {
                                     foreach (var method in @class.Value)
                                     {
-                                        if (!this.Modules[module.Key][document.Key][@class.Key].ContainsKey(method.Key))
+                                        if (!this.Modules[existingKey][document.Key][@class.Key].ContainsKey(method.Key))
                                         {
-                                            this.Modules[module.Key][document.Key][@class.Key].Add(method.Key, method.Value);
+                                            this.Modules[existingKey][document.Key][@class.Key].Add(method.Key, method.Value);
                                         }
                                         else
                                         {
                                             foreach (var line in method.Value.Lines)
                                             {
-                                                if (!this.Modules[module.Key][document.Key][@class.Key][method.Key].Lines.ContainsKey(line.Key))
+                                                if (!this.Modules[existingKey][document.Key][@class.Key][method.Key].Lines.ContainsKey(line.Key))
                                                 {
-                                                    this.Modules[module.Key][document.Key][@class.Key][method.Key].Lines.Add(line.Key, line.Value);
+                                                    this.Modules[existingKey][document.Key][@class.Key][method.Key].Lines.Add(line.Key, line.Value);
                                                 }
                                                 else
                                                 {
-                                                    this.Modules[module.Key][document.Key][@class.Key][method.Key].Lines[line.Key] += line.Value;
+                                                    this.Modules[existingKey][document.Key][@class.Key][method.Key].Lines[line.Key] += line.Value;
                                                 }
                                             }
 
                                             foreach (var branch in method.Value.Branches)
                                             {
-                                                var branches = this.Modules[module.Key][document.Key][@class.Key][method.Key].Branches;
+                                                var branches = this.Modules[existingKey][document.Key][@class.Key][method.Key].Branches;
                                                 var branchInfo = branches.FirstOrDefault(b => b.EndOffset == branch.EndOffset && b.Line == branch.Line && b.Offset == branch.Offset && b.Ordinal == branch.Ordinal && b.Path == branch.Path);
                                                 if (branchInfo == null)
                                                     branches.Add(branch);

--- a/src/coverlet.core/CoverageResult.cs
+++ b/src/coverlet.core/CoverageResult.cs
@@ -53,43 +53,43 @@ namespace Coverlet.Core
                 {
                     foreach (var document in module.Value)
                     {
-                        if (!this.Modules[existingKey].ContainsKey(document.Key))
+                        if (!this.Modules[module.Key].ContainsKey(document.Key))
                         {
-                            this.Modules[existingKey].Add(document.Key, document.Value);
+                            this.Modules[module.Key].Add(document.Key, document.Value);
                         }
                         else
                         {
                             foreach (var @class in document.Value)
                             {
-                                if (!this.Modules[existingKey][document.Key].ContainsKey(@class.Key))
+                                if (!this.Modules[module.Key][document.Key].ContainsKey(@class.Key))
                                 {
-                                    this.Modules[existingKey][document.Key].Add(@class.Key, @class.Value);
+                                    this.Modules[module.Key][document.Key].Add(@class.Key, @class.Value);
                                 }
                                 else
                                 {
                                     foreach (var method in @class.Value)
                                     {
-                                        if (!this.Modules[existingKey][document.Key][@class.Key].ContainsKey(method.Key))
+                                        if (!this.Modules[module.Key][document.Key][@class.Key].ContainsKey(method.Key))
                                         {
-                                            this.Modules[existingKey][document.Key][@class.Key].Add(method.Key, method.Value);
+                                            this.Modules[module.Key][document.Key][@class.Key].Add(method.Key, method.Value);
                                         }
                                         else
                                         {
                                             foreach (var line in method.Value.Lines)
                                             {
-                                                if (!this.Modules[existingKey][document.Key][@class.Key][method.Key].Lines.ContainsKey(line.Key))
+                                                if (!this.Modules[module.Key][document.Key][@class.Key][method.Key].Lines.ContainsKey(line.Key))
                                                 {
-                                                    this.Modules[existingKey][document.Key][@class.Key][method.Key].Lines.Add(line.Key, line.Value);
+                                                    this.Modules[module.Key][document.Key][@class.Key][method.Key].Lines.Add(line.Key, line.Value);
                                                 }
                                                 else
                                                 {
-                                                    this.Modules[existingKey][document.Key][@class.Key][method.Key].Lines[line.Key] += line.Value;
+                                                    this.Modules[module.Key][document.Key][@class.Key][method.Key].Lines[line.Key] += line.Value;
                                                 }
                                             }
 
                                             foreach (var branch in method.Value.Branches)
                                             {
-                                                var branches = this.Modules[existingKey][document.Key][@class.Key][method.Key].Branches;
+                                                var branches = this.Modules[module.Key][document.Key][@class.Key][method.Key].Branches;
                                                 var branchInfo = branches.FirstOrDefault(b => b.EndOffset == branch.EndOffset && b.Line == branch.Line && b.Offset == branch.Offset && b.Ordinal == branch.Ordinal && b.Path == branch.Path);
                                                 if (branchInfo == null)
                                                     branches.Add(branch);

--- a/src/coverlet.core/CoverageResult.cs
+++ b/src/coverlet.core/CoverageResult.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -44,9 +45,7 @@ namespace Coverlet.Core
         {
             foreach (var module in modules)
             {
-                var existingKey = Modules.Keys.SingleOrDefault(key => Path.GetFileName(key) == Path.GetFileName(module.Key));
-
-                if (existingKey == null)
+                if (!this.Modules.Keys.Contains(module.Key))
                 {
                     this.Modules.Add(module.Key, module.Value);
                 }
@@ -54,43 +53,43 @@ namespace Coverlet.Core
                 {
                     foreach (var document in module.Value)
                     {
-                        if (!this.Modules[existingKey].ContainsKey(document.Key))
+                        if (!this.Modules[module.Key].ContainsKey(document.Key))
                         {
-                            this.Modules[existingKey].Add(document.Key, document.Value);
+                            this.Modules[module.Key].Add(document.Key, document.Value);
                         }
                         else
                         {
                             foreach (var @class in document.Value)
                             {
-                                if (!this.Modules[existingKey][document.Key].ContainsKey(@class.Key))
+                                if (!this.Modules[module.Key][document.Key].ContainsKey(@class.Key))
                                 {
-                                    this.Modules[existingKey][document.Key].Add(@class.Key, @class.Value);
+                                    this.Modules[module.Key][document.Key].Add(@class.Key, @class.Value);
                                 }
                                 else
                                 {
                                     foreach (var method in @class.Value)
                                     {
-                                        if (!this.Modules[existingKey][document.Key][@class.Key].ContainsKey(method.Key))
+                                        if (!this.Modules[module.Key][document.Key][@class.Key].ContainsKey(method.Key))
                                         {
-                                            this.Modules[existingKey][document.Key][@class.Key].Add(method.Key, method.Value);
+                                            this.Modules[module.Key][document.Key][@class.Key].Add(method.Key, method.Value);
                                         }
                                         else
                                         {
                                             foreach (var line in method.Value.Lines)
                                             {
-                                                if (!this.Modules[existingKey][document.Key][@class.Key][method.Key].Lines.ContainsKey(line.Key))
+                                                if (!this.Modules[module.Key][document.Key][@class.Key][method.Key].Lines.ContainsKey(line.Key))
                                                 {
-                                                    this.Modules[existingKey][document.Key][@class.Key][method.Key].Lines.Add(line.Key, line.Value);
+                                                    this.Modules[module.Key][document.Key][@class.Key][method.Key].Lines.Add(line.Key, line.Value);
                                                 }
                                                 else
                                                 {
-                                                    this.Modules[existingKey][document.Key][@class.Key][method.Key].Lines[line.Key] += line.Value;
+                                                    this.Modules[module.Key][document.Key][@class.Key][method.Key].Lines[line.Key] += line.Value;
                                                 }
                                             }
 
                                             foreach (var branch in method.Value.Branches)
                                             {
-                                                var branches = this.Modules[existingKey][document.Key][@class.Key][method.Key].Branches;
+                                                var branches = this.Modules[module.Key][document.Key][@class.Key][method.Key].Branches;
                                                 var branchInfo = branches.FirstOrDefault(b => b.EndOffset == branch.EndOffset && b.Line == branch.Line && b.Offset == branch.Offset && b.Ordinal == branch.Ordinal && b.Path == branch.Path);
                                                 if (branchInfo == null)
                                                     branches.Add(branch);

--- a/src/coverlet.core/Helpers/InstrumentationHelper.cs
+++ b/src/coverlet.core/Helpers/InstrumentationHelper.cs
@@ -264,8 +264,7 @@ namespace Coverlet.Core.Helpers
                     ? Path.GetFullPath(Path.Combine(moduleDirectory, includeDirectory))
                     : includeDirectory).TrimEnd('*');
 
-                if (!Directory.Exists(fullPath))
-                    throw new DirectoryNotFoundException($"The included directory '{fullPath}' does not exist.");
+                if (!Directory.Exists(fullPath)) continue;
 
                 if (includeDirectory.EndsWith("*", StringComparison.Ordinal))
                     result.AddRange(Directory.GetDirectories(fullPath));

--- a/src/coverlet.core/Helpers/InstrumentationHelper.cs
+++ b/src/coverlet.core/Helpers/InstrumentationHelper.cs
@@ -78,11 +78,10 @@ namespace Coverlet.Core.Helpers
             }
         }
 
-        public static string BackupOriginalModule(string module, string identifier)
+        public static void BackupOriginalModule(string module, string identifier)
         {
             var backupPath = GetBackupPath(module, identifier);
-            File.Copy(module, backupPath);
-            return backupPath;
+            File.Copy(module, backupPath, true);
         }
 
         public static void RestoreOriginalModule(string module, string identifier)

--- a/src/coverlet.msbuild.tasks/InstrumentationTask.cs
+++ b/src/coverlet.msbuild.tasks/InstrumentationTask.cs
@@ -11,6 +11,7 @@ namespace Coverlet.MSbuild.Tasks
         private string _path;
         private string _exclude;
         private string _include;
+        private string _includeDirectories;
         private string _excludeByFile;
         private string _mergeWith;
 
@@ -38,6 +39,12 @@ namespace Coverlet.MSbuild.Tasks
             set { _include = value; }
         }
 
+        public string IncludeDirectories
+        {
+            get { return _includeDirectories; }
+            set { _includeDirectories = value; }
+        }
+
         public string ExcludeByFile
         {
             get { return _excludeByFile; }
@@ -57,8 +64,9 @@ namespace Coverlet.MSbuild.Tasks
                 var excludedSourceFiles = _excludeByFile?.Split(',');
                 var excludeFilters = _exclude?.Split(',');
                 var includeFilters = _include?.Split(',');
+                var includeDirectories = _includeDirectories?.Split(',');
 
-                _coverage = new Coverage(_path, excludeFilters, includeFilters, excludedSourceFiles, _mergeWith);
+                _coverage = new Coverage(_path, excludeFilters, includeFilters, includeDirectories, excludedSourceFiles, _mergeWith);
                 _coverage.PrepareModules();
             }
             catch (Exception ex)

--- a/src/coverlet.msbuild.tasks/InstrumentationTask.cs
+++ b/src/coverlet.msbuild.tasks/InstrumentationTask.cs
@@ -11,7 +11,7 @@ namespace Coverlet.MSbuild.Tasks
         private string _path;
         private string _exclude;
         private string _include;
-        private string _includeDirectories;
+        private string _includeDirectory;
         private string _excludeByFile;
         private string _mergeWith;
 
@@ -39,10 +39,10 @@ namespace Coverlet.MSbuild.Tasks
             set { _include = value; }
         }
 
-        public string IncludeDirectories
+        public string IncludeDirectory
         {
-            get { return _includeDirectories; }
-            set { _includeDirectories = value; }
+            get { return _includeDirectory; }
+            set { _includeDirectory = value; }
         }
 
         public string ExcludeByFile
@@ -64,7 +64,7 @@ namespace Coverlet.MSbuild.Tasks
                 var excludedSourceFiles = _excludeByFile?.Split(',');
                 var excludeFilters = _exclude?.Split(',');
                 var includeFilters = _include?.Split(',');
-                var includeDirectories = _includeDirectories?.Split(',');
+                var includeDirectories = _includeDirectory?.Split(',');
 
                 _coverage = new Coverage(_path, excludeFilters, includeFilters, includeDirectories, excludedSourceFiles, _mergeWith);
                 _coverage.PrepareModules();

--- a/src/coverlet.msbuild/coverlet.msbuild.props
+++ b/src/coverlet.msbuild/coverlet.msbuild.props
@@ -9,5 +9,6 @@
     <MergeWith Condition="$(MergeWith) == ''"></MergeWith>
     <Threshold Condition="$(Threshold) == ''">0</Threshold>
     <ThresholdType Condition="$(ThresholdType) == ''">line,branch,method</ThresholdType>
+    <IncludeDirectories Condition="$(IncludeDirectories) == ''"></IncludeDirectories>
   </PropertyGroup>
 </Project>

--- a/src/coverlet.msbuild/coverlet.msbuild.props
+++ b/src/coverlet.msbuild/coverlet.msbuild.props
@@ -9,6 +9,6 @@
     <MergeWith Condition="$(MergeWith) == ''"></MergeWith>
     <Threshold Condition="$(Threshold) == ''">0</Threshold>
     <ThresholdType Condition="$(ThresholdType) == ''">line,branch,method</ThresholdType>
-    <IncludeDirectories Condition="$(IncludeDirectories) == ''"></IncludeDirectories>
+    <IncludeDirectory Condition="$(IncludeDirectory) == ''"></IncludeDirectory>
   </PropertyGroup>
 </Project>

--- a/src/coverlet.msbuild/coverlet.msbuild.targets
+++ b/src/coverlet.msbuild/coverlet.msbuild.targets
@@ -7,7 +7,7 @@
     <Coverlet.MSbuild.Tasks.InstrumentationTask
       Condition="'$(VSTestNoBuild)' == 'true' and $(CollectCoverage) == 'true'"
       Include="$(Include)"
-      IncludeDirectories="$(IncludeDirectories)"
+      IncludeDirectory="$(IncludeDirectory)"
       Exclude="$(Exclude)"
       ExcludeByFile="$(ExcludeByFile)"
       MergeWith="$(MergeWith)"
@@ -18,7 +18,7 @@
     <Coverlet.MSbuild.Tasks.InstrumentationTask
       Condition="'$(VSTestNoBuild)' != 'true' and $(CollectCoverage) == 'true'"
       Include="$(Include)"
-      IncludeDirectories="$(IncludeDirectories)"
+      IncludeDirectory="$(IncludeDirectory)"
       Exclude="$(Exclude)"
       ExcludeByFile="$(ExcludeByFile)"
       MergeWith="$(MergeWith)"

--- a/src/coverlet.msbuild/coverlet.msbuild.targets
+++ b/src/coverlet.msbuild/coverlet.msbuild.targets
@@ -7,6 +7,7 @@
     <Coverlet.MSbuild.Tasks.InstrumentationTask
       Condition="'$(VSTestNoBuild)' == 'true' and $(CollectCoverage) == 'true'"
       Include="$(Include)"
+      IncludeDirectories="$(IncludeDirectories)"
       Exclude="$(Exclude)"
       ExcludeByFile="$(ExcludeByFile)"
       MergeWith="$(MergeWith)"
@@ -17,6 +18,7 @@
     <Coverlet.MSbuild.Tasks.InstrumentationTask
       Condition="'$(VSTestNoBuild)' != 'true' and $(CollectCoverage) == 'true'"
       Include="$(Include)"
+      IncludeDirectories="$(IncludeDirectories)"
       Exclude="$(Exclude)"
       ExcludeByFile="$(ExcludeByFile)"
       MergeWith="$(MergeWith)"

--- a/test/coverlet.core.tests/CoverageTests.cs
+++ b/test/coverlet.core.tests/CoverageTests.cs
@@ -27,7 +27,7 @@ namespace Coverlet.Core.Tests
             // Since Coverage only instruments dependancies, we need a fake module here
             var testModule = Path.Combine(directory.FullName, "test.module.dll");
 
-            var coverage = new Coverage(testModule, Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>(), string.Empty);
+            var coverage = new Coverage(testModule, Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>(), string.Empty);
             coverage.PrepareModules();
 
             var result = coverage.GetCoverageResult();

--- a/test/coverlet.core.tests/Helpers/InstrumentationHelperTests.cs
+++ b/test/coverlet.core.tests/Helpers/InstrumentationHelperTests.cs
@@ -28,7 +28,12 @@ namespace Coverlet.Core.Helpers.Tests
             string module = typeof(InstrumentationHelperTests).Assembly.Location;
             string identifier = Guid.NewGuid().ToString();
 
-            var backupPath = InstrumentationHelper.BackupOriginalModule(module, identifier);
+            InstrumentationHelper.BackupOriginalModule(module, identifier);
+
+            var backupPath = Path.Combine(
+                Path.GetTempPath(),
+                Path.GetFileNameWithoutExtension(module) + "_" + identifier + ".dll"
+            );
 
             Assert.True(File.Exists(backupPath));
         }

--- a/test/coverlet.core.tests/Helpers/InstrumentationHelperTests.cs
+++ b/test/coverlet.core.tests/Helpers/InstrumentationHelperTests.cs
@@ -12,7 +12,7 @@ namespace Coverlet.Core.Helpers.Tests
         public void TestGetDependencies()
         {
             string module = typeof(InstrumentationHelperTests).Assembly.Location;
-            var modules = InstrumentationHelper.GetCoverableModules(module, null);
+            var modules = InstrumentationHelper.GetCoverableModules(module, Array.Empty<string>());
             Assert.False(Array.Exists(modules, m => m == module));
         }
 

--- a/test/coverlet.core.tests/Helpers/InstrumentationHelperTests.cs
+++ b/test/coverlet.core.tests/Helpers/InstrumentationHelperTests.cs
@@ -226,14 +226,6 @@ namespace Coverlet.Core.Helpers.Tests
         }
 
         [Fact]
-        public void TestIncludeDirectoryInvalidThrowsDirectoryNotFoundException()
-        {
-            string module = typeof(InstrumentationHelperTests).Assembly.Location;
-            Assert.Throws<DirectoryNotFoundException>(() =>
-                InstrumentationHelper.GetCoverableModules(module, new[] {"Foobar"}));
-        }
-
-        [Fact]
         public void TestIncludeDirectories()
         {
             string module = typeof(InstrumentationHelperTests).Assembly.Location;


### PR DESCRIPTION
Adds an optional argument to probe for additional assemblies at a different location than the test assembly's directory. This is needed for corefx but should also be useful for advanced scenarios in regular .NET apps.

cc @tonerdo