### PR TITLE
Using File.Exists for HitsFile creation/update validation

### DIFF
--- a/src/coverlet.core/Instrumentation/ModuleTrackerTemplate.cs
+++ b/src/coverlet.core/Instrumentation/ModuleTrackerTemplate.cs
@@ -82,8 +82,7 @@ namespace Coverlet.Core.Instrumentation
                 if (!createdNew)
                     mutex.WaitOne();
 
-                bool failedToCreateNewHitsFile = false;
-                try
+                if (!File.Exists(HitsFilePath))
                 {
                     using (var fs = new FileStream(HitsFilePath, FileMode.CreateNew))
                     using (var bw = new BinaryWriter(fs))
@@ -95,12 +94,7 @@ namespace Coverlet.Core.Instrumentation
                         }
                     }
                 }
-                catch
-                {
-                    failedToCreateNewHitsFile = true;
-                }
-
-                if (failedToCreateNewHitsFile)
+                else
                 {
                     // Update the number of hits by adding value on disk with the ones on memory.
                     // This path should be triggered only in the case of multiple AppDomain unloads.


### PR DESCRIPTION
Related to #405

Changed to if-else condition instead of try-catch for handling hits file create/update scenario.