### PR TITLE
#254 Fix TeamCity reporter decimal separator (i18n)

### DIFF
--- a/src/coverlet.core/Reporters/TeamCityReporter.cs
+++ b/src/coverlet.core/Reporters/TeamCityReporter.cs
@@ -1,4 +1,5 @@
-﻿using Coverlet.Core;
+﻿using System.Globalization;
+using Coverlet.Core;
 using Coverlet.Core.Reporters;
 using System.Text;
 
@@ -66,9 +67,9 @@ namespace coverlet.core.Reporters
             OutputTeamCityServiceMessage("CodeCoverageAbsMTotal", coverageDetails.Total, builder);
         }
 
-        private void OutputTeamCityServiceMessage(string key, object value, StringBuilder builder)
+        private void OutputTeamCityServiceMessage(string key, double value, StringBuilder builder)
         {
-            builder.AppendLine($"##teamcity[buildStatisticValue key='{key}' value='{value}']");
+            builder.AppendLine($"##teamcity[buildStatisticValue key='{key}' value='{value.ToString("0.##", new CultureInfo("en-US"))}']");
         }
     }
 }

--- a/test/coverlet.core.tests/Reporters/TeamCityReporter.cs
+++ b/test/coverlet.core.tests/Reporters/TeamCityReporter.cs
@@ -4,119 +4,128 @@ using Xunit;
 
 namespace Coverlet.Core.Reporters.Tests
 {
-    public class TestCreateReporterTests
-    {
-        private readonly CoverageResult _result;
-        private readonly TeamCityReporter _reporter;
+	public class TestCreateReporterTests
+	{
+		private readonly CoverageResult _result;
+		private readonly TeamCityReporter _reporter;
 
-        public TestCreateReporterTests()
-        {
-            _reporter = new TeamCityReporter();
-            _result = new CoverageResult();
-            _result.Identifier = Guid.NewGuid().ToString();
+		public TestCreateReporterTests()
+		{
+			_reporter = new TeamCityReporter();
+			_result = new CoverageResult();
+			_result.Identifier = Guid.NewGuid().ToString();
 
-            var lines = new Lines { { 1, 1 }, { 2, 0 } };
+			var lines = new Lines { { 1, 1 }, { 2, 0 } };
 
-            var branches = new Branches
-            {
-                new BranchInfo
-                {
-                    Line = 1,
-                    Hits = 1,
-                    Offset = 23,
-                    EndOffset = 24,
-                    Path = 0,
-                    Ordinal = 1
-                },
-                new BranchInfo
-                {
-                    Line = 1,
-                    Hits = 0,
-                    Offset = 23,
-                    EndOffset = 27,
-                    Path = 1,
-                    Ordinal = 2
-                }
-            };
+			var branches = new Branches
+			{
+				new BranchInfo
+				{
+					Line = 1,
+					Hits = 1,
+					Offset = 23,
+					EndOffset = 24,
+					Path = 0,
+					Ordinal = 1
+				},
+				new BranchInfo
+				{
+					Line = 1,
+					Hits = 0,
+					Offset = 23,
+					EndOffset = 27,
+					Path = 1,
+					Ordinal = 2
+				},
+				new BranchInfo
+				{
+					Line = 1,
+					Hits = 0,
+					Offset = 23,
+					EndOffset = 27,
+					Path = 1,
+					Ordinal = 2
+				}
+			};
 
-            var methods = new Methods();
-            var methodString = "System.Void Coverlet.Core.Reporters.Tests.CoberturaReporterTests::TestReport()";
-            methods.Add(methodString, new Method());
-            methods[methodString].Lines = lines;
-            methods[methodString].Branches = branches;
+			var methods = new Methods();
+			var methodString = "System.Void Coverlet.Core.Reporters.Tests.CoberturaReporterTests::TestReport()";
+			methods.Add(methodString, new Method());
+			methods[methodString].Lines = lines;
+			methods[methodString].Branches = branches;
 
-            var classes = new Classes { { "Coverlet.Core.Reporters.Tests.CoberturaReporterTests", methods } };
+			var classes = new Classes { { "Coverlet.Core.Reporters.Tests.CoberturaReporterTests", methods } };
 
-            var documents = new Documents { { "doc.cs", classes } };
+			var documents = new Documents { { "doc.cs", classes } };
 
-            _result.Modules = new Modules { { "module", documents } };
-        }
+			_result.Modules = new Modules { { "module", documents } };
+		}
 
-        [Fact]
-        public void OutputType_IsConsoleOutputType()
-        {
-            // Assert
-            Assert.Equal(ReporterOutputType.Console, _reporter.OutputType);
-        }
+		[Fact]
+		public void OutputType_IsConsoleOutputType()
+		{
+			// Assert
+			Assert.Equal(ReporterOutputType.Console, _reporter.OutputType);
+		}
 
-        [Fact]
-        public void Format_IsExpectedValue()
-        {
-            // Assert
-            Assert.Equal("teamcity", _reporter.Format);
-        }
+		[Fact]
+		public void Format_IsExpectedValue()
+		{
+			// Assert
+			Assert.Equal("teamcity", _reporter.Format);
+		}
 
-        [Fact]
-        public void Format_IsNull()
-        {
-            // Assert
-            Assert.Null(_reporter.Extension);
-        }
+		[Fact]
+		public void Format_IsNull()
+		{
+			// Assert
+			Assert.Null(_reporter.Extension);
+		}
 
-        [Fact]
-        public void Report_ReturnsNonNullString()
-        {
-            // Act
-            var output = _reporter.Report(_result);
+		[Fact]
+		public void Report_ReturnsNonNullString()
+		{
+			// Act
+			var output = _reporter.Report(_result);
 
-            // Assert
-            Assert.False(string.IsNullOrWhiteSpace(output), "Output is not null or whitespace");
-        }
+			// Assert
+			Assert.False(string.IsNullOrWhiteSpace(output), "Output is not null or whitespace");
+		}
 
-        [Fact]
-        public void Report_ReportsLineCoverage()
-        {
-            // Act
-            var output = _reporter.Report(_result);
+		[Fact]
+		public void Report_ReportsLineCoverage()
+		{
+			// Act
+			var output = _reporter.Report(_result);
 
-            // Assert
-            Assert.Contains("##teamcity[buildStatisticValue key='CodeCoverageL' value='50']", output);
-            Assert.Contains("##teamcity[buildStatisticValue key='CodeCoverageAbsLCovered' value='1']", output);
-            Assert.Contains("##teamcity[buildStatisticValue key='CodeCoverageAbsLTotal' value='2']", output);
-        }
+			// Assert
+			Assert.Contains("##teamcity[buildStatisticValue key='CodeCoverageL' value='50']", output);
+			Assert.Contains("##teamcity[buildStatisticValue key='CodeCoverageAbsLCovered' value='1']", output);
+			Assert.Contains("##teamcity[buildStatisticValue key='CodeCoverageAbsLTotal' value='2']", output);
+		}
 
-        [Fact]
-        public void Report_ReportsBranchCoverage()
-        {
-            // Act
-            var output = _reporter.Report(_result);
+		[Fact]
+		public void Report_ReportsBranchCoverage()
+		{
+			// Act
+			var output = _reporter.Report(_result);
 
-            // Assert
-            Assert.Contains("##teamcity[buildStatisticValue key='CodeCoverageR' value='50']", output);
-            Assert.Contains("##teamcity[buildStatisticValue key='CodeCoverageAbsRCovered' value='1']", output);
-            Assert.Contains("##teamcity[buildStatisticValue key='CodeCoverageAbsRTotal' value='2']", output);
-        }
+			// Assert
+			Assert.Contains("##teamcity[buildStatisticValue key='CodeCoverageR' value='33.3']", output);
+			Assert.Contains("##teamcity[buildStatisticValue key='CodeCoverageAbsRCovered' value='1']", output);
+			Assert.Contains("##teamcity[buildStatisticValue key='CodeCoverageAbsRTotal' value='3']", output);
+		}
 
-        [Fact]
-        public void Report_ReportsMethodCoverage()
-        {
-            // Act
-            var output = _reporter.Report(_result);
+		[Fact]
+		public void Report_ReportsMethodCoverage()
+		{
+			// Act
+			var output = _reporter.Report(_result);
 
-            // Assert
-            Assert.Contains("##teamcity[buildStatisticValue key='CodeCoverageM' value='100']", output);
-            Assert.Contains("##teamcity[buildStatisticValue key='CodeCoverageAbsMCovered' value='1']", output);
-            Assert.Contains("##teamcity[buildStatisticValue key='CodeCoverageAbsMTotal' value='1']", output);
-        }
-    }
+			// Assert
+			Assert.Contains("##teamcity[buildStatisticValue key='CodeCoverageM' value='100']", output);
+			Assert.Contains("##teamcity[buildStatisticValue key='CodeCoverageAbsMCovered' value='1']", output);
+			Assert.Contains("##teamcity[buildStatisticValue key='CodeCoverageAbsMTotal' value='1']", output);
+		}
+	}
 }


### PR DESCRIPTION
TeamCity will error out if the output value is not using period as decimal separator, so this fix will make sure to always use period as decimal separator when reporting to TeamCity