### PR TITLE
add threshold checks for overall coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ The above command will automatically fail the build if the line, branch or metho
 dotnet test /p:CollectCoverage=true /p:Threshold=80 /p:ThresholdType=line
 ```
 
-You can specify multiple values for `ThresholdType` by separating them with commas. Valid values include `line`, `branch` and `method`.
+You can specify multiple values for `ThresholdType` by separating them with commas. Valid values include `line`, `branch` and `method` as well as `total-line`, `total-branch` and `total-method`.
 
 #### Excluding From Coverage
 

--- a/src/coverlet.console/Program.cs
+++ b/src/coverlet.console/Program.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Text;
 using ConsoleTables;
 using Coverlet.Console.Logging;
@@ -107,6 +108,31 @@ namespace Coverlet.Console
                 var overallLineCoverage = summary.CalculateLineCoverage(result.Modules);
                 var overallBranchCoverage = summary.CalculateBranchCoverage(result.Modules);
                 var overallMethodCoverage = summary.CalculateMethodCoverage(result.Modules);
+
+                if (dThreshold > 0)
+                {
+                    var overallLinePercent = overallLineCoverage.Percent * 100;
+                    var overallBranchPercent = overallBranchCoverage.Percent * 100;
+                    var overallMethodPercent = overallMethodCoverage.Percent * 100;
+
+                    if (overallLinePercent < dThreshold && dThresholdTypes.Contains("total-line", StringComparer.OrdinalIgnoreCase))
+                    {
+                        exceptionBuilder.AppendLine($"Project has a overall line coverage '{overallLinePercent}%' below specified threshold '{dThreshold}%'");
+                        thresholdFailed = true;
+                    }
+
+                    if (overallBranchPercent < dThreshold && dThresholdTypes.Contains("total-branch", StringComparer.OrdinalIgnoreCase))
+                    {
+                        exceptionBuilder.AppendLine($"Project has a overall branch coverage '{overallBranchPercent}%' below specified threshold '{dThreshold}%'");
+                        thresholdFailed = true;
+                    }
+
+                    if (overallMethodPercent < dThreshold && dThresholdTypes.Contains("total-method", StringComparer.OrdinalIgnoreCase))
+                    {
+                        exceptionBuilder.AppendLine($"Project has a overall method coverage '{overallMethodPercent}%' below specified threshold '{dThreshold}%'");
+                        thresholdFailed = true;
+                    }
+                }
 
                 foreach (var _module in result.Modules)
                 {

--- a/src/coverlet.msbuild.tasks/CoverageResultTask.cs
+++ b/src/coverlet.msbuild.tasks/CoverageResultTask.cs
@@ -99,6 +99,31 @@ namespace Coverlet.MSbuild.Tasks
                 var overallBranchCoverage = summary.CalculateBranchCoverage(result.Modules);
                 var overallMethodCoverage = summary.CalculateMethodCoverage(result.Modules);
 
+                if (_threshold > 0)
+                {
+                    var overallLinePercent = overallLineCoverage.Percent * 100;
+                    var overallBranchPercent = overallBranchCoverage.Percent * 100;
+                    var overallMethodPercent = overallMethodCoverage.Percent * 100;
+
+                    if (overallLinePercent < _threshold && thresholdTypes.Contains("total-line", StringComparer.OrdinalIgnoreCase))
+                    {
+                        exceptionBuilder.AppendLine($"Project has a overall line coverage '{overallLinePercent}%' below specified threshold '{_threshold}%'");
+                        thresholdFailed = true;
+                    }
+
+                    if (overallBranchPercent < _threshold && thresholdTypes.Contains("total-branch", StringComparer.OrdinalIgnoreCase))
+                    {
+                        exceptionBuilder.AppendLine($"Project has a overall branch coverage '{overallBranchPercent}%' below specified threshold '{_threshold}%'");
+                        thresholdFailed = true;
+                    }
+
+                    if (overallMethodPercent < _threshold && thresholdTypes.Contains("total-method", StringComparer.OrdinalIgnoreCase))
+                    {
+                        exceptionBuilder.AppendLine($"Project has a overall method coverage '{overallMethodPercent}%' below specified threshold '{_threshold}%'");
+                        thresholdFailed = true;
+                    }
+                }
+                
                 foreach (var module in result.Modules)
                 {
                     var linePercent = summary.CalculateLineCoverage(module.Value).Percent * 100;


### PR DESCRIPTION
with this change it is possible to fail the coverage analysis where not a single module is checked against the threshold, but the whole project / solution. 

fixes #245