### PR TITLE
Try to fix netstandard.dll hell

### DIFF
--- a/src/coverlet.core/Instrumentation/Instrumenter.cs
+++ b/src/coverlet.core/Instrumentation/Instrumenter.cs
@@ -76,7 +76,7 @@ namespace Coverlet.Core.Instrumentation
         private void InstrumentModule()
         {
             using (var stream = new FileStream(_module, FileMode.Open, FileAccess.ReadWrite))
-            using (var resolver = new DefaultAssemblyResolver())
+            using (var resolver = new NetstandardAwareAssemblyResolver())
             {
                 resolver.AddSearchDirectory(Path.GetDirectoryName(_module));
                 var parameters = new ReaderParameters { ReadSymbols = true, AssemblyResolver = resolver };
@@ -599,6 +599,96 @@ namespace Coverlet.Core.Instrumentation
 
                     return importedRef;
                 }
+            }
+        }
+    }
+
+    /// <summary>
+    /// In case of testing different runtime i.e. netfx we could find netstandard.dll in folder.
+    /// netstandard.dll is a forward only lib, there is no IL but only forwards to "runtime" implementation.
+    /// For some classes implementation are in different assembly for different runtime for instance:
+    /// 
+    /// For NetFx 4.7
+    /// // Token: 0x2700072C RID: 1836
+    /// .class extern forwarder System.Security.Cryptography.X509Certificates.StoreName
+    /// {
+    ///    .assembly extern System
+    /// }    
+    /// 
+    /// For netcoreapp2.2
+    /// Token: 0x2700072C RID: 1836
+    /// .class extern forwarder System.Security.Cryptography.X509Certificates.StoreName
+    /// {
+    ///    .assembly extern System.Security.Cryptography.X509Certificates
+    /// }
+    /// 
+    /// There is a concrete possibility that Cecil cannot find implementation and throws StackOverflow exception https://github.com/jbevain/cecil/issues/575
+    /// This custom resolver check if requested lib is a "official" netstandard.dll and load once of "current runtime" with
+    /// correct forwards.
+    /// Check compares 'assembly name' and 'public key token', because versions could differ between runtimes.
+    /// </summary>
+    internal class NetstandardAwareAssemblyResolver : DefaultAssemblyResolver
+    {
+        private static System.Reflection.Assembly _netStandardAssembly;
+        private static string _name;
+        private static byte[] _publicKeyToken;
+        private static AssemblyDefinition _assemblyDefinition;
+
+        static NetstandardAwareAssemblyResolver()
+        {
+            try
+            {
+                // To be sure to load information of "real" runtime netstandard implementation
+                _netStandardAssembly = System.Reflection.Assembly.LoadFile(Path.Combine(Path.GetDirectoryName(typeof(object).Assembly.Location), "netstandard.dll"));
+                System.Reflection.AssemblyName name = _netStandardAssembly.GetName();
+                _name = name.Name;
+                _publicKeyToken = name.GetPublicKeyToken();
+                _assemblyDefinition = AssemblyDefinition.ReadAssembly(_netStandardAssembly.Location);
+            }
+            catch (FileNotFoundException)
+            {
+                // netstandard not supported
+            }
+        }
+
+        // Check name and public key but not version that could be different
+        private bool CheckIfSearchingNetstandard(AssemblyNameReference name)
+        {
+            if (_netStandardAssembly is null)
+            {
+                return false;
+            }
+
+            if (_name != name.Name)
+            {
+                return false;
+            }
+
+            if (name.PublicKeyToken.Length != _publicKeyToken.Length)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < name.PublicKeyToken.Length; i++)
+            {
+                if (_publicKeyToken[i] != name.PublicKeyToken[i])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public override AssemblyDefinition Resolve(AssemblyNameReference name)
+        {
+            if (CheckIfSearchingNetstandard(name))
+            {
+                return _assemblyDefinition;
+            }
+            else
+            {
+                return base.Resolve(name);
             }
         }
     }

--- a/test/coverlet.core.tests/Instrumentation/InstrumenterTests.cs
+++ b/test/coverlet.core.tests/Instrumentation/InstrumenterTests.cs
@@ -1,11 +1,17 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Reflection;
+
+using Coverlet.Core.Logging;
+using Coverlet.Core.Samples.Tests;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Emit;
+using Mono.Cecil;
+using Moq;
 using Xunit;
 
-using Coverlet.Core.Samples.Tests;
-using Moq;
-using Coverlet.Core.Logging;
 
 namespace Coverlet.Core.Instrumentation.Tests
 {
@@ -140,6 +146,50 @@ namespace Coverlet.Core.Instrumentation.Tests
             public string Identifier { get; set; }
 
             public DirectoryInfo Directory { get; set; }
+        }
+
+        [Fact]
+        public void TestInstrument_NetStandardAwareAssemblyResolver_FromRuntime()
+        {
+            NetstandardAwareAssemblyResolver netstandardResolver = new NetstandardAwareAssemblyResolver();
+
+            // We ask for "official" netstandard.dll implementation with know MS public key cc7b13ffcd2ddd51 same in all runtime
+            AssemblyDefinition resolved = netstandardResolver.Resolve(AssemblyNameReference.Parse("netstandard, Version=0.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51"));
+            Assert.NotNull(resolved);
+
+            // We check that netstandard.dll was resolved from runtime folder, where System.Object is
+            Assert.Equal(Path.Combine(Path.GetDirectoryName(typeof(object).Assembly.Location), "netstandard.dll"), resolved.MainModule.FileName);
+        }
+
+        [Fact]
+        public void TestInstrument_NetStandardAwareAssemblyResolver_FromFolder()
+        {
+            // Someone could create a custom dll named netstandard.dll we need to be sure that not
+            // conflicts with "official" resolution
+
+            // We create dummy netstandard.dll
+            CSharpCompilation compilation = CSharpCompilation.Create(
+                "netstandard",
+                new[] { CSharpSyntaxTree.ParseText("") },
+                new[] { MetadataReference.CreateFromFile(typeof(object).Assembly.Location) },
+                new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+            Assembly newAssemlby;
+            using (var dllStream = new MemoryStream())
+            {
+                EmitResult emitResult = compilation.Emit(dllStream);
+                Assert.True(emitResult.Success);
+                newAssemlby = Assembly.Load(dllStream.ToArray());
+                // remove if exists
+                File.Delete("netstandard.dll");
+                File.WriteAllBytes("netstandard.dll", dllStream.ToArray());
+            }
+
+            NetstandardAwareAssemblyResolver netstandardResolver = new NetstandardAwareAssemblyResolver();
+            AssemblyDefinition resolved = netstandardResolver.Resolve(AssemblyNameReference.Parse(newAssemlby.FullName));
+
+            // We check if final netstandard.dll resolved is local folder one and not "official" netstandard.dll
+            Assert.Equal(Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "netstandard.dll"), Path.GetFullPath(resolved.MainModule.FileName));
         }
     }
 }

--- a/test/coverlet.core.tests/coverlet.core.tests.csproj
+++ b/test/coverlet.core.tests/coverlet.core.tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$(MSBuildThisFileDirectory)\..\..\build\$(Configuration)\coverlet.msbuild.props" />
 
   <PropertyGroup>
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.10.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Moq" Version="4.8.1" />
     <PackageReference Include="xunit" Version="2.3.1" />


### PR DESCRIPTION
Fixes https://github.com/tonerdo/coverlet/issues/340

Explanation of problem is on issue and on cecil repo https://github.com/jbevain/cecil/issues/575

I ask to @Frankwayne and @eMarkM to kindly clone and try this branch if possible and provide in case some feedback!

@Frankwayne your repro now works, you need to skip xunit `dotnet test -l trx --filter Category!=Integration /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /v:n /p:Exclude=\"[Dapper*]*,[xunit*]*\"`

/cc @tonerdo @petli and @ViktorHofer to understand if this behaviour could break coreclr/corefx coverage.