### PR TITLE
Let nbgv bump PATCH for nightly

### DIFF
--- a/src/coverlet.collector/version.json
+++ b/src/coverlet.collector/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.0.0",
+  "version": "1.0",
   "publicReleaseRefSpec": [
     "^refs/heads/master$"
   ]

--- a/src/coverlet.console/version.json
+++ b/src/coverlet.console/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.5.2",
+  "version": "1.5",
   "publicReleaseRefSpec": [
     "^refs/heads/master$"
   ]

--- a/src/coverlet.msbuild.tasks/version.json
+++ b/src/coverlet.msbuild.tasks/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.6.2",
+  "version": "2.6",
   "publicReleaseRefSpec": [
     "^refs/heads/master$"
   ]


### PR DESCRIPTION
As per off line discussion
Nightly names
```
F:\git\coverlet (removepatch -> origin)
λ dotnet pack
Microsoft (R) Build Engine version 16.1.76+g14b0a930a7 for .NET Core
Copyright (C) Microsoft Corporation. All rights reserved.
...
  Successfully created package 'F:\git\coverlet\build\Debug\coverlet.collector.1.0.30-g9aad14a1ac.nupkg'.
  Successfully created package 'F:\git\coverlet\build\Debug\coverlet.console.1.5.30-g9aad14a1ac.nupkg'.
  Successfully created package 'F:\git\coverlet\build\Debug\coverlet.msbuild.2.6.30-g9aad14a1ac.nupkg'.
```