### PR TITLE
Fix failure to cover test code

### DIFF
--- a/src/coverlet.core/Helpers/InstrumentationHelper.cs
+++ b/src/coverlet.core/Helpers/InstrumentationHelper.cs
@@ -82,12 +82,20 @@ namespace Coverlet.Core.Helpers
         public static void BackupOriginalModule(string module, string identifier)
         {
             var backupPath = GetBackupPath(module, identifier);
+            var backupSymbolPath = Path.ChangeExtension(backupPath, ".pdb");
             File.Copy(module, backupPath, true);
+
+            var symbolFile = Path.ChangeExtension(module, ".pdb");
+            if (File.Exists(symbolFile))
+            {
+                File.Copy(symbolFile, backupSymbolPath, true);
+            }
         }
 
         public static void RestoreOriginalModule(string module, string identifier)
         {
             var backupPath = GetBackupPath(module, identifier);
+            var backupSymbolPath = Path.ChangeExtension(backupPath, ".pdb");
 
             // Restore the original module - retry up to 10 times, since the destination file could be locked
             // See: https://github.com/tonerdo/coverlet/issues/25
@@ -97,6 +105,12 @@ namespace Coverlet.Core.Helpers
             {
                 File.Copy(backupPath, module, true);
                 File.Delete(backupPath);
+            }, retryStrategy, 10);
+
+            RetryHelper.Retry(() =>
+            {
+                File.Copy(backupSymbolPath, Path.ChangeExtension(module, ".pdb"), true);
+                File.Delete(backupSymbolPath);
             }, retryStrategy, 10);
         }
 

--- a/src/coverlet.core/Helpers/InstrumentationHelper.cs
+++ b/src/coverlet.core/Helpers/InstrumentationHelper.cs
@@ -48,11 +48,7 @@ namespace Coverlet.Core.Helpers
             }
 
             // The module's name must be unique.
-            // Add the test module itself to exclude it from the files enumeration.
-            var uniqueModules = new HashSet<string>
-            {
-                Path.GetFileName(module)
-            };
+            var uniqueModules = new HashSet<string>();
 
             return dirs.SelectMany(d => Directory.EnumerateFiles(d))
                 .Where(m => IsAssembly(m) && uniqueModules.Add(Path.GetFileName(m)))

--- a/src/coverlet.core/Instrumentation/Instrumenter.cs
+++ b/src/coverlet.core/Instrumentation/Instrumenter.cs
@@ -149,7 +149,7 @@ namespace Coverlet.Core.Instrumentation
                         onProcessExitIl.InsertBefore(lastInstr, Instruction.Create(OpCodes.Call, customTrackerUnloadModule));
                     }
 
-                    module.Write(stream);
+                    module.Write(stream, new WriterParameters { WriteSymbols = true });
                 }
             }
         }

--- a/test/coverlet.core.tests/CoverageTests.cs
+++ b/test/coverlet.core.tests/CoverageTests.cs
@@ -28,10 +28,7 @@ namespace Coverlet.Core.Tests
 
             // TODO: Mimic hits by calling ModuleTrackerTemplate.RecordHit before Unload
 
-            // Since Coverage only instruments dependancies, we need a fake module here
-            var testModule = Path.Combine(directory.FullName, "test.module.dll");
-
-            var coverage = new Coverage(testModule, Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>(), string.Empty, false);
+            var coverage = new Coverage(Path.Combine(directory.FullName, Path.GetFileName(module)), Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>(), string.Empty, false);
             coverage.PrepareModules();
 
             // The module hit tracker must signal to Coverage that it has done its job, so call it manually

--- a/test/coverlet.core.tests/Helpers/InstrumentationHelperTests.cs
+++ b/test/coverlet.core.tests/Helpers/InstrumentationHelperTests.cs
@@ -13,7 +13,7 @@ namespace Coverlet.Core.Helpers.Tests
         {
             string module = typeof(InstrumentationHelperTests).Assembly.Location;
             var modules = InstrumentationHelper.GetCoverableModules(module, Array.Empty<string>());
-            Assert.False(Array.Exists(modules, m => m == module));
+            Assert.True(Array.Exists(modules, m => m == module));
         }
 
         [Fact]

--- a/test/coverlet.core.tests/Samples/Samples.cs
+++ b/test/coverlet.core.tests/Samples/Samples.cs
@@ -122,6 +122,13 @@ namespace Coverlet.Core.Samples.Tests
             return value;
         }
 
+        /// <summary>
+        /// This method is used by a unit test that verifies the behavior of the instrumentation process on an assembly
+        /// which is not instrumented. Excluding this method from code coverage prevents the bytecode for this reference
+        /// method from getting modified prior to test execution so it retains its original form for the test. This is
+        /// not a problem for the test because the instrumentation process only runs on assemblies which have not
+        /// already been instrumented.
+        /// </summary>
         [ExcludeFromCodeCoverage]
         public void HasSimpleTaskWithLambda()
         {

--- a/test/coverlet.core.tests/Samples/Samples.cs
+++ b/test/coverlet.core.tests/Samples/Samples.cs
@@ -122,6 +122,7 @@ namespace Coverlet.Core.Samples.Tests
             return value;
         }
 
+        [ExcludeFromCodeCoverage]
         public void HasSimpleTaskWithLambda()
         {
             var t = new Task(() => { });


### PR DESCRIPTION
Filtering of test modules is a per-project policy applied during report creation. It should not be assumed or applied as a default configuration.

Users who rely on the current behavior for performance reasons may exclude the test modules via instrumentation properties, though this might not be required since other recent performance improvements in coverlet would be adopted at the same time an upgrade caused this change to take effect.