### PR TITLE
Threshold stats

### DIFF
--- a/src/coverlet.console/Program.cs
+++ b/src/coverlet.console/Program.cs
@@ -30,6 +30,7 @@ namespace Coverlet.Console
             CommandOption formats = app.Option("-f|--format", "Format of the generated coverage report.", CommandOptionType.MultipleValue);
             CommandOption threshold = app.Option("--threshold", "Exits with error if the coverage % is below value.", CommandOptionType.SingleValue);
             CommandOption thresholdTypes = app.Option("--threshold-type", "Coverage type to apply the threshold to.", CommandOptionType.MultipleValue);
+            CommandOption thresholdStat = app.Option("--threshold-stat", "Coverage statistic used to enforce the threshold value.", CommandOptionType.SingleValue);
             CommandOption excludeFilters = app.Option("--exclude", "Filter expressions to exclude specific modules and types.", CommandOptionType.MultipleValue);
             CommandOption includeFilters = app.Option("--include", "Filter expressions to include only specific modules and types.", CommandOptionType.MultipleValue);
             CommandOption excludedSourceFiles = app.Option("--exclude-by-file", "Glob patterns specifying source files to exclude.", CommandOptionType.MultipleValue);

--- a/src/coverlet.core/Coverage.cs
+++ b/src/coverlet.core/Coverage.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
+using Coverlet.Core.Enums;
 using Coverlet.Core.Helpers;
 using Coverlet.Core.Instrumentation;
 using Coverlet.Core.Symbols;
@@ -48,7 +49,7 @@ namespace Coverlet.Core
         public void PrepareModules()
         {
             string[] modules = InstrumentationHelper.GetCoverableModules(_module, _includeDirectories);
-            string[] excludes =  InstrumentationHelper.GetExcludedFiles(_excludedSourceFiles);
+            string[] excludes = InstrumentationHelper.GetExcludedFiles(_excludedSourceFiles);
             _excludeFilters = _excludeFilters?.Where(f => InstrumentationHelper.IsValidFilterExpression(f)).ToArray();
             _includeFilters = _includeFilters?.Where(f => InstrumentationHelper.IsValidFilterExpression(f)).ToArray();
 
@@ -131,14 +132,14 @@ namespace Coverlet.Core
                                 if (methods.TryGetValue(branch.Method, out Method method))
                                 {
                                     method.Branches.Add(new BranchInfo
-                                        { Line = branch.Number, Hits = branch.Hits, Offset = branch.Offset, EndOffset = branch.EndOffset, Path = branch.Path, Ordinal = branch.Ordinal }
+                                    { Line = branch.Number, Hits = branch.Hits, Offset = branch.Offset, EndOffset = branch.EndOffset, Path = branch.Path, Ordinal = branch.Ordinal }
                                     );
                                 }
                                 else
                                 {
                                     documents[doc.Path][branch.Class].Add(branch.Method, new Method());
                                     documents[doc.Path][branch.Class][branch.Method].Branches.Add(new BranchInfo
-                                        { Line = branch.Number, Hits = branch.Hits, Offset = branch.Offset, EndOffset = branch.EndOffset, Path = branch.Path, Ordinal = branch.Ordinal }
+                                    { Line = branch.Number, Hits = branch.Hits, Offset = branch.Offset, EndOffset = branch.EndOffset, Path = branch.Path, Ordinal = branch.Ordinal }
                                     );
                                 }
                             }
@@ -147,7 +148,7 @@ namespace Coverlet.Core
                                 documents[doc.Path].Add(branch.Class, new Methods());
                                 documents[doc.Path][branch.Class].Add(branch.Method, new Method());
                                 documents[doc.Path][branch.Class][branch.Method].Branches.Add(new BranchInfo
-                                    { Line = branch.Number, Hits = branch.Hits, Offset = branch.Offset, EndOffset = branch.EndOffset, Path = branch.Path, Ordinal = branch.Ordinal }
+                                { Line = branch.Number, Hits = branch.Hits, Offset = branch.Offset, EndOffset = branch.EndOffset, Path = branch.Path, Ordinal = branch.Ordinal }
                                 );
                             }
                         }
@@ -157,7 +158,7 @@ namespace Coverlet.Core
                             documents[doc.Path].Add(branch.Class, new Methods());
                             documents[doc.Path][branch.Class].Add(branch.Method, new Method());
                             documents[doc.Path][branch.Class][branch.Method].Branches.Add(new BranchInfo
-                                { Line = branch.Number, Hits = branch.Hits, Offset = branch.Offset, EndOffset = branch.EndOffset, Path = branch.Path, Ordinal = branch.Ordinal }
+                            { Line = branch.Number, Hits = branch.Hits, Offset = branch.Offset, EndOffset = branch.EndOffset, Path = branch.Path, Ordinal = branch.Ordinal }
                             );
                         }
                     }
@@ -292,7 +293,7 @@ namespace Coverlet.Core
             }
 
             relativePathOfBestMatch = relativePathOfBestMatch == "." ? string.Empty : relativePathOfBestMatch;
-            
+
             string replacement = Path.Combine(relativePathOfBestMatch, Path.GetFileName(document));
             replacement = replacement.Replace('\\', '/');
 

--- a/src/coverlet.core/CoverageResult.cs
+++ b/src/coverlet.core/CoverageResult.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Coverlet.Core.Enums;
 
 namespace Coverlet.Core
 {
@@ -104,6 +105,102 @@ namespace Coverlet.Core
                     }
                 }
             }
+        }
+
+        public ThresholdTypeFlags GetThresholdTypesBelowThreshold(CoverageSummary summary, double threshold, ThresholdTypeFlags thresholdTypes, ThresholdStatistic thresholdStat)
+        {
+            var thresholdTypeFlags = ThresholdTypeFlags.None;
+            switch (thresholdStat)
+            {
+                case ThresholdStatistic.Minimum:
+                    {
+                        foreach (var module in Modules)
+                        {
+                            var line = summary.CalculateLineCoverage(module.Value).Percent * 100;
+                            var branch = summary.CalculateBranchCoverage(module.Value).Percent * 100;
+                            var method = summary.CalculateMethodCoverage(module.Value).Percent * 100;
+
+                            if ((thresholdTypes & ThresholdTypeFlags.Line) != ThresholdTypeFlags.None)
+                            {
+                                if (line < threshold)
+                                    thresholdTypeFlags |= ThresholdTypeFlags.Line;
+                            }
+
+                            if ((thresholdTypes & ThresholdTypeFlags.Branch) != ThresholdTypeFlags.None)
+                            {
+                                if (branch < threshold)
+                                    thresholdTypeFlags |= ThresholdTypeFlags.Branch;
+                            }
+
+                            if ((thresholdTypes & ThresholdTypeFlags.Method) != ThresholdTypeFlags.None)
+                            {
+                                if (method < threshold)
+                                    thresholdTypeFlags |= ThresholdTypeFlags.Method;
+                            }
+                        }
+                    }
+                    break;
+                case ThresholdStatistic.Average:
+                    {
+                        double line = 0;
+                        double branch = 0;
+                        double method = 0;
+                        int numModules = Modules.Count;
+
+                        foreach (var module in Modules)
+                        {
+                            line += summary.CalculateLineCoverage(module.Value).Percent * 100;
+                            branch += summary.CalculateBranchCoverage(module.Value).Percent * 100;
+                            method += summary.CalculateMethodCoverage(module.Value).Percent * 100;
+                        }
+
+                        if ((thresholdTypes & ThresholdTypeFlags.Line) != ThresholdTypeFlags.None)
+                        {
+                            if ((line / numModules) < threshold)
+                                thresholdTypeFlags |= ThresholdTypeFlags.Line;
+                        }
+
+                        if ((thresholdTypes & ThresholdTypeFlags.Branch) != ThresholdTypeFlags.None)
+                        {
+                            if ((branch / numModules) < threshold)
+                                thresholdTypeFlags |= ThresholdTypeFlags.Branch;
+                        }
+
+                        if ((thresholdTypes & ThresholdTypeFlags.Method) != ThresholdTypeFlags.None)
+                        {
+                            if ((method / numModules) < threshold)
+                                thresholdTypeFlags |= ThresholdTypeFlags.Method;
+                        }
+                    }
+                    break;
+                case ThresholdStatistic.Total:
+                    {
+                        var line = summary.CalculateLineCoverage(Modules).Percent * 100;
+                        var branch = summary.CalculateBranchCoverage(Modules).Percent * 100;
+                        var method = summary.CalculateMethodCoverage(Modules).Percent * 100;
+
+                        if ((thresholdTypes & ThresholdTypeFlags.Line) != ThresholdTypeFlags.None)
+                        {
+                            if (line < threshold)
+                                thresholdTypeFlags |= ThresholdTypeFlags.Line;
+                        }
+
+                        if ((thresholdTypes & ThresholdTypeFlags.Branch) != ThresholdTypeFlags.None)
+                        {
+                            if (branch < threshold)
+                                thresholdTypeFlags |= ThresholdTypeFlags.Branch;
+                        }
+
+                        if ((thresholdTypes & ThresholdTypeFlags.Method) != ThresholdTypeFlags.None)
+                        {
+                            if (method < threshold)
+                                thresholdTypeFlags |= ThresholdTypeFlags.Method;
+                        }
+                    }
+                    break;
+            }
+
+            return thresholdTypeFlags;
         }
     }
 }

--- a/src/coverlet.core/Enums/ThresholdStatistic.cs
+++ b/src/coverlet.core/Enums/ThresholdStatistic.cs
@@ -1,0 +1,9 @@
+namespace Coverlet.Core.Enums
+{
+    public enum ThresholdStatistic
+    {
+        Minimum,
+        Average,
+        Total
+    }
+}

--- a/src/coverlet.core/Enums/ThresholdTypeFlags.cs
+++ b/src/coverlet.core/Enums/ThresholdTypeFlags.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Coverlet.Core.Enums
+{
+    [Flags]
+    public enum ThresholdTypeFlags
+    {
+        None = 0,
+        Line = 2,
+        Branch = 4,
+        Method = 8
+    }
+}

--- a/src/coverlet.core/Reporters/ReporterFactory.cs
+++ b/src/coverlet.core/Reporters/ReporterFactory.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Linq;
 using System.Collections.Generic;
-using coverlet.core.Reporters;
+using Coverlet.Core.Reporters;
 
 namespace Coverlet.Core.Reporters
 {

--- a/src/coverlet.core/Reporters/TeamCityReporter.cs
+++ b/src/coverlet.core/Reporters/TeamCityReporter.cs
@@ -3,7 +3,7 @@ using Coverlet.Core;
 using Coverlet.Core.Reporters;
 using System.Text;
 
-namespace coverlet.core.Reporters
+namespace Coverlet.Core.Reporters
 {
     public class TeamCityReporter : IReporter
     {

--- a/src/coverlet.msbuild.tasks/CoverageResultTask.cs
+++ b/src/coverlet.msbuild.tasks/CoverageResultTask.cs
@@ -16,6 +16,7 @@ namespace Coverlet.MSbuild.Tasks
         private string _format;
         private int _threshold;
         private string _thresholdType;
+        private string _thresholdStat;
 
         [Required]
         public string Output
@@ -43,6 +44,13 @@ namespace Coverlet.MSbuild.Tasks
         {
             get { return _thresholdType; }
             set { _thresholdType = value; }
+        }
+
+        [Required]
+        public string ThresholdStat
+        {
+            get { return _thresholdStat; }
+            set { _thresholdStat = value; }
         }
 
         public override bool Execute()

--- a/src/coverlet.msbuild.tasks/CoverageResultTask.cs
+++ b/src/coverlet.msbuild.tasks/CoverageResultTask.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using ConsoleTables;
 using Coverlet.Core;
+using Coverlet.Core.Enums;
 using Coverlet.Core.Reporters;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
@@ -14,7 +15,7 @@ namespace Coverlet.MSbuild.Tasks
     {
         private string _output;
         private string _format;
-        private int _threshold;
+        private double _threshold;
         private string _thresholdType;
         private string _thresholdStat;
 
@@ -33,7 +34,7 @@ namespace Coverlet.MSbuild.Tasks
         }
 
         [Required]
-        public int Threshold
+        public double Threshold
         {
             get { return _threshold; }
             set { _threshold = value; }
@@ -77,7 +78,9 @@ namespace Coverlet.MSbuild.Tasks
                 {
                     var reporter = new ReporterFactory(format).CreateReporter();
                     if (reporter == null)
+                    {
                         throw new Exception($"Specified output format '{format}' is not supported");
+                    }
 
                     if (reporter.OutputType == ReporterOutputType.Console)
                     {
@@ -98,14 +101,41 @@ namespace Coverlet.MSbuild.Tasks
                     }
                 }
 
-                var thresholdFailed = false;
-                var thresholdTypes = _thresholdType.Split(',').Select(t => t.Trim());
-                var summary = new CoverageSummary();
-                var exceptionBuilder = new StringBuilder();
+                var thresholdTypeFlags = ThresholdTypeFlags.None;
+                var thresholdStat = ThresholdStatistic.Minimum;
+                
+                foreach (var thresholdType in _thresholdType.Split(',').Select(t => t.Trim()))
+                {
+                    if (thresholdType.Equals("line", StringComparison.OrdinalIgnoreCase))
+                    {
+                        thresholdTypeFlags |= ThresholdTypeFlags.Line;
+                    }
+                    else if (thresholdType.Equals("branch", StringComparison.OrdinalIgnoreCase))
+                    {
+                        thresholdTypeFlags |= ThresholdTypeFlags.Branch;
+                    }
+                    else if (thresholdType.Equals("method", StringComparison.OrdinalIgnoreCase))
+                    {
+                        thresholdTypeFlags |= ThresholdTypeFlags.Method;
+                    }
+                }
+
+                if (_thresholdStat.Equals("average", StringComparison.OrdinalIgnoreCase))
+                {
+                    thresholdStat = ThresholdStatistic.Average;
+                }
+                else if (_thresholdStat.Equals("total", StringComparison.OrdinalIgnoreCase))
+                {
+                    thresholdStat = ThresholdStatistic.Total;
+                }
+
                 var coverageTable = new ConsoleTable("Module", "Line", "Branch", "Method");
-                var overallLineCoverage = summary.CalculateLineCoverage(result.Modules);
-                var overallBranchCoverage = summary.CalculateBranchCoverage(result.Modules);
-                var overallMethodCoverage = summary.CalculateMethodCoverage(result.Modules);
+                var summary = new CoverageSummary();
+                int numModules = result.Modules.Count;
+                
+                var totalLinePercent = summary.CalculateLineCoverage(result.Modules).Percent * 100;
+                var totalBranchPercent = summary.CalculateBranchCoverage(result.Modules).Percent * 100;
+                var totalMethodPercent = summary.CalculateMethodCoverage(result.Modules).Percent * 100;
 
                 foreach (var module in result.Modules)
                 {
@@ -114,37 +144,41 @@ namespace Coverlet.MSbuild.Tasks
                     var methodPercent = summary.CalculateMethodCoverage(module.Value).Percent * 100;
 
                     coverageTable.AddRow(Path.GetFileNameWithoutExtension(module.Key), $"{linePercent}%", $"{branchPercent}%", $"{methodPercent}%");
-
-                    if (_threshold > 0)
-                    {
-                        if (linePercent < _threshold && thresholdTypes.Contains("line", StringComparer.OrdinalIgnoreCase))
-                        {
-                            exceptionBuilder.AppendLine($"'{Path.GetFileNameWithoutExtension(module.Key)}' has a line coverage '{linePercent}%' below specified threshold '{_threshold}%'");
-                            thresholdFailed = true;
-                        }
-
-                        if (branchPercent < _threshold && thresholdTypes.Contains("branch", StringComparer.OrdinalIgnoreCase))
-                        {
-                            exceptionBuilder.AppendLine($"'{Path.GetFileNameWithoutExtension(module.Key)}' has a branch coverage '{branchPercent}%' below specified threshold '{_threshold}%'");
-                            thresholdFailed = true;
-                        }
-
-                        if (methodPercent < _threshold && thresholdTypes.Contains("method", StringComparer.OrdinalIgnoreCase))
-                        {
-                            exceptionBuilder.AppendLine($"'{Path.GetFileNameWithoutExtension(module.Key)}' has a method coverage '{methodPercent}%' below specified threshold '{_threshold}%'");
-                            thresholdFailed = true;
-                        }
-                    }
                 }
 
                 Console.WriteLine();
                 Console.WriteLine(coverageTable.ToStringAlternative());
-                Console.WriteLine($"Total Line: {overallLineCoverage.Percent * 100}%");
-                Console.WriteLine($"Total Branch: {overallBranchCoverage.Percent * 100}%");
-                Console.WriteLine($"Total Method: {overallMethodCoverage.Percent * 100}%");
 
-                if (thresholdFailed)
-                    throw new Exception(exceptionBuilder.ToString().TrimEnd(Environment.NewLine.ToCharArray()));
+                coverageTable.Columns.Clear();
+                coverageTable.Rows.Clear();
+
+                coverageTable.AddColumn(new [] { "", "Line", "Branch", "Method"});
+                coverageTable.AddRow("Total", $"{totalLinePercent}%", $"{totalBranchPercent}%", $"{totalMethodPercent}%");
+                coverageTable.AddRow("Average", $"{totalLinePercent / numModules}%", $"{totalBranchPercent / numModules}%", $"{totalMethodPercent / numModules}%");
+                
+                Console.WriteLine(coverageTable.ToStringAlternative());
+
+                thresholdTypeFlags = result.GetThresholdTypesBelowThreshold(summary, _threshold, thresholdTypeFlags, thresholdStat);
+                if (thresholdTypeFlags != ThresholdTypeFlags.None)
+                {
+                    var exceptionMessageBuilder = new StringBuilder();
+                    if ((thresholdTypeFlags & ThresholdTypeFlags.Line) != ThresholdTypeFlags.None)
+                    {
+                        exceptionMessageBuilder.AppendLine($"The {thresholdStat.ToString().ToLower()} line coverage is below the specified {_threshold}");
+                    }
+
+                    if ((thresholdTypeFlags & ThresholdTypeFlags.Branch) != ThresholdTypeFlags.None)
+                    {
+                        exceptionMessageBuilder.AppendLine($"The {thresholdStat.ToString().ToLower()} branch coverage is below the specified {_threshold}");
+                    }
+
+                    if ((thresholdTypeFlags & ThresholdTypeFlags.Method) != ThresholdTypeFlags.None)
+                    {
+                        exceptionMessageBuilder.AppendLine($"The {thresholdStat.ToString().ToLower()} method coverage is below the specified {_threshold}");
+                    }
+
+                    throw new Exception(exceptionMessageBuilder.ToString());
+                }
             }
             catch (Exception ex)
             {

--- a/src/coverlet.msbuild/coverlet.msbuild.props
+++ b/src/coverlet.msbuild/coverlet.msbuild.props
@@ -12,6 +12,6 @@
     <CoverletOutput Condition="$(CoverletOutput) == ''">$([MSBuild]::EnsureTrailingSlash('$(MSBuildProjectDirectory)'))</CoverletOutput>
     <Threshold Condition="$(Threshold) == ''">0</Threshold>
     <ThresholdType Condition="$(ThresholdType) == ''">line,branch,method</ThresholdType>
-    <ThresholdStat Condition="$(ThresholdStat) == ''">Minimum</ThresholdStat>
+    <ThresholdStat Condition="$(ThresholdStat) == ''">minimum</ThresholdStat>
   </PropertyGroup>
 </Project>

--- a/src/coverlet.msbuild/coverlet.msbuild.props
+++ b/src/coverlet.msbuild/coverlet.msbuild.props
@@ -12,5 +12,6 @@
     <CoverletOutput Condition="$(CoverletOutput) == ''">$([MSBuild]::EnsureTrailingSlash('$(MSBuildProjectDirectory)'))</CoverletOutput>
     <Threshold Condition="$(Threshold) == ''">0</Threshold>
     <ThresholdType Condition="$(ThresholdType) == ''">line,branch,method</ThresholdType>
+    <ThresholdStat Condition="$(ThresholdStat) == ''">Minimum</ThresholdStat>
   </PropertyGroup>
 </Project>

--- a/src/coverlet.msbuild/coverlet.msbuild.targets
+++ b/src/coverlet.msbuild/coverlet.msbuild.targets
@@ -35,7 +35,8 @@
       Output="$(CoverletOutput)"
       OutputFormat="$(CoverletOutputFormat)"
       Threshold="$(Threshold)"
-      ThresholdType="$(ThresholdType)" />
+      ThresholdType="$(ThresholdType)"
+      ThresholdStat="$(ThresholdStat)" />
   </Target>
 
 </Project>

--- a/test/coverlet.core.performancetest/PerformanceTest.cs
+++ b/test/coverlet.core.performancetest/PerformanceTest.cs
@@ -3,13 +3,13 @@ using System.Threading.Tasks;
 using System.Collections.Generic;
 using Xunit;
 
-namespace coverlet.core.performancetest
+namespace Coverlet.Core.PerformanceTest
 {
     /// <summary>
     /// Test the performance of coverlet by running a unit test that calls a reasonably big and complex test class.
     /// Enable the test, compile, then run the test in the command line:
     /// <code>
-    /// dotnet test /p:CollectCoverage=true test/coverlet.core.performancetest/
+    /// dotnet test /p:CollectCoverage=true test/Coverlet.Core.PerformanceTest/
     /// </code>
     /// </summary>
     public class PerformanceTest

--- a/test/coverlet.core.tests/Instrumentation/ModuleTrackerTemplateTests.cs
+++ b/test/coverlet.core.tests/Instrumentation/ModuleTrackerTemplateTests.cs
@@ -5,7 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace coverlet.core.tests.Instrumentation
+namespace Coverlet.Core.Tests.Instrumentation
 {
     public class ModuleTrackerTemplateTestsFixture : IDisposable
     {

--- a/test/coverlet.core.tests/Reporters/ReporterFactoryTests.cs
+++ b/test/coverlet.core.tests/Reporters/ReporterFactoryTests.cs
@@ -1,4 +1,4 @@
-using coverlet.core.Reporters;
+using Coverlet.Core.Reporters;
 using Xunit;
 
 namespace Coverlet.Core.Reporters.Tests

--- a/test/coverlet.core.tests/Reporters/TeamCityReporter.cs
+++ b/test/coverlet.core.tests/Reporters/TeamCityReporter.cs
@@ -1,5 +1,5 @@
-﻿using coverlet.core.Reporters;
-using System;
+﻿using System;
+using Coverlet.Core.Reporters;
 using Xunit;
 
 namespace Coverlet.Core.Reporters.Tests


### PR DESCRIPTION
This PR introduces the ability to specify the statistic used to determine coverage threshold conformance. It introduces the options `/p:ThresholdStat` for msbuild and `--threshold-stat` for the global tool and supports `minimum`, `average` or `total` statistics

Fixes #245 