### PR TITLE
Prefer modern UseDotNet task over obsolete DotNetCoreInstaller

### DIFF
--- a/build.yml
+++ b/build.yml
@@ -1,7 +1,8 @@
 steps:
-- task: DotNetCoreInstaller@0
+- task: UseDotNet@2
   inputs:
-    version: '2.2.300'
-  displayName: 'Install .NET Core SDK'
+    version: 2.2.300
+  displayName: Install .NET Core SDK
+
 - script: dotnet msbuild build.proj /p:Configuration=$(buildConfiguration)
   displayName: 'Run Build'


### PR DESCRIPTION
Prefer modern UseDotNet task over obsolete DotNetCoreInstaller

The `UseDotNet` task is newer and follows best practices from the
dotnet SDK team better than the older `DotNetCoreInstaller` task.

One significant difference between the two is that `UseDotNet` sets
`DOTNET_MULTILEVEL_LOOKUP=0`, such that once you use this task once, you have to
manually install *all* SDK/runtime versions that your pipeline requires.
This task *may* be used more than once in order to accomplish this.
This is actually a *good* thing, because it means your pipeline is more fully
self-describing, and less dependent on whatever versions the agents happen to
have installed at the time.

I do wonder what @MarcoRossignoli meant when he said in #425:

> this update does not conflicts with #396 because there we use DOTNET_MULTILEVEL_LOOKUP=0

Since here we *do* set that, what does that mean for #396?