### PR TITLE
Build *_validate branches on CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,6 @@
 trigger:
   branches:
-    include: ["master"]
+    include: ["master", "*_validate"]
   paths:
     exclude: [".github", "doc", "*.md"]
 


### PR DESCRIPTION
Per support for the idea [here](https://github.com/tonerdo/coverlet/pull/428/files#r287685633), this adds any branch ending with `_validate` to the CI builds.