### PR TITLE
Suppress NU5125

### DIFF
--- a/src/coverlet.console/coverlet.console.csproj
+++ b/src/coverlet.console/coverlet.console.csproj
@@ -15,7 +15,7 @@
     <PackageTags>coverage;testing;unit-test;lcov;opencover;quality</PackageTags>
     <PackageIconUrl>https://raw.githubusercontent.com/tonerdo/coverlet/master/_assets/coverlet-icon.svg?sanitize=true</PackageIconUrl>
     <PackageProjectUrl>https://github.com/tonerdo/coverlet</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/tonerdo/coverlet/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/tonerdo/coverlet</RepositoryUrl>
   </PropertyGroup>

--- a/src/coverlet.msbuild.tasks/coverlet.msbuild.tasks.csproj
+++ b/src/coverlet.msbuild.tasks/coverlet.msbuild.tasks.csproj
@@ -10,7 +10,7 @@
     <PackageVersion>$(AssemblyVersion)</PackageVersion>
     <Title>coverlet.msbuild</Title>
     <Authors>tonerdo</Authors>
-    <PackageLicenseUrl>https://github.com/tonerdo/coverlet/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>http://github.com/tonerdo/coverlet</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/tonerdo/coverlet/master/_assets/coverlet-icon.svg?sanitize=true</PackageIconUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>


### PR DESCRIPTION
I noticed that compiling in release we get a warning from nuget packages
```
C:\Program Files\dotnet\sdk\3.0.100-preview4-011223\Sdks\NuGet.Build.Tasks.Pack\build\NuGet.Build.Tasks.Pack.targets(199,5): warning NU5125: The 'licenseUrl' element will be deprecated. Consider using the 'license' element instead. [D:\g it\coverlet\src\coverlet.msbuild.tasks\coverlet.msbuild.tasks.csproj] [D:\git\coverlet\build.proj]
```
`licenceUrl` will be deprecated https://github.com/NuGet/Announcements/issues/32
I found that in aspnet repo the warning is suppressed https://github.com/aspnet/AspNetCore/blob/7a040f310bf83ed5a731a506b693eb5054cb1637/Directory.Build.props#L48
BTW we can use new `PackageLicenseExpression` https://docs.microsoft.com/en-us/nuget/reference/msbuild-targets#packing-a-license-expression-or-a-license-file
I used `MIT`  SPDX license identifiers https://spdx.org/licenses/MIT.html
Now the package has got a link to license statement  
![image](https://user-images.githubusercontent.com/7894084/57184436-cbe17180-6ebb-11e9-9b82-088fdd50b617.png)
Point to https://licenses.nuget.org/MIT same statement of https://github.com/tonerdo/coverlet/blob/master/LICENSE
I preferred to use [licence expression](https://github.com/NuGet/Home/wiki/Packaging-License-within-the-nupkg-(Technical-Spec)#license-expression-pack) instead of [embedded file](https://github.com/NuGet/Home/wiki/Packaging-License-within-the-nupkg-(Technical-Spec)#license-file-pack) to keep package "lightweight"

/cc @tonerdo @petli 
/cc also @nkolev92 that I found on aspnet core issue https://github.com/aspnet/AspNetCore/issues/3751#issuecomment-434078733 to know if the usage is correct