### PR TITLE
Update newtosoft reference

### DIFF
--- a/src/coverlet.core/coverlet.core.csproj
+++ b/src/coverlet.core/coverlet.core.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Mono.Cecil" Version="0.10.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.1" />
     <!--
               Do not change System.Reflection.Metadata version since we need to support VSTest DataCollectors. Goto https://www.nuget.org/packages/System.Reflection.Metadata to check versions.
               We need to load assembly version 1.4.2.0 to properly work


### PR DESCRIPTION
Newtosoft.Json has got a bug on old version and doesn't handle type converter in correct way.
During test with collector and msbuild this issue doesn't raised up, they loaded correct one, but I think that in some cases they load "users project" referenced version...and if it's old hit the bug.
I see this issue only on manual load https://github.com/tonerdo/coverlet/pull/420#discussion_r286904435
Fix referenced version for now...if we'll get issue I'll write custom serializer or move to [BinarySerializer](https://docs.microsoft.com/en-us/dotnet/standard/serialization/binary-serialization#binary-serialization-in-net-core) XmlSerializer or others.

cc: @tonerdo 