### PR TITLE
Fix README to match teamcity keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,12 +136,12 @@ The currently supported [TeamCity statistics](https://confluence.jetbrains.com/d
 | TeamCity Statistic Key  | Description                    |
 | :---                    | :---                           |
 | CodeCoverageL           | Line-level code coverage       |
-| CodeCoverageC           | Class-level code coverage      |
+| CodeCoverageR           | Branch-level code coverage     |
 | CodeCoverageM           | Method-level code coverage     |
 | CodeCoverageAbsLTotal   | The total number of lines      |
 | CodeCoverageAbsLCovered | The number of covered lines    |
-| CodeCoverageAbsCTotal   | The total number of classes    |
-| CodeCoverageAbsCCovered | The number of covered classes  |
+| CodeCoverageAbsRTotal   | The total number of branches   |
+| CodeCoverageAbsRCovered | The number of covered branches |
 | CodeCoverageAbsMTotal   | The total number of methods    |
 | CodeCoverageAbsMCovered | The number of covered methods  |
 


### PR DESCRIPTION
The list of TeamCity Statistic Keys in the README does not match the keys in code.
https://github.com/tonerdo/coverlet/blob/38a2104e893a686c05d85cb97ae55ab6c90c9836/src/coverlet.core/Reporters/TeamCityReporter.cs#L46-L56