### PR TITLE
Remove unnecessary comma in README docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ You can also ignore specific source files from code coverage using the `ExcludeB
  - Use file path or directory path with globbing (e.g `dir1/*.cs`)
 
 ```bash
-dotnet test /p:CollectCoverage=true /p:ExcludeByFile=\"../dir1/class1.cs,../dir2/*.cs,../dir3/**/*.cs,\"
+dotnet test /p:CollectCoverage=true /p:ExcludeByFile=\"../dir1/class1.cs,../dir2/*.cs,../dir3/**/*.cs\"
 ```
 
 ##### Filters


### PR DESCRIPTION
Super nitty, I know, but this was throwing me off when I was trying to use these arguments, so I figured I'd toss up a small PR to help clarify.