### PR TITLE
Use Nerdbank.GitVersioning

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+
+  <ItemGroup>
+    <PackageReference Include="Nerdbank.GitVersioning" Version="2.3.38" PrivateAssets="all" />
+  </ItemGroup>
+
+</Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+</Project>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,7 @@ image:
 configuration:
   - Debug
   - Release
+skip_tags: true
 build_script:
   - ps: echo "Building for $env:CONFIGURATION on $env:APPVEYOR_BUILD_WORKER_IMAGE"
   - ps: dotnet msbuild build.proj /p:Configuration=$env:CONFIGURATION

--- a/src/coverlet.console/coverlet.console.csproj
+++ b/src/coverlet.console/coverlet.console.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -6,12 +6,10 @@
     <ToolCommandName>coverlet</ToolCommandName>
     <PackAsTool>true</PackAsTool>
     <AssemblyTitle>coverlet.console</AssemblyTitle>
-    <AssemblyVersion>1.5.0</AssemblyVersion>
     <Authors>tonerdo</Authors>
     <PackageId>$(AssemblyTitle)</PackageId>
     <Title>$(AssemblyTitle)</Title>
     <Description>Coverlet is a cross platform code coverage tool for .NET Core, with support for line, branch and method coverage.</Description>
-    <PackageVersion>$(AssemblyVersion)</PackageVersion>
     <PackageTags>coverage;testing;unit-test;lcov;opencover;quality</PackageTags>
     <PackageIconUrl>https://raw.githubusercontent.com/tonerdo/coverlet/master/_assets/coverlet-icon.svg?sanitize=true</PackageIconUrl>
     <PackageProjectUrl>https://github.com/tonerdo/coverlet</PackageProjectUrl>

--- a/src/coverlet.core/coverlet.core.csproj
+++ b/src/coverlet.core/coverlet.core.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <AssemblyVersion>5.0.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/coverlet.msbuild.tasks/coverlet.msbuild.tasks.csproj
+++ b/src/coverlet.msbuild.tasks/coverlet.msbuild.tasks.csproj
@@ -3,11 +3,8 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <AssemblyTitle>coverlet.msbuild.tasks</AssemblyTitle>
-    <AssemblyVersion>2.6.0</AssemblyVersion>
 
     <PackageId>coverlet.msbuild</PackageId>
-    <PackageVersion>$(AssemblyVersion)</PackageVersion>
     <Title>coverlet.msbuild</Title>
     <Authors>tonerdo</Authors>
     <PackageLicenseUrl>https://github.com/tonerdo/coverlet/blob/master/LICENSE</PackageLicenseUrl>

--- a/version.json
+++ b/version.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
+  "version": "2.6",
+  "publicReleaseRefSpec": [
+    "^refs/heads/master$"
+  ],
+  "cloudBuild": {
+    "buildNumber": {
+      "enabled": true
+    }
+  }
+}


### PR DESCRIPTION
~~⚠️ This pull request depends on #299, and will be substantially simplified once that PR is merged. ⚠️~~ 

## Overview

This change uses **Nerdbank.GitVersioning** to automatically version the assemblies and packages as work progresses in the repository.

## Deployment

Deploying a release to NuGet is much simpler after this change is applied. After setting up an environment (see next part), here are the steps to release a build:

1. After merging a pull request to master, locate the AppVeyor build you want to release
2. Open the **Image: Visual Studio 2017; Configuration: Release** job for the build (this is the only job containing the full set of correct artifacts for release)
3. At the top of the AppVeyor page, click **Deploy**
4. Select the **NuGet (coverlet)** environment and deploy
5. After deployment succeeds, create and push a tag in the repository

## Creating the environment

💡 This is a one-time setup process, after which you can use the environment any time you want to make a new coverlet release.

1. Log in to AppVeyor and go to the **Environments** tab (at the top, next to **Projects**)
1. Create a new environment
1. Select **NuGet** as the deployment provider
1. In your NuGet profile, create a new API key, and scope the key to `coverlet.*`
1. Back in AppVeyor environment setup apply the following:
    * Environment name: NuGet (coverlet)
    * API key: Copied from step (4)
1. Click **Add environment** to create the environment