### PR TITLE
[Bug fix]Fix "/p:UseSourceLink=true" bug

### DIFF
--- a/src/coverlet.core/Coverage.cs
+++ b/src/coverlet.core/Coverage.cs
@@ -339,10 +339,18 @@ namespace Coverlet.Core
                 string key = sourceLinkDocument.Key;
                 if (Path.GetFileName(key) != "*") continue;
 
-                if (!Path.GetDirectoryName(document).StartsWith(Path.GetDirectoryName(key) + Path.DirectorySeparatorChar))
-                    continue;
+                string directoryDocument = Path.GetDirectoryName(document);
+                string sourceLinkRoot = Path.GetDirectoryName(key);
+                string relativePath = "";
 
-                var relativePath = Path.GetDirectoryName(document).Substring(Path.GetDirectoryName(key).Length + 1);
+                // if document is on repo root we skip relative path calculation
+                if (directoryDocument != sourceLinkRoot)
+                {
+                    if (!directoryDocument.StartsWith(sourceLinkRoot + Path.DirectorySeparatorChar))
+                        continue;
+
+                    relativePath = directoryDocument.Substring(sourceLinkRoot.Length + 1);
+                }
 
                 if (relativePathOfBestMatch.Length == 0)
                 {


### PR DESCRIPTION
Fixes https://github.com/tonerdo/coverlet/issues/418

This PR https://github.com/tonerdo/coverlet/pull/299/files changed the way we build source link url.
In case of source is on repo root(special case) we need to skip relative path calculation.

cc: @tonerdo @dbolin

EDIT: now we have a nightly build  (https://www.myget.org/F/coverlet-dev/api/v3/index.json) after merge we can ask to Dominic to try!