### PR TITLE
Fix build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,6 +24,7 @@ jobs:
       SourceFolder: build\$(BuildConfiguration)
       Contents: '*.nupkg'
       TargetFolder: $(Build.ArtifactStagingDirectory)\Packages
+    condition: eq(variables['BuildConfiguration'], 'Release')
   - task: PublishBuildArtifacts@1
     displayName: Publish packages as build artifacts
     inputs:

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
   <PropertyGroup>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>


### PR DESCRIPTION
Missing RepoRoot variable on test project.

cc: @tonerdo  @AArnott 