### PR TITLE
Only trigger CI on master branch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,9 @@
+trigger:
+  branches:
+    include: ["master"]
+  paths:
+    exclude: [".github", "doc", "*.md"]
+
 jobs:
 - job: Windows
   displayName: Windows


### PR DESCRIPTION
This adjusts the CI to only build certain designated branches rather than every single branch. This can be useful:

1. In forks of the project, so that Azure Pipelines the user may have set up doesn't run on every branch pushed to their fork.
1. If writers of *this* main repo push branches to the main repo in preparation for a PR, AZP doesn't build it twice (once as CI for the source branch, and once for PR).

Note that in my own repos, I also add `*_validate` as a branch spec that is included in CI so that I can get full CI validation on one of my own branches simply by pushing a branch named with a `_validate` suffix. We could do that here too if you want.

This also suppresses CI altogether when docs, the special `.github` folder, or markdown files in the root of the repo are changed.