### PR TITLE
Capture packages as build artifacts

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,6 +12,19 @@ jobs:
     vmImage: 'windows-2019'
   steps:
   - template: build.yml
+  - task: CopyFiles@2
+    displayName: Collect packages
+    inputs:
+      SourceFolder: build\$(BuildConfiguration)
+      Contents: '*.nupkg'
+      TargetFolder: $(Build.ArtifactStagingDirectory)\Packages
+  - task: PublishBuildArtifacts@1
+    displayName: Publish packages as build artifacts
+    inputs:
+      PathtoPublish: $(Build.ArtifactStagingDirectory)\Packages
+      ArtifactName: Packages
+      publishLocation: Container
+    condition: eq(variables['BuildConfiguration'], 'Release')
 
 - job: macOS
   displayName: macOS


### PR DESCRIPTION
Publish Nuget packages as build artifacts

This allows the build results to be downloaded for further testing or a Release pipeline to actually push them to nuget.org.