### PR TITLE
Fix PackageOutputPath in local builds

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,7 @@
 <Project>
   <PropertyGroup>
     <RepoRoot>$(MSBuildThisFileDirectory)</RepoRoot>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <PackageOutputPath>$(MSBuildThisFileDirectory)build\$(Configuration)\</PackageOutputPath>
   </PropertyGroup>
 


### PR DESCRIPTION
Define Configuration when undefined before using it. Otherwise packages build to just build\ instead of build\debug.