### PR TITLE
Coverage percentage output value rounded down with max 2 decimal precision

### DIFF
--- a/src/coverlet.console/Program.cs
+++ b/src/coverlet.console/Program.cs
@@ -156,15 +156,15 @@ namespace Coverlet.Console
                 var summary = new CoverageSummary();
                 int numModules = result.Modules.Count;
 
-                var totalLinePercent = summary.CalculateLineCoverage(result.Modules).Percent * 100;
-                var totalBranchPercent = summary.CalculateBranchCoverage(result.Modules).Percent * 100;
-                var totalMethodPercent = summary.CalculateMethodCoverage(result.Modules).Percent * 100;
+                var totalLinePercent = summary.CalculateLineCoverage(result.Modules).GetCoveragePercentage();
+                var totalBranchPercent = summary.CalculateBranchCoverage(result.Modules).GetCoveragePercentage();
+                var totalMethodPercent = summary.CalculateMethodCoverage(result.Modules).GetCoveragePercentage();
 
                 foreach (var _module in result.Modules)
                 {
-                    var linePercent = summary.CalculateLineCoverage(_module.Value).Percent * 100;
-                    var branchPercent = summary.CalculateBranchCoverage(_module.Value).Percent * 100;
-                    var methodPercent = summary.CalculateMethodCoverage(_module.Value).Percent * 100;
+                    var linePercent = summary.CalculateLineCoverage(_module.Value).GetCoveragePercentage();
+                    var branchPercent = summary.CalculateBranchCoverage(_module.Value).GetCoveragePercentage();
+                    var methodPercent = summary.CalculateMethodCoverage(_module.Value).GetCoveragePercentage();
 
                     coverageTable.AddRow(Path.GetFileNameWithoutExtension(_module.Key), $"{linePercent}%", $"{branchPercent}%", $"{methodPercent}%");
                 }

--- a/src/coverlet.console/Program.cs
+++ b/src/coverlet.console/Program.cs
@@ -156,15 +156,15 @@ namespace Coverlet.Console
                 var summary = new CoverageSummary();
                 int numModules = result.Modules.Count;
 
-                var totalLinePercent = summary.CalculateLineCoverage(result.Modules).GetCoveragePercentage();
-                var totalBranchPercent = summary.CalculateBranchCoverage(result.Modules).GetCoveragePercentage();
-                var totalMethodPercent = summary.CalculateMethodCoverage(result.Modules).GetCoveragePercentage();
+                var totalLinePercent = summary.CalculateLineCoverage(result.Modules).Percent;
+                var totalBranchPercent = summary.CalculateBranchCoverage(result.Modules).Percent;
+                var totalMethodPercent = summary.CalculateMethodCoverage(result.Modules).Percent;
 
                 foreach (var _module in result.Modules)
                 {
-                    var linePercent = summary.CalculateLineCoverage(_module.Value).GetCoveragePercentage();
-                    var branchPercent = summary.CalculateBranchCoverage(_module.Value).GetCoveragePercentage();
-                    var methodPercent = summary.CalculateMethodCoverage(_module.Value).GetCoveragePercentage();
+                    var linePercent = summary.CalculateLineCoverage(_module.Value).Percent;
+                    var branchPercent = summary.CalculateBranchCoverage(_module.Value).Percent;
+                    var methodPercent = summary.CalculateMethodCoverage(_module.Value).Percent;
 
                     coverageTable.AddRow(Path.GetFileNameWithoutExtension(_module.Key), $"{linePercent}%", $"{branchPercent}%", $"{methodPercent}%");
                 }

--- a/src/coverlet.core/CoverageDetails.cs
+++ b/src/coverlet.core/CoverageDetails.cs
@@ -6,6 +6,6 @@ namespace Coverlet.Core
     {
         public double Covered { get; internal set; }
         public int Total { get; internal set; }
-        public double Percent => Total == 0 ? 1D : Math.Floor((Covered / Total) * 10000) / 100;
+        public double Percent => Total == 0 ? 100D : Math.Floor((Covered / Total) * 10000) / 100;
     }
 }

--- a/src/coverlet.core/CoverageDetails.cs
+++ b/src/coverlet.core/CoverageDetails.cs
@@ -8,7 +8,18 @@ namespace Coverlet.Core
         public int Total { get; internal set; }
         public double Percent
         {
-            get => Math.Round(Total == 0 ? 1 : Covered / Total, 3);
+            get => Math.Round(Total == 0 ? 1 : Covered / Total, 4);
+        }
+
+        public double GetCoveragePercentage()
+        {
+            double percentage = Percent * 100;
+            return RoundDown(percentage);
+        }
+
+        private double RoundDown(double percentage)
+        {
+            return Math.Floor(percentage * 100) / 100;
         }
     }
 }

--- a/src/coverlet.core/CoverageDetails.cs
+++ b/src/coverlet.core/CoverageDetails.cs
@@ -6,20 +6,6 @@ namespace Coverlet.Core
     {
         public double Covered { get; internal set; }
         public int Total { get; internal set; }
-        public double Percent
-        {
-            get => Math.Round(Total == 0 ? 1 : Covered / Total, 4);
-        }
-
-        public double GetCoveragePercentage()
-        {
-            double percentage = Percent * 100;
-            return RoundDown(percentage);
-        }
-
-        private double RoundDown(double percentage)
-        {
-            return Math.Floor(percentage * 100) / 100;
-        }
+        public double Percent => Total == 0 ? 1D : Math.Floor((Covered / Total) * 10000) / 100;
     }
 }

--- a/src/coverlet.core/CoverageResult.cs
+++ b/src/coverlet.core/CoverageResult.cs
@@ -170,9 +170,9 @@ namespace Coverlet.Core
                     {
                         foreach (var module in Modules)
                         {
-                            var line = summary.CalculateLineCoverage(module.Value).Percent * 100;
-                            var branch = summary.CalculateBranchCoverage(module.Value).Percent * 100;
-                            var method = summary.CalculateMethodCoverage(module.Value).Percent * 100;
+                            var line = summary.CalculateLineCoverage(module.Value).GetCoveragePercentage();
+                            var branch = summary.CalculateBranchCoverage(module.Value).GetCoveragePercentage();
+                            var method = summary.CalculateMethodCoverage(module.Value).GetCoveragePercentage();
 
                             if ((thresholdTypes & ThresholdTypeFlags.Line) != ThresholdTypeFlags.None)
                             {
@@ -203,9 +203,9 @@ namespace Coverlet.Core
 
                         foreach (var module in Modules)
                         {
-                            line += summary.CalculateLineCoverage(module.Value).Percent * 100;
-                            branch += summary.CalculateBranchCoverage(module.Value).Percent * 100;
-                            method += summary.CalculateMethodCoverage(module.Value).Percent * 100;
+                            line += summary.CalculateLineCoverage(module.Value).GetCoveragePercentage();
+                            branch += summary.CalculateBranchCoverage(module.Value).GetCoveragePercentage();
+                            method += summary.CalculateMethodCoverage(module.Value).GetCoveragePercentage();
                         }
 
                         if ((thresholdTypes & ThresholdTypeFlags.Line) != ThresholdTypeFlags.None)
@@ -229,9 +229,9 @@ namespace Coverlet.Core
                     break;
                 case ThresholdStatistic.Total:
                     {
-                        var line = summary.CalculateLineCoverage(Modules).Percent * 100;
-                        var branch = summary.CalculateBranchCoverage(Modules).Percent * 100;
-                        var method = summary.CalculateMethodCoverage(Modules).Percent * 100;
+                        var line = summary.CalculateLineCoverage(Modules).GetCoveragePercentage();
+                        var branch = summary.CalculateBranchCoverage(Modules).GetCoveragePercentage();
+                        var method = summary.CalculateMethodCoverage(Modules).GetCoveragePercentage();
 
                         if ((thresholdTypes & ThresholdTypeFlags.Line) != ThresholdTypeFlags.None)
                         {

--- a/src/coverlet.core/CoverageResult.cs
+++ b/src/coverlet.core/CoverageResult.cs
@@ -170,9 +170,9 @@ namespace Coverlet.Core
                     {
                         foreach (var module in Modules)
                         {
-                            var line = summary.CalculateLineCoverage(module.Value).GetCoveragePercentage();
-                            var branch = summary.CalculateBranchCoverage(module.Value).GetCoveragePercentage();
-                            var method = summary.CalculateMethodCoverage(module.Value).GetCoveragePercentage();
+                            var line = summary.CalculateLineCoverage(module.Value).Percent;
+                            var branch = summary.CalculateBranchCoverage(module.Value).Percent;
+                            var method = summary.CalculateMethodCoverage(module.Value).Percent;
 
                             if ((thresholdTypes & ThresholdTypeFlags.Line) != ThresholdTypeFlags.None)
                             {
@@ -203,9 +203,9 @@ namespace Coverlet.Core
 
                         foreach (var module in Modules)
                         {
-                            line += summary.CalculateLineCoverage(module.Value).GetCoveragePercentage();
-                            branch += summary.CalculateBranchCoverage(module.Value).GetCoveragePercentage();
-                            method += summary.CalculateMethodCoverage(module.Value).GetCoveragePercentage();
+                            line += summary.CalculateLineCoverage(module.Value).Percent;
+                            branch += summary.CalculateBranchCoverage(module.Value).Percent;
+                            method += summary.CalculateMethodCoverage(module.Value).Percent;
                         }
 
                         if ((thresholdTypes & ThresholdTypeFlags.Line) != ThresholdTypeFlags.None)
@@ -229,9 +229,9 @@ namespace Coverlet.Core
                     break;
                 case ThresholdStatistic.Total:
                     {
-                        var line = summary.CalculateLineCoverage(Modules).GetCoveragePercentage();
-                        var branch = summary.CalculateBranchCoverage(Modules).GetCoveragePercentage();
-                        var method = summary.CalculateMethodCoverage(Modules).GetCoveragePercentage();
+                        var line = summary.CalculateLineCoverage(Modules).Percent;
+                        var branch = summary.CalculateBranchCoverage(Modules).Percent;
+                        var method = summary.CalculateMethodCoverage(Modules).Percent;
 
                         if ((thresholdTypes & ThresholdTypeFlags.Line) != ThresholdTypeFlags.None)
                         {

--- a/src/coverlet.core/Reporters/CoberturaReporter.cs
+++ b/src/coverlet.core/Reporters/CoberturaReporter.cs
@@ -82,7 +82,7 @@ namespace Coverlet.Core.Reporters
                                 {
                                     var branches = meth.Value.Branches.Where(b => b.Line == ln.Key).ToList();
                                     var branchInfoCoverage = summary.CalculateBranchCoverage(branches);
-                                    line.Add(new XAttribute("condition-coverage", $"{branchInfoCoverage.Percent * 100}% ({branchInfoCoverage.Covered}/{branchInfoCoverage.Total})"));
+                                    line.Add(new XAttribute("condition-coverage", $"{branchInfoCoverage.GetCoveragePercentage()}% ({branchInfoCoverage.Covered}/{branchInfoCoverage.Total})"));
                                     XElement conditions = new XElement("conditions");
                                     var byOffset = branches.GroupBy(b => b.Offset).ToDictionary(b => b.Key, b => b.ToList());
                                     foreach (var entry in byOffset)
@@ -90,7 +90,7 @@ namespace Coverlet.Core.Reporters
                                         XElement condition = new XElement("condition");
                                         condition.Add(new XAttribute("number", entry.Key));
                                         condition.Add(new XAttribute("type", entry.Value.Count() > 2 ? "switch" : "jump")); // Just guessing here
-                                        condition.Add(new XAttribute("coverage", $"{summary.CalculateBranchCoverage(entry.Value).Percent * 100}%"));
+                                        condition.Add(new XAttribute("coverage", $"{summary.CalculateBranchCoverage(entry.Value).GetCoveragePercentage()}%"));
                                         conditions.Add(condition);
                                     }
 

--- a/src/coverlet.core/Reporters/CoberturaReporter.cs
+++ b/src/coverlet.core/Reporters/CoberturaReporter.cs
@@ -25,8 +25,8 @@ namespace Coverlet.Core.Reporters
 
             XDocument xml = new XDocument();
             XElement coverage = new XElement("coverage");
-            coverage.Add(new XAttribute("line-rate", summary.CalculateLineCoverage(result.Modules).Percent.ToString()));
-            coverage.Add(new XAttribute("branch-rate", summary.CalculateBranchCoverage(result.Modules).Percent.ToString()));
+            coverage.Add(new XAttribute("line-rate", (summary.CalculateLineCoverage(result.Modules).Percent / 100).ToString()));
+            coverage.Add(new XAttribute("branch-rate", (summary.CalculateLineCoverage(result.Modules).Percent / 100).ToString()));
             coverage.Add(new XAttribute("version", "1.9"));
             coverage.Add(new XAttribute("timestamp", ((int)(DateTime.UtcNow - new DateTime(1970, 1, 1)).TotalSeconds).ToString()));
 
@@ -38,8 +38,8 @@ namespace Coverlet.Core.Reporters
             {
                 XElement package = new XElement("package");
                 package.Add(new XAttribute("name", Path.GetFileNameWithoutExtension(module.Key)));
-                package.Add(new XAttribute("line-rate", summary.CalculateLineCoverage(module.Value).Percent.ToString()));
-                package.Add(new XAttribute("branch-rate", summary.CalculateBranchCoverage(module.Value).Percent.ToString()));
+                package.Add(new XAttribute("line-rate", (summary.CalculateLineCoverage(module.Value).Percent / 100).ToString()));
+                package.Add(new XAttribute("branch-rate", (summary.CalculateBranchCoverage(module.Value).Percent / 100).ToString()));
                 package.Add(new XAttribute("complexity", summary.CalculateCyclomaticComplexity(module.Value).ToString()));
 
                 XElement classes = new XElement("classes");
@@ -50,8 +50,8 @@ namespace Coverlet.Core.Reporters
                         XElement @class = new XElement("class");
                         @class.Add(new XAttribute("name", cls.Key));
                         @class.Add(new XAttribute("filename", document.Key));
-                        @class.Add(new XAttribute("line-rate", summary.CalculateLineCoverage(cls.Value).Percent.ToString()));
-                        @class.Add(new XAttribute("branch-rate", summary.CalculateBranchCoverage(cls.Value).Percent.ToString()));
+                        @class.Add(new XAttribute("line-rate", (summary.CalculateLineCoverage(cls.Value).Percent / 100).ToString()));
+                        @class.Add(new XAttribute("branch-rate", (summary.CalculateBranchCoverage(cls.Value).Percent / 100).ToString()));
                         @class.Add(new XAttribute("complexity", summary.CalculateCyclomaticComplexity(cls.Value).ToString()));
 
                         XElement classLines = new XElement("lines");
@@ -66,8 +66,8 @@ namespace Coverlet.Core.Reporters
                             XElement method = new XElement("method");
                             method.Add(new XAttribute("name", meth.Key.Split(':')[2].Split('(')[0]));
                             method.Add(new XAttribute("signature", "(" + meth.Key.Split(':')[2].Split('(')[1]));
-                            method.Add(new XAttribute("line-rate", summary.CalculateLineCoverage(meth.Value.Lines).Percent.ToString()));
-                            method.Add(new XAttribute("branch-rate", summary.CalculateBranchCoverage(meth.Value.Branches).Percent.ToString()));
+                            method.Add(new XAttribute("line-rate", (summary.CalculateLineCoverage(meth.Value.Lines).Percent / 100).ToString()));
+                            method.Add(new XAttribute("branch-rate", (summary.CalculateBranchCoverage(meth.Value.Branches).Percent / 100).ToString()));
 
                             XElement lines = new XElement("lines");
                             foreach (var ln in meth.Value.Lines)
@@ -82,7 +82,7 @@ namespace Coverlet.Core.Reporters
                                 {
                                     var branches = meth.Value.Branches.Where(b => b.Line == ln.Key).ToList();
                                     var branchInfoCoverage = summary.CalculateBranchCoverage(branches);
-                                    line.Add(new XAttribute("condition-coverage", $"{branchInfoCoverage.GetCoveragePercentage()}% ({branchInfoCoverage.Covered}/{branchInfoCoverage.Total})"));
+                                    line.Add(new XAttribute("condition-coverage", $"{branchInfoCoverage.Percent}% ({branchInfoCoverage.Covered}/{branchInfoCoverage.Total})"));
                                     XElement conditions = new XElement("conditions");
                                     var byOffset = branches.GroupBy(b => b.Offset).ToDictionary(b => b.Key, b => b.ToList());
                                     foreach (var entry in byOffset)
@@ -90,7 +90,7 @@ namespace Coverlet.Core.Reporters
                                         XElement condition = new XElement("condition");
                                         condition.Add(new XAttribute("number", entry.Key));
                                         condition.Add(new XAttribute("type", entry.Value.Count() > 2 ? "switch" : "jump")); // Just guessing here
-                                        condition.Add(new XAttribute("coverage", $"{summary.CalculateBranchCoverage(entry.Value).GetCoveragePercentage()}%"));
+                                        condition.Add(new XAttribute("coverage", $"{summary.CalculateBranchCoverage(entry.Value).Percent}%"));
                                         conditions.Add(condition);
                                     }
 

--- a/src/coverlet.core/Reporters/CoberturaReporter.cs
+++ b/src/coverlet.core/Reporters/CoberturaReporter.cs
@@ -26,7 +26,7 @@ namespace Coverlet.Core.Reporters
             XDocument xml = new XDocument();
             XElement coverage = new XElement("coverage");
             coverage.Add(new XAttribute("line-rate", (summary.CalculateLineCoverage(result.Modules).Percent / 100).ToString()));
-            coverage.Add(new XAttribute("branch-rate", (summary.CalculateLineCoverage(result.Modules).Percent / 100).ToString()));
+            coverage.Add(new XAttribute("branch-rate", (summary.CalculateBranchCoverage(result.Modules).Percent / 100).ToString()));
             coverage.Add(new XAttribute("version", "1.9"));
             coverage.Add(new XAttribute("timestamp", ((int)(DateTime.UtcNow - new DateTime(1970, 1, 1)).TotalSeconds).ToString()));
 

--- a/src/coverlet.core/Reporters/OpenCoverReporter.cs
+++ b/src/coverlet.core/Reporters/OpenCoverReporter.cs
@@ -77,8 +77,8 @@ namespace Coverlet.Core.Reporters
 
                             method.Add(new XAttribute("cyclomaticComplexity", methCyclomaticComplexity.ToString()));
                             method.Add(new XAttribute("nPathComplexity", "0"));
-                            method.Add(new XAttribute("sequenceCoverage", Math.Round(methLineCoverage.Percent * 100, 2).ToString("G", CultureInfo.InvariantCulture)));
-                            method.Add(new XAttribute("branchCoverage", Math.Round(methBranchCoverage.Percent * 100, 2).ToString("G", CultureInfo.InvariantCulture)));
+                            method.Add(new XAttribute("sequenceCoverage", methLineCoverage.GetCoveragePercentage().ToString("G", CultureInfo.InvariantCulture)));
+                            method.Add(new XAttribute("branchCoverage", methBranchCoverage.GetCoveragePercentage().ToString("G", CultureInfo.InvariantCulture)));
                             method.Add(new XAttribute("isConstructor", meth.Key.Contains("ctor").ToString()));
                             method.Add(new XAttribute("isGetter", meth.Key.Contains("get_").ToString()));
                             method.Add(new XAttribute("isSetter", meth.Key.Contains("set_").ToString()));
@@ -158,8 +158,8 @@ namespace Coverlet.Core.Reporters
                             methodSummary.Add(new XAttribute("visitedSequencePoints", methLineCoverage.Covered.ToString()));
                             methodSummary.Add(new XAttribute("numBranchPoints", methBranchCoverage.Total.ToString()));
                             methodSummary.Add(new XAttribute("visitedBranchPoints", methBranchCoverage.Covered.ToString()));
-                            methodSummary.Add(new XAttribute("sequenceCoverage", Math.Round(methLineCoverage.Percent * 100, 2).ToString("G", CultureInfo.InvariantCulture)));
-                            methodSummary.Add(new XAttribute("branchCoverage", Math.Round(methBranchCoverage.Percent * 100, 2).ToString("G", CultureInfo.InvariantCulture)));
+                            methodSummary.Add(new XAttribute("sequenceCoverage", methLineCoverage.GetCoveragePercentage().ToString("G", CultureInfo.InvariantCulture)));
+                            methodSummary.Add(new XAttribute("branchCoverage", methBranchCoverage.GetCoveragePercentage().ToString("G", CultureInfo.InvariantCulture)));
                             methodSummary.Add(new XAttribute("maxCyclomaticComplexity", methCyclomaticComplexity.ToString()));
                             methodSummary.Add(new XAttribute("minCyclomaticComplexity", methCyclomaticComplexity.ToString()));
                             methodSummary.Add(new XAttribute("visitedClasses", "0"));
@@ -192,8 +192,8 @@ namespace Coverlet.Core.Reporters
                         classSummary.Add(new XAttribute("visitedSequencePoints", classLineCoverage.Covered.ToString()));
                         classSummary.Add(new XAttribute("numBranchPoints", classBranchCoverage.Total.ToString()));
                         classSummary.Add(new XAttribute("visitedBranchPoints", classBranchCoverage.Covered.ToString()));
-                        classSummary.Add(new XAttribute("sequenceCoverage", Math.Round(classLineCoverage.Percent * 100, 2).ToString("G", CultureInfo.InvariantCulture)));
-                        classSummary.Add(new XAttribute("branchCoverage", Math.Round(classBranchCoverage.Percent * 100, 2).ToString("G", CultureInfo.InvariantCulture)));
+                        classSummary.Add(new XAttribute("sequenceCoverage", classLineCoverage.GetCoveragePercentage().ToString("G", CultureInfo.InvariantCulture)));
+                        classSummary.Add(new XAttribute("branchCoverage", classBranchCoverage.GetCoveragePercentage().ToString("G", CultureInfo.InvariantCulture)));
                         classSummary.Add(new XAttribute("maxCyclomaticComplexity", classMaxCyclomaticComplexity.ToString()));
                         classSummary.Add(new XAttribute("minCyclomaticComplexity", classMinCyclomaticComplexity.ToString()));
                         classSummary.Add(new XAttribute("visitedClasses", classVisited ? "1" : "0"));
@@ -223,8 +223,8 @@ namespace Coverlet.Core.Reporters
             coverageSummary.Add(new XAttribute("visitedSequencePoints", moduleLineCoverage.Covered.ToString()));
             coverageSummary.Add(new XAttribute("numBranchPoints", moduleBranchCoverage.Total.ToString()));
             coverageSummary.Add(new XAttribute("visitedBranchPoints", moduleBranchCoverage.Covered.ToString()));
-            coverageSummary.Add(new XAttribute("sequenceCoverage", Math.Round(moduleLineCoverage.Percent * 100, 2).ToString("G", CultureInfo.InvariantCulture)));
-            coverageSummary.Add(new XAttribute("branchCoverage", Math.Round(moduleBranchCoverage.Percent * 100, 2).ToString("G", CultureInfo.InvariantCulture)));
+            coverageSummary.Add(new XAttribute("sequenceCoverage", moduleLineCoverage.GetCoveragePercentage().ToString("G", CultureInfo.InvariantCulture)));
+            coverageSummary.Add(new XAttribute("branchCoverage", moduleBranchCoverage.GetCoveragePercentage().ToString("G", CultureInfo.InvariantCulture)));
             coverageSummary.Add(new XAttribute("maxCyclomaticComplexity", moduleMaxCyclomaticComplexity.ToString()));
             coverageSummary.Add(new XAttribute("minCyclomaticComplexity", moduleMinCyclomaticComplexity.ToString()));
             coverageSummary.Add(new XAttribute("visitedClasses", visitedClasses.ToString()));

--- a/src/coverlet.core/Reporters/OpenCoverReporter.cs
+++ b/src/coverlet.core/Reporters/OpenCoverReporter.cs
@@ -77,8 +77,8 @@ namespace Coverlet.Core.Reporters
 
                             method.Add(new XAttribute("cyclomaticComplexity", methCyclomaticComplexity.ToString()));
                             method.Add(new XAttribute("nPathComplexity", "0"));
-                            method.Add(new XAttribute("sequenceCoverage", methLineCoverage.GetCoveragePercentage().ToString("G", CultureInfo.InvariantCulture)));
-                            method.Add(new XAttribute("branchCoverage", methBranchCoverage.GetCoveragePercentage().ToString("G", CultureInfo.InvariantCulture)));
+                            method.Add(new XAttribute("sequenceCoverage", methLineCoverage.Percent.ToString("G", CultureInfo.InvariantCulture)));
+                            method.Add(new XAttribute("branchCoverage", methBranchCoverage.Percent.ToString("G", CultureInfo.InvariantCulture)));
                             method.Add(new XAttribute("isConstructor", meth.Key.Contains("ctor").ToString()));
                             method.Add(new XAttribute("isGetter", meth.Key.Contains("get_").ToString()));
                             method.Add(new XAttribute("isSetter", meth.Key.Contains("set_").ToString()));
@@ -158,8 +158,8 @@ namespace Coverlet.Core.Reporters
                             methodSummary.Add(new XAttribute("visitedSequencePoints", methLineCoverage.Covered.ToString()));
                             methodSummary.Add(new XAttribute("numBranchPoints", methBranchCoverage.Total.ToString()));
                             methodSummary.Add(new XAttribute("visitedBranchPoints", methBranchCoverage.Covered.ToString()));
-                            methodSummary.Add(new XAttribute("sequenceCoverage", methLineCoverage.GetCoveragePercentage().ToString("G", CultureInfo.InvariantCulture)));
-                            methodSummary.Add(new XAttribute("branchCoverage", methBranchCoverage.GetCoveragePercentage().ToString("G", CultureInfo.InvariantCulture)));
+                            methodSummary.Add(new XAttribute("sequenceCoverage", methLineCoverage.Percent.ToString("G", CultureInfo.InvariantCulture)));
+                            methodSummary.Add(new XAttribute("branchCoverage", methBranchCoverage.Percent.ToString("G", CultureInfo.InvariantCulture)));
                             methodSummary.Add(new XAttribute("maxCyclomaticComplexity", methCyclomaticComplexity.ToString()));
                             methodSummary.Add(new XAttribute("minCyclomaticComplexity", methCyclomaticComplexity.ToString()));
                             methodSummary.Add(new XAttribute("visitedClasses", "0"));
@@ -192,8 +192,8 @@ namespace Coverlet.Core.Reporters
                         classSummary.Add(new XAttribute("visitedSequencePoints", classLineCoverage.Covered.ToString()));
                         classSummary.Add(new XAttribute("numBranchPoints", classBranchCoverage.Total.ToString()));
                         classSummary.Add(new XAttribute("visitedBranchPoints", classBranchCoverage.Covered.ToString()));
-                        classSummary.Add(new XAttribute("sequenceCoverage", classLineCoverage.GetCoveragePercentage().ToString("G", CultureInfo.InvariantCulture)));
-                        classSummary.Add(new XAttribute("branchCoverage", classBranchCoverage.GetCoveragePercentage().ToString("G", CultureInfo.InvariantCulture)));
+                        classSummary.Add(new XAttribute("sequenceCoverage", classLineCoverage.Percent.ToString("G", CultureInfo.InvariantCulture)));
+                        classSummary.Add(new XAttribute("branchCoverage", classBranchCoverage.Percent.ToString("G", CultureInfo.InvariantCulture)));
                         classSummary.Add(new XAttribute("maxCyclomaticComplexity", classMaxCyclomaticComplexity.ToString()));
                         classSummary.Add(new XAttribute("minCyclomaticComplexity", classMinCyclomaticComplexity.ToString()));
                         classSummary.Add(new XAttribute("visitedClasses", classVisited ? "1" : "0"));
@@ -223,8 +223,8 @@ namespace Coverlet.Core.Reporters
             coverageSummary.Add(new XAttribute("visitedSequencePoints", moduleLineCoverage.Covered.ToString()));
             coverageSummary.Add(new XAttribute("numBranchPoints", moduleBranchCoverage.Total.ToString()));
             coverageSummary.Add(new XAttribute("visitedBranchPoints", moduleBranchCoverage.Covered.ToString()));
-            coverageSummary.Add(new XAttribute("sequenceCoverage", moduleLineCoverage.GetCoveragePercentage().ToString("G", CultureInfo.InvariantCulture)));
-            coverageSummary.Add(new XAttribute("branchCoverage", moduleBranchCoverage.GetCoveragePercentage().ToString("G", CultureInfo.InvariantCulture)));
+            coverageSummary.Add(new XAttribute("sequenceCoverage", moduleLineCoverage.Percent.ToString("G", CultureInfo.InvariantCulture)));
+            coverageSummary.Add(new XAttribute("branchCoverage", moduleBranchCoverage.Percent.ToString("G", CultureInfo.InvariantCulture)));
             coverageSummary.Add(new XAttribute("maxCyclomaticComplexity", moduleMaxCyclomaticComplexity.ToString()));
             coverageSummary.Add(new XAttribute("minCyclomaticComplexity", moduleMinCyclomaticComplexity.ToString()));
             coverageSummary.Add(new XAttribute("visitedClasses", visitedClasses.ToString()));

--- a/src/coverlet.core/Reporters/TeamCityReporter.cs
+++ b/src/coverlet.core/Reporters/TeamCityReporter.cs
@@ -34,7 +34,7 @@ namespace Coverlet.Core.Reporters
         private void OutputLineCoverage(CoverageDetails coverageDetails, StringBuilder builder)
         {
             // The total number of lines
-            OutputTeamCityServiceMessage("CodeCoverageL", coverageDetails.GetCoveragePercentage(), builder);
+            OutputTeamCityServiceMessage("CodeCoverageL", coverageDetails.Percent, builder);
 
             // The number of covered lines
             OutputTeamCityServiceMessage("CodeCoverageAbsLCovered", coverageDetails.Covered, builder);
@@ -46,7 +46,7 @@ namespace Coverlet.Core.Reporters
         private void OutputBranchCoverage(CoverageDetails coverageDetails, StringBuilder builder)
         {
             // The total number of branches
-            OutputTeamCityServiceMessage("CodeCoverageR", coverageDetails.GetCoveragePercentage(), builder);
+            OutputTeamCityServiceMessage("CodeCoverageR", coverageDetails.Percent, builder);
 
             // The number of covered branches
             OutputTeamCityServiceMessage("CodeCoverageAbsRCovered", coverageDetails.Covered, builder);
@@ -58,7 +58,7 @@ namespace Coverlet.Core.Reporters
         private void OutputMethodCoverage(CoverageDetails coverageDetails, StringBuilder builder)
         {
             // The total number of methods
-            OutputTeamCityServiceMessage("CodeCoverageM", coverageDetails.GetCoveragePercentage(), builder);
+            OutputTeamCityServiceMessage("CodeCoverageM", coverageDetails.Percent, builder);
 
             // The number of covered methods
             OutputTeamCityServiceMessage("CodeCoverageAbsMCovered", coverageDetails.Covered, builder);

--- a/src/coverlet.core/Reporters/TeamCityReporter.cs
+++ b/src/coverlet.core/Reporters/TeamCityReporter.cs
@@ -34,7 +34,7 @@ namespace Coverlet.Core.Reporters
         private void OutputLineCoverage(CoverageDetails coverageDetails, StringBuilder builder)
         {
             // The total number of lines
-            OutputTeamCityServiceMessage("CodeCoverageL", coverageDetails.Percent * 100, builder);
+            OutputTeamCityServiceMessage("CodeCoverageL", coverageDetails.GetCoveragePercentage(), builder);
 
             // The number of covered lines
             OutputTeamCityServiceMessage("CodeCoverageAbsLCovered", coverageDetails.Covered, builder);
@@ -46,7 +46,7 @@ namespace Coverlet.Core.Reporters
         private void OutputBranchCoverage(CoverageDetails coverageDetails, StringBuilder builder)
         {
             // The total number of branches
-            OutputTeamCityServiceMessage("CodeCoverageR", coverageDetails.Percent * 100, builder);
+            OutputTeamCityServiceMessage("CodeCoverageR", coverageDetails.GetCoveragePercentage(), builder);
 
             // The number of covered branches
             OutputTeamCityServiceMessage("CodeCoverageAbsRCovered", coverageDetails.Covered, builder);
@@ -58,7 +58,7 @@ namespace Coverlet.Core.Reporters
         private void OutputMethodCoverage(CoverageDetails coverageDetails, StringBuilder builder)
         {
             // The total number of methods
-            OutputTeamCityServiceMessage("CodeCoverageM", coverageDetails.Percent * 100, builder);
+            OutputTeamCityServiceMessage("CodeCoverageM", coverageDetails.GetCoveragePercentage(), builder);
 
             // The number of covered methods
             OutputTeamCityServiceMessage("CodeCoverageAbsMCovered", coverageDetails.Covered, builder);

--- a/src/coverlet.msbuild.tasks/CoverageResultTask.cs
+++ b/src/coverlet.msbuild.tasks/CoverageResultTask.cs
@@ -139,15 +139,15 @@ namespace Coverlet.MSbuild.Tasks
                 var summary = new CoverageSummary();
                 int numModules = result.Modules.Count;
 
-                var totalLinePercent = summary.CalculateLineCoverage(result.Modules).Percent * 100;
-                var totalBranchPercent = summary.CalculateBranchCoverage(result.Modules).Percent * 100;
-                var totalMethodPercent = summary.CalculateMethodCoverage(result.Modules).Percent * 100;
+                var totalLinePercent = summary.CalculateLineCoverage(result.Modules).GetCoveragePercentage();
+                var totalBranchPercent = summary.CalculateBranchCoverage(result.Modules).GetCoveragePercentage();
+                var totalMethodPercent = summary.CalculateMethodCoverage(result.Modules).GetCoveragePercentage();
 
                 foreach (var module in result.Modules)
                 {
-                    var linePercent = summary.CalculateLineCoverage(module.Value).Percent * 100;
-                    var branchPercent = summary.CalculateBranchCoverage(module.Value).Percent * 100;
-                    var methodPercent = summary.CalculateMethodCoverage(module.Value).Percent * 100;
+                    var linePercent = summary.CalculateLineCoverage(module.Value).GetCoveragePercentage();
+                    var branchPercent = summary.CalculateBranchCoverage(module.Value).GetCoveragePercentage();
+                    var methodPercent = summary.CalculateMethodCoverage(module.Value).GetCoveragePercentage();
 
                     coverageTable.AddRow(Path.GetFileNameWithoutExtension(module.Key), $"{linePercent}%", $"{branchPercent}%", $"{methodPercent}%");
                 }

--- a/src/coverlet.msbuild.tasks/CoverageResultTask.cs
+++ b/src/coverlet.msbuild.tasks/CoverageResultTask.cs
@@ -139,15 +139,15 @@ namespace Coverlet.MSbuild.Tasks
                 var summary = new CoverageSummary();
                 int numModules = result.Modules.Count;
 
-                var totalLinePercent = summary.CalculateLineCoverage(result.Modules).GetCoveragePercentage();
-                var totalBranchPercent = summary.CalculateBranchCoverage(result.Modules).GetCoveragePercentage();
-                var totalMethodPercent = summary.CalculateMethodCoverage(result.Modules).GetCoveragePercentage();
+                var totalLinePercent = summary.CalculateLineCoverage(result.Modules).Percent;
+                var totalBranchPercent = summary.CalculateBranchCoverage(result.Modules).Percent;
+                var totalMethodPercent = summary.CalculateMethodCoverage(result.Modules).Percent;
 
                 foreach (var module in result.Modules)
                 {
-                    var linePercent = summary.CalculateLineCoverage(module.Value).GetCoveragePercentage();
-                    var branchPercent = summary.CalculateBranchCoverage(module.Value).GetCoveragePercentage();
-                    var methodPercent = summary.CalculateMethodCoverage(module.Value).GetCoveragePercentage();
+                    var linePercent = summary.CalculateLineCoverage(module.Value).Percent;
+                    var branchPercent = summary.CalculateBranchCoverage(module.Value).Percent;
+                    var methodPercent = summary.CalculateMethodCoverage(module.Value).Percent;
 
                     coverageTable.AddRow(Path.GetFileNameWithoutExtension(module.Key), $"{linePercent}%", $"{branchPercent}%", $"{methodPercent}%");
                 }

--- a/test/coverlet.core.tests/CoverageSummaryTests.cs
+++ b/test/coverlet.core.tests/CoverageSummaryTests.cs
@@ -85,10 +85,10 @@ namespace Coverlet.Core.Tests
             var @class = document.Value.First();
             var method = @class.Value.First();
 
-            Assert.Equal(0.5, summary.CalculateLineCoverage(module.Value).Percent);
-            Assert.Equal(0.5, summary.CalculateLineCoverage(document.Value).Percent);
-            Assert.Equal(0.5, summary.CalculateLineCoverage(@class.Value).Percent);
-            Assert.Equal(0.5, summary.CalculateLineCoverage(method.Value.Lines).Percent);
+            Assert.Equal(50, summary.CalculateLineCoverage(module.Value).Percent);
+            Assert.Equal(50, summary.CalculateLineCoverage(document.Value).Percent);
+            Assert.Equal(50, summary.CalculateLineCoverage(@class.Value).Percent);
+            Assert.Equal(50, summary.CalculateLineCoverage(method.Value.Lines).Percent);
         }
 
         [Fact]
@@ -101,10 +101,10 @@ namespace Coverlet.Core.Tests
             var @class = document.Value.First();
             var method = @class.Value.First();
 
-            Assert.Equal(1, summary.CalculateBranchCoverage(module.Value).Percent);
-            Assert.Equal(1, summary.CalculateBranchCoverage(document.Value).Percent);
-            Assert.Equal(1, summary.CalculateBranchCoverage(@class.Value).Percent);
-            Assert.Equal(1, summary.CalculateBranchCoverage(method.Value.Branches).Percent);
+            Assert.Equal(100, summary.CalculateBranchCoverage(module.Value).Percent);
+            Assert.Equal(100, summary.CalculateBranchCoverage(document.Value).Percent);
+            Assert.Equal(100, summary.CalculateBranchCoverage(@class.Value).Percent);
+            Assert.Equal(100, summary.CalculateBranchCoverage(method.Value.Branches).Percent);
         }
 
         [Fact]
@@ -117,58 +117,10 @@ namespace Coverlet.Core.Tests
             var @class = document.Value.First();
             var method = @class.Value.First();
 
-            Assert.Equal(1, summary.CalculateMethodCoverage(module.Value).Percent);
-            Assert.Equal(1, summary.CalculateMethodCoverage(document.Value).Percent);
-            Assert.Equal(1, summary.CalculateMethodCoverage(@class.Value).Percent);
-            Assert.Equal(1, summary.CalculateMethodCoverage(method.Value.Lines).Percent);
-        }
-
-        [Fact]
-        public void TestCalculateLineCoveragePercentage()
-        {
-            CoverageSummary summary = new CoverageSummary();
-
-            var module = _modules.First();
-            var document = module.Value.First();
-            var @class = document.Value.First();
-            var method = @class.Value.First();
-
-            Assert.Equal(50, summary.CalculateLineCoverage(module.Value).GetCoveragePercentage());
-            Assert.Equal(50, summary.CalculateLineCoverage(document.Value).GetCoveragePercentage());
-            Assert.Equal(50, summary.CalculateLineCoverage(@class.Value).GetCoveragePercentage());
-            Assert.Equal(50, summary.CalculateLineCoverage(method.Value.Lines).GetCoveragePercentage());
-        }
-
-        [Fact]
-        public void TestCalculateBranchCoveragePercentage()
-        {
-            CoverageSummary summary = new CoverageSummary();
-
-            var module = _modules.First();
-            var document = module.Value.First();
-            var @class = document.Value.First();
-            var method = @class.Value.First();
-
-            Assert.Equal(100, summary.CalculateBranchCoverage(module.Value).GetCoveragePercentage());
-            Assert.Equal(100, summary.CalculateBranchCoverage(document.Value).GetCoveragePercentage());
-            Assert.Equal(100, summary.CalculateBranchCoverage(@class.Value).GetCoveragePercentage());
-            Assert.Equal(100, summary.CalculateBranchCoverage(method.Value.Branches).GetCoveragePercentage());
-        }
-
-        [Fact]
-        public void TestCalculateMethodCoveragePercentage()
-        {
-            CoverageSummary summary = new CoverageSummary();
-
-            var module = _modules.First();
-            var document = module.Value.First();
-            var @class = document.Value.First();
-            var method = @class.Value.First();
-
-            Assert.Equal(100, summary.CalculateMethodCoverage(module.Value).GetCoveragePercentage());
-            Assert.Equal(100, summary.CalculateMethodCoverage(document.Value).GetCoveragePercentage());
-            Assert.Equal(100, summary.CalculateMethodCoverage(@class.Value).GetCoveragePercentage());
-            Assert.Equal(100, summary.CalculateMethodCoverage(method.Value.Lines).GetCoveragePercentage());
+            Assert.Equal(100, summary.CalculateMethodCoverage(module.Value).Percent);
+            Assert.Equal(100, summary.CalculateMethodCoverage(document.Value).Percent);
+            Assert.Equal(100, summary.CalculateMethodCoverage(@class.Value).Percent);
+            Assert.Equal(100, summary.CalculateMethodCoverage(method.Value.Lines).Percent);
         }
 
         [Fact]
@@ -181,10 +133,10 @@ namespace Coverlet.Core.Tests
             var @class = document.Value.First();
             var method = @class.Value.First();
 
-            Assert.Equal(16.66, summary.CalculateLineCoverage(module.Value).GetCoveragePercentage());
-            Assert.Equal(16.66, summary.CalculateLineCoverage(document.Value).GetCoveragePercentage());
-            Assert.Equal(16.66, summary.CalculateLineCoverage(@class.Value).GetCoveragePercentage());
-            Assert.Equal(16.66, summary.CalculateLineCoverage(method.Value.Lines).GetCoveragePercentage());
+            Assert.Equal(16.66, summary.CalculateLineCoverage(module.Value).Percent);
+            Assert.Equal(16.66, summary.CalculateLineCoverage(document.Value).Percent);
+            Assert.Equal(16.66, summary.CalculateLineCoverage(@class.Value).Percent);
+            Assert.Equal(16.66, summary.CalculateLineCoverage(method.Value.Lines).Percent);
         }
 
         [Fact]
@@ -197,10 +149,10 @@ namespace Coverlet.Core.Tests
             var @class = document.Value.First();
             var method = @class.Value.First();
 
-            Assert.Equal(16.66, summary.CalculateBranchCoverage(module.Value).GetCoveragePercentage());
-            Assert.Equal(16.66, summary.CalculateBranchCoverage(document.Value).GetCoveragePercentage());
-            Assert.Equal(16.66, summary.CalculateBranchCoverage(@class.Value).GetCoveragePercentage());
-            Assert.Equal(16.66, summary.CalculateBranchCoverage(method.Value.Branches).GetCoveragePercentage());
+            Assert.Equal(16.66, summary.CalculateBranchCoverage(module.Value).Percent);
+            Assert.Equal(16.66, summary.CalculateBranchCoverage(document.Value).Percent);
+            Assert.Equal(16.66, summary.CalculateBranchCoverage(@class.Value).Percent);
+            Assert.Equal(16.66, summary.CalculateBranchCoverage(method.Value.Branches).Percent);
         }
     }
 }

--- a/test/coverlet.core.tests/CoverageSummaryTests.cs
+++ b/test/coverlet.core.tests/CoverageSummaryTests.cs
@@ -11,8 +11,46 @@ namespace Coverlet.Core.Tests
     public class CoverageSummaryTests
     {
         private Modules _modules;
+        private Modules _moduleArithmeticPrecision;
 
         public CoverageSummaryTests()
+        {
+            SetupData();
+            SetupDataForArithmeticPrecision();
+        }
+
+        private void SetupDataForArithmeticPrecision()
+        {
+            Lines lines = new Lines();
+            lines.Add(1, 1);
+            for (int i = 2; i <= 6; i++)
+            {
+                lines.Add(i, 0);
+            }
+            Branches branches = new Branches();
+            branches.Add(new BranchInfo { Line = 1, Hits = 1, Offset = 1, Path = 0, Ordinal = 1 });
+            for (int i = 2; i <= 6; i++)
+            {
+                branches.Add(new BranchInfo { Line = 1, Hits = 0, Offset = 1, Path = 1, Ordinal = (uint)i });
+            }
+
+            Methods methods = new Methods();
+            var methodString = "System.Void Coverlet.Core.Tests.CoverageSummaryTests::TestCalculateSummary()";
+            methods.Add(methodString, new Method());
+            methods[methodString].Lines = lines;
+            methods[methodString].Branches = branches;
+
+            Classes classes = new Classes();
+            classes.Add("Coverlet.Core.Tests.CoverageSummaryTests", methods);
+
+            Documents documents = new Documents();
+            documents.Add("doc.cs", classes);
+
+            _moduleArithmeticPrecision = new Modules();
+            _moduleArithmeticPrecision.Add("module", documents);
+        }
+
+        private void SetupData()
         {
             Lines lines = new Lines();
             lines.Add(1, 1);
@@ -83,6 +121,86 @@ namespace Coverlet.Core.Tests
             Assert.Equal(1, summary.CalculateMethodCoverage(document.Value).Percent);
             Assert.Equal(1, summary.CalculateMethodCoverage(@class.Value).Percent);
             Assert.Equal(1, summary.CalculateMethodCoverage(method.Value.Lines).Percent);
+        }
+
+        [Fact]
+        public void TestCalculateLineCoveragePercentage()
+        {
+            CoverageSummary summary = new CoverageSummary();
+
+            var module = _modules.First();
+            var document = module.Value.First();
+            var @class = document.Value.First();
+            var method = @class.Value.First();
+
+            Assert.Equal(50, summary.CalculateLineCoverage(module.Value).GetCoveragePercentage());
+            Assert.Equal(50, summary.CalculateLineCoverage(document.Value).GetCoveragePercentage());
+            Assert.Equal(50, summary.CalculateLineCoverage(@class.Value).GetCoveragePercentage());
+            Assert.Equal(50, summary.CalculateLineCoverage(method.Value.Lines).GetCoveragePercentage());
+        }
+
+        [Fact]
+        public void TestCalculateBranchCoveragePercentage()
+        {
+            CoverageSummary summary = new CoverageSummary();
+
+            var module = _modules.First();
+            var document = module.Value.First();
+            var @class = document.Value.First();
+            var method = @class.Value.First();
+
+            Assert.Equal(100, summary.CalculateBranchCoverage(module.Value).GetCoveragePercentage());
+            Assert.Equal(100, summary.CalculateBranchCoverage(document.Value).GetCoveragePercentage());
+            Assert.Equal(100, summary.CalculateBranchCoverage(@class.Value).GetCoveragePercentage());
+            Assert.Equal(100, summary.CalculateBranchCoverage(method.Value.Branches).GetCoveragePercentage());
+        }
+
+        [Fact]
+        public void TestCalculateMethodCoveragePercentage()
+        {
+            CoverageSummary summary = new CoverageSummary();
+
+            var module = _modules.First();
+            var document = module.Value.First();
+            var @class = document.Value.First();
+            var method = @class.Value.First();
+
+            Assert.Equal(100, summary.CalculateMethodCoverage(module.Value).GetCoveragePercentage());
+            Assert.Equal(100, summary.CalculateMethodCoverage(document.Value).GetCoveragePercentage());
+            Assert.Equal(100, summary.CalculateMethodCoverage(@class.Value).GetCoveragePercentage());
+            Assert.Equal(100, summary.CalculateMethodCoverage(method.Value.Lines).GetCoveragePercentage());
+        }
+
+        [Fact]
+        public void TestCalculateLineCoveragePercentage_ArithmeticPrecisionCheck()
+        {
+            CoverageSummary summary = new CoverageSummary();
+
+            var module = _moduleArithmeticPrecision.First();
+            var document = module.Value.First();
+            var @class = document.Value.First();
+            var method = @class.Value.First();
+
+            Assert.Equal(16.66, summary.CalculateLineCoverage(module.Value).GetCoveragePercentage());
+            Assert.Equal(16.66, summary.CalculateLineCoverage(document.Value).GetCoveragePercentage());
+            Assert.Equal(16.66, summary.CalculateLineCoverage(@class.Value).GetCoveragePercentage());
+            Assert.Equal(16.66, summary.CalculateLineCoverage(method.Value.Lines).GetCoveragePercentage());
+        }
+
+        [Fact]
+        public void TestCalculateBranchCoveragePercentage_ArithmeticPrecisionCheck()
+        {
+            CoverageSummary summary = new CoverageSummary();
+
+            var module = _moduleArithmeticPrecision.First();
+            var document = module.Value.First();
+            var @class = document.Value.First();
+            var method = @class.Value.First();
+
+            Assert.Equal(16.66, summary.CalculateBranchCoverage(module.Value).GetCoveragePercentage());
+            Assert.Equal(16.66, summary.CalculateBranchCoverage(document.Value).GetCoveragePercentage());
+            Assert.Equal(16.66, summary.CalculateBranchCoverage(@class.Value).GetCoveragePercentage());
+            Assert.Equal(16.66, summary.CalculateBranchCoverage(method.Value.Branches).GetCoveragePercentage());
         }
     }
 }

--- a/test/coverlet.core.tests/Reporters/OpenCoverReporterTests.cs
+++ b/test/coverlet.core.tests/Reporters/OpenCoverReporterTests.cs
@@ -17,13 +17,13 @@ namespace Coverlet.Core.Reporters.Tests
             result.Identifier = Guid.NewGuid().ToString();
 
             result.Modules = new Modules();
-            result.Modules.Add("Coverlet.Core.Reporters.Tests", CreateFirstDocuments());
+            result.Modules.Add("Coverlet.Core.Reporters.Tests", CreateFirstDocuments());            
 
             OpenCoverReporter reporter = new OpenCoverReporter();
             string report = reporter.Report(result);
             Assert.NotEmpty(report);
             XDocument doc = XDocument.Load(new MemoryStream(Encoding.UTF8.GetBytes(report)));
-            Assert.Empty(doc.Descendants().Attributes("sequenceCoverage").Where(v => v.Value != "33.3"));
+            Assert.Empty(doc.Descendants().Attributes("sequenceCoverage").Where(v => v.Value != "33.33"));
             Assert.Empty(doc.Descendants().Attributes("branchCoverage").Where(v => v.Value != "25"));
         }
 

--- a/test/coverlet.core.tests/Reporters/OpenCoverReporterTests.cs
+++ b/test/coverlet.core.tests/Reporters/OpenCoverReporterTests.cs
@@ -17,7 +17,7 @@ namespace Coverlet.Core.Reporters.Tests
             result.Identifier = Guid.NewGuid().ToString();
 
             result.Modules = new Modules();
-            result.Modules.Add("Coverlet.Core.Reporters.Tests", CreateFirstDocuments());            
+            result.Modules.Add("Coverlet.Core.Reporters.Tests", CreateFirstDocuments());
 
             OpenCoverReporter reporter = new OpenCoverReporter();
             string report = reporter.Report(result);

--- a/test/coverlet.core.tests/Reporters/TeamCityReporter.cs
+++ b/test/coverlet.core.tests/Reporters/TeamCityReporter.cs
@@ -111,7 +111,7 @@ namespace Coverlet.Core.Reporters.Tests
             var output = _reporter.Report(_result);
 
             // Assert
-            Assert.Contains("##teamcity[buildStatisticValue key='CodeCoverageR' value='33.3']", output);
+            Assert.Contains("##teamcity[buildStatisticValue key='CodeCoverageR' value='33.33']", output);
             Assert.Contains("##teamcity[buildStatisticValue key='CodeCoverageAbsRCovered' value='1']", output);
             Assert.Contains("##teamcity[buildStatisticValue key='CodeCoverageAbsRTotal' value='3']", output);
         }


### PR DESCRIPTION
[Reports-After_Change.zip](https://github.com/tonerdo/coverlet/files/3148605/Reports-After_Change.zip)
[Reports-Before_Change.zip](https://github.com/tonerdo/coverlet/files/3148606/Reports-Before_Change.zip)

Related to issue #382 

Change Details:
1. All percentage output are rounded down (Floor) with maximum of 2 decimal precision.
2. Arithmetic precision error fixed by rounding- ex: `0.1400D * 100 = 14.000000000000002`
3. In Cobertura Report, "line-rate" and "branch-rate" value will have an extra decimal precision
Before: 0.143
After: 0.1432
4. In OpenCover report, "sequenceCoverage" and "branchCoverage" value will have an extra decimal precision
Before: 33.3
After: 33.33
5. In TeamCitry report, "CodeCoverageR" value will have an extra decimal precision
Before: 33.3
After: 33.33

I also updated and added new test cases to cover for the changes. Previously, we are rounding with max 3 decimal points before multiplying with 100. This yields value like 81.5%. I had to increase that to max 4 decimal points to yield like 81.52% when multiplied with 100%. In large projects, two decimal point reporting is useful and allows for incremental valuation without too much data loss after rounding down. Also I think, 2 decimal precision is commonly accepted standard.

Let me know If I missed something. Thanks

Edit: I have attached output for reports before my change (Coverlet.Console version 1.5.0) and after my change in zip.

Sample console output in version 1.5.0:
```
+-----------+-------+--------+--------+
| Module    | Line  | Branch | Method |
+-----------+-------+--------+--------+
| AppCenter | 13.8% | 25%    | 50%    |
+-----------+-------+--------+--------+

+---------+-------+--------+--------+
|         | Line  | Branch | Method |
+---------+-------+--------+--------+
| Total   | 13.8% | 25%    | 50%    |
+---------+-------+--------+--------+
| Average | 13.8% | 25%    | 50%    |
+---------+-------+--------+--------+
```

Sample console output after my change:
```
+-----------+--------+--------+--------+
| Module    | Line   | Branch | Method |
+-----------+--------+--------+--------+
| AppCenter | 13.79% | 25%    | 50%    |
+-----------+--------+--------+--------+

+---------+--------+--------+--------+
|         | Line   | Branch | Method |
+---------+--------+--------+--------+
| Total   | 13.79% | 25%    | 50%    |
+---------+--------+--------+--------+
| Average | 13.79% | 25%    | 50%    |
+---------+--------+--------+--------+
```