### PR TITLE
Different exit codes to indicate particular failures

### DIFF
--- a/src/coverlet.console/ExitCodes.cs
+++ b/src/coverlet.console/ExitCodes.cs
@@ -1,0 +1,34 @@
+﻿using System;
+
+/// <summary>
+/// Exit Codes returned from Coverlet console process.
+/// </summary>
+[Flags]
+internal enum CommandExitCodes
+{
+    /// <summary>
+    /// Indicates successful run of dotnet test without any test failure and coverage percentage above threshold if provided.
+    /// </summary>
+    Success = 0,
+
+    /// <summary>
+    /// Indicates test failure by dotnet test.
+    /// </summary>
+    TestFailed = 1,
+
+    /// <summary>
+    /// Indicates coverage percentage is below given threshold for one or more threshold type.
+    /// </summary>
+    CoverageBelowThreshold = 2,
+
+    /// <summary>
+    /// Indicates exception occurred during Coverlet process.
+    /// </summary>
+    Exception = 101,
+
+    /// <summary>
+    /// Indicates missing options or empty arguments for Coverlet process.
+    /// </summary>
+    CommandParsingException = 102
+}
+

--- a/src/coverlet.console/Program.cs
+++ b/src/coverlet.console/Program.cs
@@ -14,43 +14,7 @@ using McMaster.Extensions.CommandLineUtils;
 namespace Coverlet.Console
 {
     class Program
-    {
-        /// <summary>
-        /// Exit Codes returned from Coverlet console process.
-        /// </summary>
-        enum CommandExitCodes
-        {
-            /// <summary>
-            /// Indicates successful run of dotnet test without any test failure and coverage percentage above threshold if provided.
-            /// </summary>
-            Success = 0,
-
-            /// <summary>
-            /// Indicates test failure by dotnet test.
-            /// </summary>
-            TestFailed = 1,
-
-            /// <summary>
-            /// Indicates coverage percentage is below given threshold for one or more threshold type.
-            /// </summary>
-            CoverageBelowThreshold = 2,
-
-            /// <summary>
-            /// Indicates test failure by dotnet test and coverage percentage is below given threshold for one or more threshold type.
-            /// </summary>
-            TestFailedAndCoverageBelowThreshold = TestFailed + CoverageBelowThreshold,
-
-            /// <summary>
-            /// Indicates exception occurred during Coverlet process.
-            /// </summary>
-            Exception = 101,
-
-            /// <summary>
-            /// Indicates missing options or empty arguments for Coverlet process.
-            /// </summary>
-            CommandParsingException = 102
-        }
-
+    {        
         static int Main(string[] args)
         {
             var logger = new ConsoleLogger();
@@ -59,7 +23,7 @@ namespace Coverlet.Console
             app.FullName = "Cross platform .NET Core code coverage tool";
             app.HelpOption("-h|--help");
             app.VersionOption("-v|--version", GetAssemblyVersion());
-            int exitCode = 0;
+            int exitCode = (int)CommandExitCodes.Success;
 
             CommandArgument module = app.Argument("<ASSEMBLY>", "Path to the test assembly.");
             CommandOption target = app.Option("-t|--target", "Path to the test runner application.", CommandOptionType.SingleValue);

--- a/src/coverlet.console/Program.cs
+++ b/src/coverlet.console/Program.cs
@@ -14,7 +14,7 @@ using McMaster.Extensions.CommandLineUtils;
 namespace Coverlet.Console
 {
     class Program
-    {        
+    {
         static int Main(string[] args)
         {
             var logger = new ConsoleLogger();

--- a/src/coverlet.console/Program.cs
+++ b/src/coverlet.console/Program.cs
@@ -188,7 +188,7 @@ namespace Coverlet.Console
                 logger.LogInformation(coverageTable.ToStringAlternative());
                 if (process.ExitCode > 0)
                 {
-                    exitCode = (int)CommandExitCodes.TestFailed;
+                    exitCode += (int)CommandExitCodes.TestFailed;
                 }
                 thresholdTypeFlags = result.GetThresholdTypesBelowThreshold(summary, dThreshold, thresholdTypeFlags, dThresholdStat);
                 if (thresholdTypeFlags != ThresholdTypeFlags.None)


### PR DESCRIPTION
Closes #388 

**Exit Codes:**
- 0 : Success
- 1 : Test failed (based on dotnet test)
- 2 : Coverage percentage is below any threshold type
- 3 : Test failed and Coverage percentage is below any threshold type

- 101: General exception during coverlet process
- 102: Missing options or invalid arguments for coverlet process

Attached the output screenshot for all the above scenarios.  
[ExitCodes.zip](https://github.com/tonerdo/coverlet/files/3184006/ExitCodes.zip)

For any exception related code, we can use values starting from 101. We can use 1-100 for any of custom failures from the process. I didn't wanted to go negative for exceptions since if someone is currently using `exitcode > 0` to determine error cases in their script, then we will be breaking them. 