### PR TITLE
Make Inclusion of Test Assembly Optional

### DIFF
--- a/src/coverlet.console/Program.cs
+++ b/src/coverlet.console/Program.cs
@@ -38,6 +38,7 @@ namespace Coverlet.Console
             CommandOption excludedSourceFiles = app.Option("--exclude-by-file", "Glob patterns specifying source files to exclude.", CommandOptionType.MultipleValue);
             CommandOption includeDirectories = app.Option("--include-directory", "Include directories containing additional assemblies to be instrumented.", CommandOptionType.MultipleValue);
             CommandOption excludeAttributes = app.Option("--exclude-by-attribute", "Attributes to exclude from code coverage.", CommandOptionType.MultipleValue);
+            CommandOption includeTestAssembly = app.Option("--include-test-assembly", "Specifies whether to report code coverage of the test assembly", CommandOptionType.NoValue);
             CommandOption singleHit = app.Option("--single-hit", "Specifies whether to limit code coverage hit reporting to a single hit for each location", CommandOptionType.NoValue);
             CommandOption mergeWith = app.Option("--merge-with", "Path to existing coverage result to merge.", CommandOptionType.SingleValue);
             CommandOption useSourceLink = app.Option("--use-source-link", "Specifies whether to use SourceLink URIs in place of file system paths.", CommandOptionType.NoValue);
@@ -50,7 +51,17 @@ namespace Coverlet.Console
                 if (!target.HasValue())
                     throw new CommandParsingException(app, "Target must be specified.");
 
-                Coverage coverage = new Coverage(module.Value, includeFilters.Values.ToArray(), includeDirectories.Values.ToArray(), excludeFilters.Values.ToArray(), excludedSourceFiles.Values.ToArray(), excludeAttributes.Values.ToArray(), singleHit.HasValue(), mergeWith.Value(), useSourceLink.HasValue(), logger);
+                Coverage coverage = new Coverage(module.Value,
+                    includeFilters.Values.ToArray(),
+                    includeDirectories.Values.ToArray(),
+                    excludeFilters.Values.ToArray(),
+                    excludedSourceFiles.Values.ToArray(),
+                    excludeAttributes.Values.ToArray(),
+                    includeTestAssembly.HasValue(),
+                    singleHit.HasValue(),
+                    mergeWith.Value(),
+                    useSourceLink.HasValue(),
+                    logger);
                 coverage.PrepareModules();
 
                 Process process = new Process();

--- a/src/coverlet.core/Coverage.cs
+++ b/src/coverlet.core/Coverage.cs
@@ -21,6 +21,7 @@ namespace Coverlet.Core
         private string[] _excludeFilters;
         private string[] _excludedSourceFiles;
         private string[] _excludeAttributes;
+        private bool _includeTestAssembly;
         private bool _singleHit;
         private string _mergeWith;
         private bool _useSourceLink;
@@ -38,6 +39,7 @@ namespace Coverlet.Core
             string[] excludeFilters,
             string[] excludedSourceFiles,
             string[] excludeAttributes,
+            bool includeTestAssembly,
             bool singleHit,
             string mergeWith,
             bool useSourceLink,
@@ -49,6 +51,7 @@ namespace Coverlet.Core
             _excludeFilters = excludeFilters;
             _excludedSourceFiles = excludedSourceFiles;
             _excludeAttributes = excludeAttributes;
+            _includeTestAssembly = includeTestAssembly;
             _singleHit = singleHit;
             _mergeWith = mergeWith;
             _useSourceLink = useSourceLink;
@@ -60,7 +63,7 @@ namespace Coverlet.Core
 
         public void PrepareModules()
         {
-            string[] modules = InstrumentationHelper.GetCoverableModules(_module, _includeDirectories);
+            string[] modules = InstrumentationHelper.GetCoverableModules(_module, _includeDirectories, _includeTestAssembly);
             string[] excludes = InstrumentationHelper.GetExcludedFiles(_excludedSourceFiles);
 
             Array.ForEach(_excludeFilters ?? Array.Empty<string>(), filter => _logger.LogInformation($"Excluded module filter '{filter}'"));

--- a/src/coverlet.core/Helpers/InstrumentationHelper.cs
+++ b/src/coverlet.core/Helpers/InstrumentationHelper.cs
@@ -14,7 +14,7 @@ namespace Coverlet.Core.Helpers
 {
     internal static class InstrumentationHelper
     {
-        public static string[] GetCoverableModules(string module, string[] directories)
+        public static string[] GetCoverableModules(string module, string[] directories, bool includeTestAssembly)
         {
             Debug.Assert(directories != null);
 
@@ -49,6 +49,9 @@ namespace Coverlet.Core.Helpers
 
             // The module's name must be unique.
             var uniqueModules = new HashSet<string>();
+
+            if (!includeTestAssembly)
+                uniqueModules.Add(Path.GetFileName(module));
 
             return dirs.SelectMany(d => Directory.EnumerateFiles(d))
                 .Where(m => IsAssembly(m) && uniqueModules.Add(Path.GetFileName(m)))

--- a/src/coverlet.msbuild.tasks/InstrumentationTask.cs
+++ b/src/coverlet.msbuild.tasks/InstrumentationTask.cs
@@ -14,6 +14,7 @@ namespace Coverlet.MSbuild.Tasks
         private string _exclude;
         private string _excludeByFile;
         private string _excludeByAttribute;
+        private bool _includeTestAssembly;
         private bool _singleHit;
         private string _mergeWith;
         private bool _useSourceLink;
@@ -61,6 +62,12 @@ namespace Coverlet.MSbuild.Tasks
             set { _excludeByAttribute = value; }
         }
 
+        public bool IncludeTestAssembly
+        {
+            get { return _includeTestAssembly; }
+            set { _includeTestAssembly = value; }
+        }
+
         public bool SingleHit
         {
             get { return _singleHit; }
@@ -94,7 +101,7 @@ namespace Coverlet.MSbuild.Tasks
                 var excludedSourceFiles = _excludeByFile?.Split(',');
                 var excludeAttributes = _excludeByAttribute?.Split(',');
 
-                _coverage = new Coverage(_path, includeFilters, includeDirectories, excludeFilters, excludedSourceFiles, excludeAttributes, _singleHit, _mergeWith, _useSourceLink, _logger);
+                _coverage = new Coverage(_path, includeFilters, includeDirectories, excludeFilters, excludedSourceFiles, excludeAttributes, _includeTestAssembly, _singleHit, _mergeWith, _useSourceLink, _logger);
                 _coverage.PrepareModules();
             }
             catch (Exception ex)

--- a/src/coverlet.msbuild.tasks/coverlet.msbuild.props
+++ b/src/coverlet.msbuild.tasks/coverlet.msbuild.props
@@ -6,6 +6,7 @@
     <Exclude Condition="$(Exclude) == ''"></Exclude>
     <ExcludeByFile Condition="$(ExcludeByFile) == ''"></ExcludeByFile>
     <ExcludeByAttribute Condition="$(ExcludeByAttribute) == ''"></ExcludeByAttribute>
+    <IncludeTestAssembly Condition="'$(IncludeTestAssembly)' == ''">false</IncludeTestAssembly>
     <SingleHit Condition="'$(SingleHit)' == ''">false</SingleHit>
     <MergeWith Condition="$(MergeWith) == ''"></MergeWith>
     <UseSourceLink Condition="$(UseSourceLink) == ''">false</UseSourceLink>

--- a/src/coverlet.msbuild.tasks/coverlet.msbuild.targets
+++ b/src/coverlet.msbuild.tasks/coverlet.msbuild.targets
@@ -12,6 +12,7 @@
       Exclude="$(Exclude)"
       ExcludeByFile="$(ExcludeByFile)"
       ExcludeByAttribute="$(ExcludeByAttribute)"
+      IncludeTestAssembly="$(IncludeTestAssembly)"
       SingleHit="$(SingleHit)"
       MergeWith="$(MergeWith)"
       UseSourceLink="$(UseSourceLink)" />
@@ -26,6 +27,7 @@
       Exclude="$(Exclude)"
       ExcludeByFile="$(ExcludeByFile)"
       ExcludeByAttribute="$(ExcludeByAttribute)"
+      IncludeTestAssembly="$(IncludeTestAssembly)"
       SingleHit="$(SingleHit)"
       MergeWith="$(MergeWith)"
       UseSourceLink="$(UseSourceLink)" />

--- a/test/coverlet.core.tests/CoverageTests.cs
+++ b/test/coverlet.core.tests/CoverageTests.cs
@@ -31,5 +31,28 @@ namespace Coverlet.Core.Tests
 
             directory.Delete(true);
         }
+
+        [Fact]
+        public void TestCoverageWithTestAssembly()
+        {
+            string module = GetType().Assembly.Location;
+            string pdb = Path.Combine(Path.GetDirectoryName(module), Path.GetFileNameWithoutExtension(module) + ".pdb");
+
+            var directory = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString()));
+
+            File.Copy(module, Path.Combine(directory.FullName, Path.GetFileName(module)), true);
+            File.Copy(pdb, Path.Combine(directory.FullName, Path.GetFileName(pdb)), true);
+
+            // TODO: Find a way to mimick hits
+
+            var coverage = new Coverage(Path.Combine(directory.FullName, Path.GetFileName(module)), Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>(), true, false, string.Empty, false, new Mock<ILogger>().Object);
+            coverage.PrepareModules();
+
+            var result = coverage.GetCoverageResult();
+
+            Assert.NotEmpty(result.Modules);
+
+            directory.Delete(true);
+        }
     }
 }

--- a/test/coverlet.core.tests/CoverageTests.cs
+++ b/test/coverlet.core.tests/CoverageTests.cs
@@ -22,12 +22,12 @@ namespace Coverlet.Core.Tests
 
             // TODO: Find a way to mimick hits
 
-            var coverage = new Coverage(Path.Combine(directory.FullName, Path.GetFileName(module)), Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>(), false, string.Empty, false, new Mock<ILogger>().Object);
+            var coverage = new Coverage(Path.Combine(directory.FullName, Path.GetFileName(module)), Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>(), false, false, string.Empty, false, new Mock<ILogger>().Object);
             coverage.PrepareModules();
 
             var result = coverage.GetCoverageResult();
 
-            Assert.NotEmpty(result.Modules);
+            Assert.Empty(result.Modules);
 
             directory.Delete(true);
         }

--- a/test/coverlet.core.tests/Helpers/InstrumentationHelperTests.cs
+++ b/test/coverlet.core.tests/Helpers/InstrumentationHelperTests.cs
@@ -17,6 +17,14 @@ namespace Coverlet.Core.Helpers.Tests
         }
 
         [Fact]
+        public void TestGetDependenciesWithTestAssembly()
+        {
+            string module = typeof(InstrumentationHelperTests).Assembly.Location;
+            var modules = InstrumentationHelper.GetCoverableModules(module, Array.Empty<string>(), true);
+            Assert.True(Array.Exists(modules, m => m == module));
+        }
+
+        [Fact]
         public void TestHasPdb()
         {
             Assert.True(InstrumentationHelper.HasPdb(typeof(InstrumentationHelperTests).Assembly.Location));

--- a/test/coverlet.core.tests/Helpers/InstrumentationHelperTests.cs
+++ b/test/coverlet.core.tests/Helpers/InstrumentationHelperTests.cs
@@ -12,8 +12,8 @@ namespace Coverlet.Core.Helpers.Tests
         public void TestGetDependencies()
         {
             string module = typeof(InstrumentationHelperTests).Assembly.Location;
-            var modules = InstrumentationHelper.GetCoverableModules(module, Array.Empty<string>());
-            Assert.True(Array.Exists(modules, m => m == module));
+            var modules = InstrumentationHelper.GetCoverableModules(module, Array.Empty<string>(), false);
+            Assert.False(Array.Exists(modules, m => m == module));
         }
 
         [Fact]
@@ -235,16 +235,16 @@ namespace Coverlet.Core.Helpers.Tests
             string module = typeof(InstrumentationHelperTests).Assembly.Location;
 
             var currentDirModules = InstrumentationHelper.GetCoverableModules(module,
-                new[] { Environment.CurrentDirectory });
+                new[] { Environment.CurrentDirectory }, false);
 
             var parentDirWildcardModules = InstrumentationHelper.GetCoverableModules(module,
-                new[] { Path.Combine(Directory.GetParent(Environment.CurrentDirectory).FullName, "*") });
+                new[] { Path.Combine(Directory.GetParent(Environment.CurrentDirectory).FullName, "*") }, false);
 
             // There are at least as many modules found when searching the parent directory's subdirectories
             Assert.True(parentDirWildcardModules.Length >= currentDirModules.Length);
 
             var relativePathModules = InstrumentationHelper.GetCoverableModules(module,
-                new[] { "." });
+                new[] { "." }, false);
 
             // Same number of modules found when using a relative path
             Assert.Equal(currentDirModules.Length, relativePathModules.Length);


### PR DESCRIPTION
You can now set `IncludeTestAssembly` (MSBuild) or `--include-test-assembly` (Global Tool) to `true` include coverage for the test assembly. It is `false` by default

Fixes #372 