### PR TITLE
Remove PATCH from version.json

### DIFF
--- a/src/coverlet.collector/version.json
+++ b/src/coverlet.collector/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.0.0",
+  "version": "1.0",
   "publicReleaseRefSpec": [
     "^refs/heads/master$"
   ]

--- a/src/coverlet.console/version.json
+++ b/src/coverlet.console/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.5.1",
+  "version": "1.5",
   "publicReleaseRefSpec": [
     "^refs/heads/master$"
   ]

--- a/src/coverlet.msbuild.tasks/version.json
+++ b/src/coverlet.msbuild.tasks/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.6.1",
+  "version": "2.6",
   "publicReleaseRefSpec": [
     "^refs/heads/master$"
   ]


### PR DESCRIPTION
This allows for simpler and more descriptive file versions.

Previous to this change, we were building packages with a version that collides with previously published ones (1.5.1, and 2.6.1). After this change, the next version built and pushed will be 1.5.x and 2.6.x where x is some larger number (larger than 2) based on the git version height.