### PR TITLE
Avoid unnecessary null checks in RecordHit

### DIFF
--- a/src/coverlet.core/Instrumentation/Instrumenter.cs
+++ b/src/coverlet.core/Instrumentation/Instrumenter.cs
@@ -41,15 +41,11 @@ namespace Coverlet.Core.Instrumentation
             _includeFilters = includeFilters;
             _excludedFiles = excludedFiles ?? Array.Empty<string>();
             _excludedAttributes = excludedAttributes;
+
+            IsCoreLibrary = Path.GetFileNameWithoutExtension(_module) == "System.Private.CoreLib";
         }
 
-        private bool IsCoreLibrary
-        {
-            get
-            {
-                return Path.GetFileNameWithoutExtension(_module) == "System.Private.CoreLib";
-            }
-        }
+        private bool IsCoreLibrary { get; }
 
         public bool CanInstrument() => InstrumentationHelper.HasPdb(_module);
 

--- a/src/coverlet.template/ModuleTrackerTemplate.cs
+++ b/src/coverlet.template/ModuleTrackerTemplate.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.IO.MemoryMappedFiles;
@@ -42,13 +41,18 @@ namespace Coverlet.Core.Instrumentation
             AppDomain.CurrentDomain.DomainUnload += new EventHandler(UnloadModule);
         }
 
-        public static void RecordHit(int hitLocationIndex)
+        public static void RecordHitInCoreLibrary(int hitLocationIndex)
         {
             // Make sure to avoid recording if this is a call to RecordHit within the AppDomain setup code in an
             // instrumented build of System.Private.CoreLib.
             if (HitsArray is null)
                 return;
 
+            Interlocked.Increment(ref HitsArray[hitLocationIndex]);
+        }
+
+        public static void RecordHit(int hitLocationIndex)
+        {
             Interlocked.Increment(ref HitsArray[hitLocationIndex]);
         }
 


### PR DESCRIPTION
Fixes #305 

The performance benefit of this change is minimal in debug builds, but could be observable in other cases. Either way, an unnecessary null check is removed from the hot path.