### PR TITLE
 Fix `dotnet build` of a clean repo

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
+    <RepoRoot>$(MSBuildThisFileDirectory)</RepoRoot>
     <PackageOutputPath>$(MSBuildThisFileDirectory)build\$(Configuration)\</PackageOutputPath>
   </PropertyGroup>
 

--- a/build.proj
+++ b/build.proj
@@ -13,19 +13,7 @@
     <Exec Command="dotnet build &quot;$(MSBuildThisFileDirectory)src\coverlet.collector\coverlet.collector.csproj&quot; -c $(Configuration)" />
   </Target>
 
-  <Target Name="PublishMSBuildTaskProject" AfterTargets="BuildAllProjects">
-    <Exec Command="dotnet publish &quot;$(MSBuildThisFileDirectory)src\coverlet.msbuild.tasks\coverlet.msbuild.tasks.csproj&quot; -c $(Configuration) -o &quot;$(OutputPath)&quot;" />
-  </Target>
-
-  <Target Name="CopyMSBuildScripts" AfterTargets="PublishMSBuildTaskProject">
-    <ItemGroup>
-      <BuildScript Include="$(MSBuildThisFileDirectory)src\coverlet.msbuild.tasks\coverlet.msbuild.props" />
-      <BuildScript Include="$(MSBuildThisFileDirectory)src\coverlet.msbuild.tasks\coverlet.msbuild.targets" />
-    </ItemGroup>
-    <Copy SourceFiles="@(BuildScript)" DestinationFolder="$(OutputPath)" />
-  </Target>
-
-  <Target Name="RunTests" AfterTargets="CopyMSBuildScripts">
+  <Target Name="RunTests" AfterTargets="BuildAllProjects">
     <Exec Command="dotnet test &quot;$(MSBuildThisFileDirectory)test\coverlet.core.tests\coverlet.core.tests.csproj&quot; -c $(Configuration) /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Include=[coverlet.*]*"/>
     <Exec Command="dotnet test &quot;$(MSBuildThisFileDirectory)test\coverlet.collector.tests\coverlet.collector.tests.csproj&quot; -c $(Configuration) /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Include=[coverlet.*]*"/>
   </Target>

--- a/src/coverlet.msbuild.tasks/coverlet.msbuild.props
+++ b/src/coverlet.msbuild.tasks/coverlet.msbuild.props
@@ -16,4 +16,7 @@
     <ThresholdType Condition="$(ThresholdType) == ''">line,branch,method</ThresholdType>
     <ThresholdStat Condition="$(ThresholdStat) == ''">minimum</ThresholdStat>
   </PropertyGroup>
+  <PropertyGroup>
+    <CoverletToolsPath Condition=" '$(CoverletToolsPath)' == '' ">$(MSBuildThisFileDirectory)</CoverletToolsPath>
+  </PropertyGroup>
 </Project>

--- a/src/coverlet.msbuild.tasks/coverlet.msbuild.targets
+++ b/src/coverlet.msbuild.tasks/coverlet.msbuild.targets
@@ -1,7 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <UsingTask TaskName="Coverlet.MSbuild.Tasks.InstrumentationTask" AssemblyFile="$(MSBuildThisFileDirectory)coverlet.msbuild.tasks.dll"/>
-  <UsingTask TaskName="Coverlet.MSbuild.Tasks.CoverageResultTask" AssemblyFile="$(MSBuildThisFileDirectory)coverlet.msbuild.tasks.dll"/>
+  <UsingTask TaskName="Coverlet.MSbuild.Tasks.InstrumentationTask" AssemblyFile="$(CoverletToolsPath)coverlet.msbuild.tasks.dll"/>
+  <UsingTask TaskName="Coverlet.MSbuild.Tasks.CoverageResultTask" AssemblyFile="$(CoverletToolsPath)coverlet.msbuild.tasks.dll"/>
 
   <Target Name="InstrumentModulesNoBuild" BeforeTargets="VSTest">
     <Coverlet.MSbuild.Tasks.InstrumentationTask

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -1,0 +1,20 @@
+<Project>
+  <Choose>
+    <!-- This condition tests whether coverlet.msbuild.props has been imported by the project -->
+    <When Condition=" '$(ThresholdType)' != '' ">
+      <ItemGroup>
+        <!-- Arrange for the project that builds the build tools has built first. -->
+        <ProjectReference Include="$(MSBuildThisFileDirectory)\..\src\coverlet.msbuild.tasks\coverlet.msbuild.tasks.csproj">
+          <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+        </ProjectReference>
+      </ItemGroup>
+      <PropertyGroup>
+        <!-- Ensure that the built tools can be found at build time.
+             This is required when the coverlet.msbuild imports are made in their src directory
+             (so that msbuild eval works even before they are built)
+             so that they can still find the tooling that will be built by the build. -->
+        <CoverletToolsPath>$(MSBuildThisFileDirectory)..\src\coverlet.msbuild.tasks\bin\$(Configuration)\netstandard2.0\</CoverletToolsPath>
+      </PropertyGroup>
+    </When>
+  </Choose>
+</Project>

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -4,7 +4,7 @@
     <When Condition=" '$(ThresholdType)' != '' ">
       <ItemGroup>
         <!-- Arrange for the project that builds the build tools has built first. -->
-        <ProjectReference Include="$(MSBuildThisFileDirectory)\..\src\coverlet.msbuild.tasks\coverlet.msbuild.tasks.csproj">
+        <ProjectReference Include="$(RepoRoot)src\coverlet.msbuild.tasks\coverlet.msbuild.tasks.csproj">
           <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
         </ProjectReference>
       </ItemGroup>
@@ -13,7 +13,7 @@
              This is required when the coverlet.msbuild imports are made in their src directory
              (so that msbuild eval works even before they are built)
              so that they can still find the tooling that will be built by the build. -->
-        <CoverletToolsPath>$(MSBuildThisFileDirectory)..\src\coverlet.msbuild.tasks\bin\$(Configuration)\netstandard2.0\</CoverletToolsPath>
+        <CoverletToolsPath>$(RepoRoot)src\coverlet.msbuild.tasks\bin\$(Configuration)\netstandard2.0\</CoverletToolsPath>
       </PropertyGroup>
     </When>
   </Choose>

--- a/test/coverlet.collector.tests/coverlet.collector.tests.csproj
+++ b/test/coverlet.collector.tests/coverlet.collector.tests.csproj
@@ -18,8 +18,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\coverlet.core\coverlet.core.csproj" />
-    <ProjectReference Include="..\..\src\coverlet.collector\coverlet.collector.csproj" />
+    <ProjectReference Include="$(RepoRoot)src\coverlet.core\coverlet.core.csproj" />
+    <ProjectReference Include="$(RepoRoot)src\coverlet.collector\coverlet.collector.csproj" />
   </ItemGroup>
 
 </Project>

--- a/test/coverlet.core.performancetest/coverlet.core.performancetest.csproj
+++ b/test/coverlet.core.performancetest/coverlet.core.performancetest.csproj
@@ -1,5 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\src\coverlet.msbuild.tasks\coverlet.msbuild.props" />
+  <Import Project="$(RepoRoot)src\coverlet.msbuild.tasks\coverlet.msbuild.props" />
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
@@ -15,5 +15,5 @@
     <ProjectReference Include="..\coverlet.testsubject\coverlet.testsubject.csproj" />
   </ItemGroup>
 
-  <Import Project="..\..\src\coverlet.msbuild.tasks\coverlet.msbuild.targets" />
+  <Import Project="$(RepoRoot)src\coverlet.msbuild.tasks\coverlet.msbuild.targets" />
 </Project>

--- a/test/coverlet.core.performancetest/coverlet.core.performancetest.csproj
+++ b/test/coverlet.core.performancetest/coverlet.core.performancetest.csproj
@@ -1,5 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$(MSBuildThisFileDirectory)\..\..\build\$(Configuration)\coverlet.msbuild.props" />
+  <Import Project="..\..\src\coverlet.msbuild.tasks\coverlet.msbuild.props" />
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
@@ -15,5 +15,5 @@
     <ProjectReference Include="..\coverlet.testsubject\coverlet.testsubject.csproj" />
   </ItemGroup>
 
-  <Import Project="$(MSBuildThisFileDirectory)\..\..\build\$(Configuration)\coverlet.msbuild.targets" />
+  <Import Project="..\..\src\coverlet.msbuild.tasks\coverlet.msbuild.targets" />
 </Project>

--- a/test/coverlet.core.tests/coverlet.core.tests.csproj
+++ b/test/coverlet.core.tests/coverlet.core.tests.csproj
@@ -1,5 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="$(MSBuildThisFileDirectory)\..\..\build\$(Configuration)\coverlet.msbuild.props" />
+  <Import Project="..\..\src\coverlet.msbuild.tasks\coverlet.msbuild.props" />
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
@@ -19,5 +19,5 @@
     <ProjectReference Include="..\..\src\coverlet.core\coverlet.core.csproj" />
   </ItemGroup>
 
-  <Import Project="$(MSBuildThisFileDirectory)\..\..\build\$(Configuration)\coverlet.msbuild.targets" />
+  <Import Project="..\..\src\coverlet.msbuild.tasks\coverlet.msbuild.targets" />
 </Project>

--- a/test/coverlet.core.tests/coverlet.core.tests.csproj
+++ b/test/coverlet.core.tests/coverlet.core.tests.csproj
@@ -1,5 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\..\src\coverlet.msbuild.tasks\coverlet.msbuild.props" />
+  <Import Project="$(RepoRoot)src\coverlet.msbuild.tasks\coverlet.msbuild.props" />
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
@@ -16,8 +16,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\coverlet.core\coverlet.core.csproj" />
+    <ProjectReference Include="$(RepoRoot)src\coverlet.core\coverlet.core.csproj" />
   </ItemGroup>
 
-  <Import Project="..\..\src\coverlet.msbuild.tasks\coverlet.msbuild.targets" />
+  <Import Project="$(RepoRoot)src\coverlet.msbuild.tasks\coverlet.msbuild.targets" />
 </Project>


### PR DESCRIPTION
For a perfectly clean repo (git clean -fdx), `dotnet build` fails because some tests require that other projects have been built using build.proj first.

This change adds the necessary build ordering instructions so that the build tasks are always built before the tests that need them, and the tests are always run against the *latest* source code being tested rather than the last version that happened to be built with build.proj.