### PR TITLE
Ignore msbuild.binlog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ bld/
 [Oo]bj/
 [Ll]og/
 [Bb]uild/
+msbuild.binlog
 
 # Visual Studio 2015 cache/options directory
 .vs/


### PR DESCRIPTION
msbuild.binlog is the default filename for msbuild logs when using the /bl switch.