### PR TITLE
Fix failure to process coverage reports for parallel builds

### DIFF
--- a/src/coverlet.console/Program.cs
+++ b/src/coverlet.console/Program.cs
@@ -50,7 +50,7 @@ namespace Coverlet.Console
                 if (!target.HasValue())
                     throw new CommandParsingException(app, "Target must be specified.");
 
-                Coverage coverage = new Coverage(module.Value, includeFilters.Values.ToArray(), includeDirectories.Values.ToArray(), excludeFilters.Values.ToArray(), excludedSourceFiles.Values.ToArray(), excludeAttributes.Values.ToArray(), singleHit.HasValue(), mergeWith.Value(), useSourceLink.HasValue(), logger);
+                Coverage coverage = new Coverage(module.Value, includeFilters.Values.ToArray(), includeDirectories.Values.ToArray(), excludeFilters.Values.ToArray(), excludedSourceFiles.Values.ToArray(), excludeAttributes.Values.ToArray(), singleHit.HasValue(), mergeWith.Value(), useSourceLink.HasValue(), logger, Guid.NewGuid().ToString());
                 coverage.PrepareModules();
 
                 Process process = new Process();

--- a/src/coverlet.core/Coverage.cs
+++ b/src/coverlet.core/Coverage.cs
@@ -41,7 +41,8 @@ namespace Coverlet.Core
             bool singleHit,
             string mergeWith,
             bool useSourceLink,
-            ILogger logger)
+            ILogger logger,
+            string identifier)
         {
             _module = module;
             _includeFilters = includeFilters;
@@ -53,8 +54,8 @@ namespace Coverlet.Core
             _mergeWith = mergeWith;
             _useSourceLink = useSourceLink;
             _logger = logger;
+            _identifier = identifier;
 
-            _identifier = Guid.NewGuid().ToString();
             _results = new List<InstrumenterResult>();
         }
 

--- a/src/coverlet.msbuild.tasks/CoverageResultTask.cs
+++ b/src/coverlet.msbuild.tasks/CoverageResultTask.cs
@@ -13,12 +13,20 @@ namespace Coverlet.MSbuild.Tasks
 {
     public class CoverageResultTask : Task
     {
+        private string _identifier;
         private string _output;
         private string _format;
         private double _threshold;
         private string _thresholdType;
         private string _thresholdStat;
         private MSBuildLogger _logger;
+
+        [Required]
+        public string Identifier
+        {
+            get { return _identifier; }
+            set { _identifier = value; }
+        }
 
         [Required]
         public string Output
@@ -66,7 +74,7 @@ namespace Coverlet.MSbuild.Tasks
             {
                 Console.WriteLine("\nCalculating coverage result...");
 
-                var coverage = InstrumentationTask.Coverage;
+                var coverage = InstrumentationTask.Coverage[Identifier];
                 var result = coverage.GetCoverageResult();
 
                 var directory = Path.GetDirectoryName(_output);

--- a/src/coverlet.msbuild.tasks/coverlet.msbuild.props
+++ b/src/coverlet.msbuild.tasks/coverlet.msbuild.props
@@ -1,6 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <CollectCoverage Condition="$(CollectCoverage) == ''">false</CollectCoverage>
+    <CoverletIdentifier>$([System.Guid]::NewGuid())</CoverletIdentifier>
     <Include Condition="$(Include) == ''"></Include>
     <IncludeDirectory Condition="$(IncludeDirectory) == ''"></IncludeDirectory>
     <Exclude Condition="$(Exclude) == ''"></Exclude>

--- a/src/coverlet.msbuild.tasks/coverlet.msbuild.targets
+++ b/src/coverlet.msbuild.tasks/coverlet.msbuild.targets
@@ -7,6 +7,7 @@
     <Coverlet.MSbuild.Tasks.InstrumentationTask
       Condition="'$(VSTestNoBuild)' == 'true' and $(CollectCoverage) == 'true'"
       Path="$(TargetPath)"
+      Identifier="$(CoverletIdentifier)"
       Include="$(Include)"
       IncludeDirectory="$(IncludeDirectory)"
       Exclude="$(Exclude)"
@@ -21,6 +22,7 @@
     <Coverlet.MSbuild.Tasks.InstrumentationTask
       Condition="'$(VSTestNoBuild)' != 'true' and $(CollectCoverage) == 'true'"
       Path="$(TargetPath)"
+      Identifier="$(CoverletIdentifier)"
       Include="$(Include)"
       IncludeDirectory="$(IncludeDirectory)"
       Exclude="$(Exclude)"
@@ -34,6 +36,7 @@
   <Target Name="GenerateCoverageResult" AfterTargets="VSTest">
     <Coverlet.MSbuild.Tasks.CoverageResultTask
       Condition="$(CollectCoverage) == 'true'"
+      Identifier="$(CoverletIdentifier)"
       Output="$(CoverletOutput)"
       OutputFormat="$(CoverletOutputFormat)"
       Threshold="$(Threshold)"

--- a/test/coverlet.core.tests/CoverageTests.cs
+++ b/test/coverlet.core.tests/CoverageTests.cs
@@ -22,7 +22,7 @@ namespace Coverlet.Core.Tests
 
             // TODO: Find a way to mimick hits
 
-            var coverage = new Coverage(Path.Combine(directory.FullName, Path.GetFileName(module)), Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>(), false, string.Empty, false, new Mock<ILogger>().Object);
+            var coverage = new Coverage(Path.Combine(directory.FullName, Path.GetFileName(module)), Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>(), false, string.Empty, false, new Mock<ILogger>().Object, Guid.NewGuid().ToString());
             coverage.PrepareModules();
 
             var result = coverage.GetCoverageResult();


### PR DESCRIPTION
This is a workaround for #364. Eventually this code should be updated to avoid the state sharing altogether.