### PR TITLE
Fix opencover report numbers

### DIFF
--- a/src/coverlet.core/Reporters/OpenCoverReporter.cs
+++ b/src/coverlet.core/Reporters/OpenCoverReporter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -76,8 +77,8 @@ namespace Coverlet.Core.Reporters
 
                             method.Add(new XAttribute("cyclomaticComplexity", methCyclomaticComplexity.ToString()));
                             method.Add(new XAttribute("nPathComplexity", "0"));
-                            method.Add(new XAttribute("sequenceCoverage", methLineCoverage.Percent.ToString()));
-                            method.Add(new XAttribute("branchCoverage", methBranchCoverage.Percent.ToString()));
+                            method.Add(new XAttribute("sequenceCoverage", Math.Round(methLineCoverage.Percent * 100, 2).ToString("G", CultureInfo.InvariantCulture)));
+                            method.Add(new XAttribute("branchCoverage", Math.Round(methBranchCoverage.Percent * 100, 2).ToString("G", CultureInfo.InvariantCulture)));
                             method.Add(new XAttribute("isConstructor", meth.Key.Contains("ctor").ToString()));
                             method.Add(new XAttribute("isGetter", meth.Key.Contains("get_").ToString()));
                             method.Add(new XAttribute("isSetter", meth.Key.Contains("set_").ToString()));
@@ -157,8 +158,8 @@ namespace Coverlet.Core.Reporters
                             methodSummary.Add(new XAttribute("visitedSequencePoints", methLineCoverage.Covered.ToString()));
                             methodSummary.Add(new XAttribute("numBranchPoints", methBranchCoverage.Total.ToString()));
                             methodSummary.Add(new XAttribute("visitedBranchPoints", methBranchCoverage.Covered.ToString()));
-                            methodSummary.Add(new XAttribute("sequenceCoverage", methLineCoverage.Percent.ToString()));
-                            methodSummary.Add(new XAttribute("branchCoverage", methBranchCoverage.Percent.ToString()));
+                            methodSummary.Add(new XAttribute("sequenceCoverage", Math.Round(methLineCoverage.Percent * 100, 2).ToString("G", CultureInfo.InvariantCulture)));
+                            methodSummary.Add(new XAttribute("branchCoverage", Math.Round(methBranchCoverage.Percent * 100, 2).ToString("G", CultureInfo.InvariantCulture)));
                             methodSummary.Add(new XAttribute("maxCyclomaticComplexity", methCyclomaticComplexity.ToString()));
                             methodSummary.Add(new XAttribute("minCyclomaticComplexity", methCyclomaticComplexity.ToString()));
                             methodSummary.Add(new XAttribute("visitedClasses", "0"));
@@ -191,8 +192,8 @@ namespace Coverlet.Core.Reporters
                         classSummary.Add(new XAttribute("visitedSequencePoints", classLineCoverage.Covered.ToString()));
                         classSummary.Add(new XAttribute("numBranchPoints", classBranchCoverage.Total.ToString()));
                         classSummary.Add(new XAttribute("visitedBranchPoints", classBranchCoverage.Covered.ToString()));
-                        classSummary.Add(new XAttribute("sequenceCoverage", classLineCoverage.Percent.ToString()));
-                        classSummary.Add(new XAttribute("branchCoverage", classBranchCoverage.Percent.ToString()));
+                        classSummary.Add(new XAttribute("sequenceCoverage", Math.Round(classLineCoverage.Percent * 100, 2).ToString("G", CultureInfo.InvariantCulture)));
+                        classSummary.Add(new XAttribute("branchCoverage", Math.Round(classBranchCoverage.Percent * 100, 2).ToString("G", CultureInfo.InvariantCulture)));
                         classSummary.Add(new XAttribute("maxCyclomaticComplexity", classMaxCyclomaticComplexity.ToString()));
                         classSummary.Add(new XAttribute("minCyclomaticComplexity", classMinCyclomaticComplexity.ToString()));
                         classSummary.Add(new XAttribute("visitedClasses", classVisited ? "1" : "0"));
@@ -214,7 +215,7 @@ namespace Coverlet.Core.Reporters
             }
 
             var moduleLineCoverage = summary.CalculateLineCoverage(result.Modules);
-            var moduleBranchCoverage = summary.CalculateLineCoverage(result.Modules);
+            var moduleBranchCoverage = summary.CalculateBranchCoverage(result.Modules);
             var moduleMaxCyclomaticComplexity = summary.CalculateMaxCyclomaticComplexity(result.Modules);
             var moduleMinCyclomaticComplexity = summary.CalculateMinCyclomaticComplexity(result.Modules);
 
@@ -222,8 +223,8 @@ namespace Coverlet.Core.Reporters
             coverageSummary.Add(new XAttribute("visitedSequencePoints", moduleLineCoverage.Covered.ToString()));
             coverageSummary.Add(new XAttribute("numBranchPoints", moduleBranchCoverage.Total.ToString()));
             coverageSummary.Add(new XAttribute("visitedBranchPoints", moduleBranchCoverage.Covered.ToString()));
-            coverageSummary.Add(new XAttribute("sequenceCoverage", moduleLineCoverage.Percent.ToString()));
-            coverageSummary.Add(new XAttribute("branchCoverage", moduleBranchCoverage.Percent.ToString()));
+            coverageSummary.Add(new XAttribute("sequenceCoverage", Math.Round(moduleLineCoverage.Percent * 100, 2).ToString("G", CultureInfo.InvariantCulture)));
+            coverageSummary.Add(new XAttribute("branchCoverage", Math.Round(moduleBranchCoverage.Percent * 100, 2).ToString("G", CultureInfo.InvariantCulture)));
             coverageSummary.Add(new XAttribute("maxCyclomaticComplexity", moduleMaxCyclomaticComplexity.ToString()));
             coverageSummary.Add(new XAttribute("minCyclomaticComplexity", moduleMinCyclomaticComplexity.ToString()));
             coverageSummary.Add(new XAttribute("visitedClasses", visitedClasses.ToString()));

--- a/test/coverlet.core.tests/Reporters/OpenCoverReporterTests.cs
+++ b/test/coverlet.core.tests/Reporters/OpenCoverReporterTests.cs
@@ -1,5 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml.Linq;
 using Xunit;
 
 namespace Coverlet.Core.Reporters.Tests
@@ -16,7 +20,11 @@ namespace Coverlet.Core.Reporters.Tests
             result.Modules.Add("Coverlet.Core.Reporters.Tests", CreateFirstDocuments());
 
             OpenCoverReporter reporter = new OpenCoverReporter();
-            Assert.NotEqual(string.Empty, reporter.Report(result));
+            string report = reporter.Report(result);
+            Assert.NotEmpty(report);
+            XDocument doc = XDocument.Load(new MemoryStream(Encoding.UTF8.GetBytes(report)));
+            Assert.Empty(doc.Descendants().Attributes("sequenceCoverage").Where(v => v.Value != "33.3"));
+            Assert.Empty(doc.Descendants().Attributes("branchCoverage").Where(v => v.Value != "25"));
         }
 
         [Fact]
@@ -42,10 +50,13 @@ namespace Coverlet.Core.Reporters.Tests
             Lines lines = new Lines();
             lines.Add(1, 1);
             lines.Add(2, 0);
+            lines.Add(3, 0);
 
             Branches branches = new Branches();
             branches.Add(new BranchInfo { Line = 1, Hits = 1, Offset = 23, EndOffset = 24, Path = 0, Ordinal = 1 });
             branches.Add(new BranchInfo { Line = 1, Hits = 0, Offset = 23, EndOffset = 27, Path = 1, Ordinal = 2 });
+            branches.Add(new BranchInfo { Line = 1, Hits = 0, Offset = 40, EndOffset = 41, Path = 0, Ordinal = 3 });
+            branches.Add(new BranchInfo { Line = 1, Hits = 0, Offset = 40, EndOffset = 44, Path = 1, Ordinal = 4 });
 
             Methods methods = new Methods();
             var methodString = "System.Void Coverlet.Core.Reporters.Tests.OpenCoverReporterTests.TestReport()";


### PR DESCRIPTION
Fixes https://github.com/tonerdo/coverlet/issues/315

New output
```xml
﻿<?xml version="1.0" encoding="utf-8"?>
<CoverageSession>
  <Summary numSequencePoints="3" visitedSequencePoints="1" numBranchPoints="4" visitedBranchPoints="1" sequenceCoverage="33.3" branchCoverage="25" maxCyclomaticComplexity="4" minCyclomaticComplexity="4" visitedClasses="1" numClasses="1" visitedMethods="1" numMethods="1" />
  <Modules>
    <Module hash="E04CA10A-958D-4B1C-AB12-7833BBACF011">
      <ModulePath>Coverlet.Core.Reporters.Tests</ModulePath>
      <ModuleTime>2019-01-30T09:22:19</ModuleTime>
      <ModuleName>Coverlet.Core.Reporters</ModuleName>
      <Files>
        <File uid="1" fullPath="doc.cs" />
      </Files>
      <Classes>
        <Class>
          <Summary numSequencePoints="3" visitedSequencePoints="1" numBranchPoints="4" visitedBranchPoints="1" sequenceCoverage="33.3" branchCoverage="25" maxCyclomaticComplexity="4" minCyclomaticComplexity="4" visitedClasses="1" numClasses="1" visitedMethods="1" numMethods="1" />
          <FullName>Coverlet.Core.Reporters.Tests.OpenCoverReporterTests</FullName>
          <Methods>
            <Method cyclomaticComplexity="4" nPathComplexity="0" sequenceCoverage="33.3" branchCoverage="25" isConstructor="False" isGetter="False" isSetter="False" isStatic="True">
              <Summary numSequencePoints="3" visitedSequencePoints="1" numBranchPoints="4" visitedBranchPoints="1" sequenceCoverage="33.3" branchCoverage="25" maxCyclomaticComplexity="4" minCyclomaticComplexity="4" visitedClasses="0" numClasses="0" visitedMethods="1" numMethods="1" />
              <MetadataToken />
              <Name>System.Void Coverlet.Core.Reporters.Tests.OpenCoverReporterTests.TestReport()</Name>
              <FileRef uid="1" />
              <SequencePoints>
                <SequencePoint vc="1" uspid="1" ordinal="0" sl="1" sc="1" el="1" ec="2" bec="0" bev="0" fileid="1" />
                <SequencePoint vc="0" uspid="2" ordinal="1" sl="2" sc="1" el="2" ec="2" bec="0" bev="0" fileid="1" />
                <SequencePoint vc="0" uspid="3" ordinal="2" sl="3" sc="1" el="3" ec="2" bec="0" bev="0" fileid="1" />
              </SequencePoints>
              <BranchPoints>
                <BranchPoint vc="1" uspid="1" ordinal="1" path="0" offset="23" offsetend="24" sl="1" fileid="1" />
                <BranchPoint vc="0" uspid="1" ordinal="2" path="1" offset="23" offsetend="27" sl="1" fileid="1" />
                <BranchPoint vc="0" uspid="1" ordinal="3" path="0" offset="40" offsetend="41" sl="1" fileid="1" />
                <BranchPoint vc="0" uspid="1" ordinal="4" path="1" offset="40" offsetend="44" sl="1" fileid="1" />
              </BranchPoints>
              <MethodPoint vc="1" uspid="0" p8:type="SequencePoint" ordinal="0" offset="0" sc="0" sl="1" ec="1" el="3" bec="0" bev="0" fileid="1" xmlns:p8="xsi" />
            </Method>
          </Methods>
        </Class>
      </Classes>
    </Module>
  </Modules>
</CoverageSession>
```

/cc @tonerdo @charlieschmidt

