### PR TITLE
Add support for Sourcelink

### DIFF
--- a/src/coverlet.console/Program.cs
+++ b/src/coverlet.console/Program.cs
@@ -36,6 +36,7 @@ namespace Coverlet.Console
             CommandOption includeDirectories = app.Option("--include-directory", "Include directories containing additional assemblies to be instrumented.", CommandOptionType.MultipleValue);
             CommandOption excludeAttributes = app.Option("--exclude-by-attribute", "Attributes to exclude from code coverage.", CommandOptionType.MultipleValue);
             CommandOption mergeWith = app.Option("--merge-with", "Path to existing coverage result to merge.", CommandOptionType.SingleValue);
+            CommandOption useSourceLink = app.Option("--use-source-link", "Specifies whether to use SourceLink URIs in place of file system paths.", CommandOptionType.NoValue);
 
             app.OnExecute(() =>
             {
@@ -45,7 +46,7 @@ namespace Coverlet.Console
                 if (!target.HasValue())
                     throw new CommandParsingException(app, "Target must be specified.");
 
-                Coverage coverage = new Coverage(module.Value, includeFilters.Values.ToArray(), includeDirectories.Values.ToArray(), excludeFilters.Values.ToArray(), excludedSourceFiles.Values.ToArray(), excludeAttributes.Values.ToArray(), mergeWith.Value());
+                Coverage coverage = new Coverage(module.Value, includeFilters.Values.ToArray(), includeDirectories.Values.ToArray(), excludeFilters.Values.ToArray(), excludedSourceFiles.Values.ToArray(), excludeAttributes.Values.ToArray(), mergeWith.Value(), useSourceLink.HasValue());
                 coverage.PrepareModules();
 
                 Process process = new Process();

--- a/src/coverlet.core/Coverage.cs
+++ b/src/coverlet.core/Coverage.cs
@@ -248,5 +248,46 @@ namespace Coverlet.Core
                 InstrumentationHelper.DeleteHitsFile(result.HitsFilePath);
             }
         }
+
+        private string GetSourceLinkUrl(Dictionary<string, string> sourceLinkDocuments, string document)
+        {
+            if (sourceLinkDocuments.TryGetValue(document, out string url))
+            {
+                return url;
+            }
+
+            var keyWithBestMatch = string.Empty;
+            var relativePathOfBestMatch = string.Empty;
+
+            foreach (var sourceLinkDocument in sourceLinkDocuments)
+            {
+                string key = sourceLinkDocument.Key;
+                if (Path.GetFileName(key) != "*") continue;
+
+                string relativePath = Path.GetRelativePath(Path.GetDirectoryName(key), Path.GetDirectoryName(document));
+
+                if (relativePath.Contains("..")) continue;
+
+                if (relativePathOfBestMatch.Length == 0)
+                {
+                    keyWithBestMatch = sourceLinkDocument.Key;
+                    relativePathOfBestMatch = relativePath;
+                }
+
+                if (relativePath.Length < relativePathOfBestMatch.Length)
+                {
+                    keyWithBestMatch = sourceLinkDocument.Key;
+                    relativePathOfBestMatch = relativePath;
+                }
+            }
+
+            relativePathOfBestMatch = relativePathOfBestMatch == "." ? string.Empty : relativePathOfBestMatch;
+            
+            string replacement = Path.Combine(relativePathOfBestMatch, Path.GetFileName(document));
+            replacement = replacement.Replace('\\', '/');
+
+            url = sourceLinkDocuments[keyWithBestMatch];
+            return url.Replace("*", replacement);
+        }
     }
 }

--- a/src/coverlet.core/Instrumentation/Instrumenter.cs
+++ b/src/coverlet.core/Instrumentation/Instrumenter.cs
@@ -79,6 +79,12 @@ namespace Coverlet.Core.Instrumentation
                     var types = module.GetTypes();
                     AddCustomModuleTrackerToModule(module);
 
+                    var sourceLinkDebugInfo = module.CustomDebugInformations.FirstOrDefault(c => c.Kind == CustomDebugInformationKind.SourceLink);
+                    if (sourceLinkDebugInfo != null)
+                    {
+                        _result.SourceLink = ((SourceLinkDebugInformation)sourceLinkDebugInfo).Content;
+                    }
+
                     foreach (TypeDefinition type in types)
                     {
                         var actualType = type.DeclaringType ?? type;

--- a/src/coverlet.core/Instrumentation/InstrumenterResult.cs
+++ b/src/coverlet.core/Instrumentation/InstrumenterResult.cs
@@ -43,6 +43,7 @@ namespace Coverlet.Core.Instrumentation
         public string Module;
         public string HitsFilePath;
         public string ModulePath;
+        public string SourceLink;
         public Dictionary<string, Document> Documents { get; private set; }
         public List<(bool isBranch, int docIndex, int start, int end)> HitCandidates { get; private set; }
     }

--- a/src/coverlet.core/coverlet.core.csproj
+++ b/src/coverlet.core/coverlet.core.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <OutputType>Library</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyVersion>4.0.0</AssemblyVersion>
   </PropertyGroup>
 
@@ -9,6 +10,7 @@
     <PackageReference Include="Mono.Cecil" Version="0.10.1" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="System.Reflection.Metadata" Version="1.5.0" />
+    <PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="2.0.1" />
   </ItemGroup>
 

--- a/src/coverlet.msbuild.tasks/InstrumentationTask.cs
+++ b/src/coverlet.msbuild.tasks/InstrumentationTask.cs
@@ -9,12 +9,13 @@ namespace Coverlet.MSbuild.Tasks
     {
         private static Coverage _coverage;
         private string _path;
-        private string _exclude;
         private string _include;
         private string _includeDirectory;
+        private string _exclude;
         private string _excludeByFile;
-        private string _mergeWith;
         private string _excludeByAttribute;
+        private string _mergeWith;
+        private bool _useSourceLink;
 
         internal static Coverage Coverage
         {
@@ -26,12 +27,6 @@ namespace Coverlet.MSbuild.Tasks
         {
             get { return _path; }
             set { _path = value; }
-        }
-
-        public string Exclude
-        {
-            get { return _exclude; }
-            set { _exclude = value; }
         }
 
         public string Include
@@ -46,16 +41,16 @@ namespace Coverlet.MSbuild.Tasks
             set { _includeDirectory = value; }
         }
 
+        public string Exclude
+        {
+            get { return _exclude; }
+            set { _exclude = value; }
+        }
+
         public string ExcludeByFile
         {
             get { return _excludeByFile; }
             set { _excludeByFile = value; }
-        }
-
-        public string MergeWith
-        {
-            get { return _mergeWith; }
-            set { _mergeWith = value; }
         }
 
         public string ExcludeByAttribute
@@ -64,17 +59,29 @@ namespace Coverlet.MSbuild.Tasks
             set { _excludeByAttribute = value; }
         }
 
+        public string MergeWith
+        {
+            get { return _mergeWith; }
+            set { _mergeWith = value; }
+        }
+
+        public bool UseSourceLink
+        {
+            get { return _useSourceLink; }
+            set { _useSourceLink = value; }
+        }
+
         public override bool Execute()
         {
             try
             {
-                var excludedSourceFiles = _excludeByFile?.Split(',');
-                var excludeFilters = _exclude?.Split(',');
                 var includeFilters = _include?.Split(',');
                 var includeDirectories = _includeDirectory?.Split(',');
+                var excludeFilters = _exclude?.Split(',');
+                var excludedSourceFiles = _excludeByFile?.Split(',');
                 var excludeAttributes = _excludeByAttribute?.Split(',');
 
-                _coverage = new Coverage(_path, includeFilters, includeDirectories, excludeFilters, excludedSourceFiles, excludeAttributes, _mergeWith);
+                _coverage = new Coverage(_path, includeFilters, includeDirectories, excludeFilters, excludedSourceFiles, excludeAttributes, _mergeWith, _useSourceLink);
                 _coverage.PrepareModules();
             }
             catch (Exception ex)

--- a/src/coverlet.msbuild.tasks/coverlet.msbuild.tasks.csproj
+++ b/src/coverlet.msbuild.tasks/coverlet.msbuild.tasks.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <OutputType>Library</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <AssemblyVersion>2.3.0</AssemblyVersion>
   </PropertyGroup>
 

--- a/src/coverlet.msbuild/coverlet.msbuild.props
+++ b/src/coverlet.msbuild/coverlet.msbuild.props
@@ -1,15 +1,16 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <CollectCoverage Condition="$(CollectCoverage) == ''">false</CollectCoverage>
-    <CoverletOutputFormat Condition="$(CoverletOutputFormat) == ''">json</CoverletOutputFormat>
-    <CoverletOutput Condition="$(CoverletOutput) == ''">$([MSBuild]::EnsureTrailingSlash('$(MSBuildProjectDirectory)'))</CoverletOutput>
     <Include Condition="$(Include) == ''"></Include>
+    <IncludeDirectory Condition="$(IncludeDirectory) == ''"></IncludeDirectory>
     <Exclude Condition="$(Exclude) == ''"></Exclude>
     <ExcludeByFile Condition="$(ExcludeByFile) == ''"></ExcludeByFile>
+    <ExcludeByAttribute Condition="$(ExcludeByAttribute) == ''"></ExcludeByAttribute>
     <MergeWith Condition="$(MergeWith) == ''"></MergeWith>
+    <UseSourceLink Condition="$(UseSourceLink) == ''">false</UseSourceLink>
+    <CoverletOutputFormat Condition="$(CoverletOutputFormat) == ''">json</CoverletOutputFormat>
+    <CoverletOutput Condition="$(CoverletOutput) == ''">$([MSBuild]::EnsureTrailingSlash('$(MSBuildProjectDirectory)'))</CoverletOutput>
     <Threshold Condition="$(Threshold) == ''">0</Threshold>
     <ThresholdType Condition="$(ThresholdType) == ''">line,branch,method</ThresholdType>
-    <IncludeDirectory Condition="$(IncludeDirectory) == ''"></IncludeDirectory>
-    <ExcludeByAttribute Condition="$(ExcludeByAttribute) == ''"></ExcludeByAttribute>
   </PropertyGroup>
 </Project>

--- a/src/coverlet.msbuild/coverlet.msbuild.targets
+++ b/src/coverlet.msbuild/coverlet.msbuild.targets
@@ -6,25 +6,27 @@
   <Target Name="InstrumentModulesNoBuild" BeforeTargets="VSTest">
     <Coverlet.MSbuild.Tasks.InstrumentationTask
       Condition="'$(VSTestNoBuild)' == 'true' and $(CollectCoverage) == 'true'"
+      Path="$(TargetPath)"
       Include="$(Include)"
       IncludeDirectory="$(IncludeDirectory)"
       Exclude="$(Exclude)"
       ExcludeByFile="$(ExcludeByFile)"
-      MergeWith="$(MergeWith)"
       ExcludeByAttribute="$(ExcludeByAttribute)"
-      Path="$(TargetPath)" />
+      MergeWith="$(MergeWith)"
+      UseSourceLink="$(UseSourceLink)" />
   </Target>
 
   <Target Name="InstrumentModulesAfterBuild" AfterTargets="BuildProject">
     <Coverlet.MSbuild.Tasks.InstrumentationTask
       Condition="'$(VSTestNoBuild)' != 'true' and $(CollectCoverage) == 'true'"
+      Path="$(TargetPath)"
       Include="$(Include)"
       IncludeDirectory="$(IncludeDirectory)"
       Exclude="$(Exclude)"
       ExcludeByFile="$(ExcludeByFile)"
-      MergeWith="$(MergeWith)"
       ExcludeByAttribute="$(ExcludeByAttribute)"
-      Path="$(TargetPath)" />
+      MergeWith="$(MergeWith)"
+      UseSourceLink="$(UseSourceLink)" />
   </Target>
 
   <Target Name="GenerateCoverageResult" AfterTargets="VSTest">

--- a/test/coverlet.core.tests/CoverageTests.cs
+++ b/test/coverlet.core.tests/CoverageTests.cs
@@ -27,7 +27,7 @@ namespace Coverlet.Core.Tests
             // Since Coverage only instruments dependancies, we need a fake module here
             var testModule = Path.Combine(directory.FullName, "test.module.dll");
 
-            var coverage = new Coverage(testModule, Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>(), string.Empty);
+            var coverage = new Coverage(testModule, Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>(), string.Empty, false);
             coverage.PrepareModules();
 
             var result = coverage.GetCoverageResult();


### PR DESCRIPTION
You can now specify that Coverlet uses SourceLink URIs in place of document paths in Coverage results.

MSBuild:

```bash
dotnet test /p:CollectCoverage=true /p:UseSourceLink=true
```

Global Tool:

```bash
coverlet test-assembly.dll --target "dotnet" --targetargs "test test-project --no-build" --use-source-link
```

cc @ViktorHofer 

Fixes #257 