### PR TITLE
Add missing IsTestProject and IsPackable properties

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -31,9 +31,7 @@
   </Target>
 
   <Target Name="CreateNuGetPackage" AfterTargets="RunTests" Condition="$(Configuration) == 'Release'">
-    <Exec Command="dotnet pack &quot;$(MSBuildThisFileDirectory)src\coverlet.msbuild.tasks\coverlet.msbuild.tasks.csproj&quot; -c $(Configuration) -o $(OutputPath) /p:PublicRelease=$(PublicRelease)"  />
-    <Exec Command="dotnet pack &quot;$(MSBuildThisFileDirectory)src\coverlet.console\coverlet.console.csproj&quot; -c $(Configuration) -o $(OutputPath) /p:PublicRelease=$(PublicRelease)" />
-    <Exec Command="dotnet pack &quot;$(MSBuildThisFileDirectory)src\coverlet.collector\coverlet.collector.csproj&quot; -c $(Configuration) -o $(OutputPath) /p:PublicRelease=$(PublicRelease)" />
+    <Exec Command="dotnet pack coverlet.sln -c $(Configuration) /p:PublicRelease=$(PublicRelease)"  />
   </Target>
 
 </Project>

--- a/src/coverlet.core/coverlet.core.csproj
+++ b/src/coverlet.core/coverlet.core.csproj
@@ -4,6 +4,7 @@
     <OutputType>Library</OutputType>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyVersion>5.1.0</AssemblyVersion>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <PropertyGroup>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+</Project>

--- a/test/coverlet.testsubject/coverlet.testsubject.csproj
+++ b/test/coverlet.testsubject/coverlet.testsubject.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>false</IsTestProject>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
This lets us "pack" the solution instead of listing out each project individually, since projects know themselves whether they should be packable.

This also lets us run `dotnet test` in the root of the repo and all the right projects actually get tested.

I also remove the `-o` switch from the `dotnet pack` command in `build.proj` because it is (already) redundant with a recent change that added this line:

https://github.com/tonerdo/coverlet/blob/02708bbaeaf7742b8da56321f5aaa4f70c0ee74c/Directory.Build.props#L4