### PR TITLE
Uniform helper namespace

### DIFF
--- a/src/coverlet.core/Helpers/RetryHelper.cs
+++ b/src/coverlet.core/Helpers/RetryHelper.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 
-namespace Coverlet.Core
+namespace Coverlet.Core.Helpers
 {
     // A slightly amended version of the code found here: https://stackoverflow.com/a/1563234/186184
     // This code allows for varying backoff strategies through the use of Func<TimeSpan>.


### PR DESCRIPTION
Reviewing https://github.com/tonerdo/coverlet/pull/397 I found that `RetryHelper` isn't in a proper namespace.

/cc @tonerdo @petli 