### PR TITLE
[Bug fix]Fix instrumentation serialization bug

### DIFF
--- a/Documentation/Troubleshooting.md
+++ b/Documentation/Troubleshooting.md
@@ -59,3 +59,55 @@ Hits file:'C:\Users\Marco\AppData\Local\Temp\coverlet.core_703263e9-21f0-4d1c-9c
 | Average | 4,44%  | 3,455% | 5,66%  |
 +---------+--------+--------+--------+
 ```
+
+## Use local build
+
+Sometimes is useful test local updated source to fix issue.  
+You can "load" your local build using simple switch:
+
+* build repo
+
+```
+D:\git\coverlet (fixjsonserializerbug -> origin)
+λ dotnet build
+Microsoft (R) Build Engine version 16.1.76+g14b0a930a7 for .NET Core
+Copyright (C) Microsoft Corporation. All rights reserved.
+
+  Restore completed in 52.23 ms for D:\git\coverlet\test\coverlet.testsubject\coverlet.testsubject.csproj.
+  Restore completed in 58.97 ms for D:\git\coverlet\src\coverlet.console\coverlet.console.csproj.
+  Restore completed in 59 ms for D:\git\coverlet\src\coverlet.core\coverlet.core.csproj.
+  Restore completed in 59.17 ms for D:\git\coverlet\src\coverlet.msbuild.tasks\coverlet.msbuild.tasks.csproj.
+  Restore completed in 59.26 ms for D:\git\coverlet\src\coverlet.collector\coverlet.collector.csproj.
+  Restore completed in 60.1 ms for D:\git\coverlet\test\coverlet.collector.tests\coverlet.collector.tests.csproj.
+  Restore completed in 60.42 ms for D:\git\coverlet\test\coverlet.core.performancetest\coverlet.core.performancetest.csproj.
+  Restore completed in 60.47 ms for D:\git\coverlet\test\coverlet.core.tests\coverlet.core.tests.csproj.
+  Restore completed in 22.85 ms for D:\git\coverlet\test\coverlet.core.tests\coverlet.core.tests.csproj.
+  coverlet.testsubject -> D:\git\coverlet\test\coverlet.testsubject\bin\Debug\netcoreapp2.0\coverlet.testsubject.dll
+  coverlet.core -> D:\git\coverlet\src\coverlet.core\bin\Debug\netstandard2.0\coverlet.core.dll
+  coverlet.msbuild.tasks -> D:\git\coverlet\src\coverlet.msbuild.tasks\bin\Debug\netstandard2.0\coverlet.msbuild.tasks.dll
+  coverlet.collector -> D:\git\coverlet\src\coverlet.collector\bin\Debug\netcoreapp2.0\coverlet.collector.dll
+  coverlet.console -> D:\git\coverlet\src\coverlet.console\bin\Debug\netcoreapp2.2\coverlet.console.dll
+  coverlet.core.performancetest -> D:\git\coverlet\test\coverlet.core.performancetest\bin\Debug\netcoreapp2.0\coverlet.core.performancetest.dll
+  coverlet.core.tests -> D:\git\coverlet\test\coverlet.core.tests\bin\Debug\netcoreapp2.0\coverlet.core.tests.dll
+  coverlet.collector.tests -> D:\git\coverlet\test\coverlet.collector.tests\bin\Debug\netcoreapp2.2\coverlet.collector.tests.dll
+
+Build succeeded.
+    0 Warning(s)
+    0 Error(s)
+
+Time Elapsed 00:00:07.42
+
+D:\git\coverlet (fixjsonserializerbug -> origin)
+λ
+
+```
+
+* Go to repro project and run
+```
+D:\git\Cake.Codecov\Source\Cake.Codecov.Tests (develop -> origin)
+λ dotnet test /p:CollectCoverage=true /p:Exclude="[xunit.*]*" /p:CoverletToolsPath=D:\git\coverlet\src\coverlet.msbuild.tasks\bin\Debug\netstandard2.0\  
+Test run for D:\git\Cake.Codecov\Source\Cake.Codecov.Tests\bin\Debug\netcoreapp2.0\Cake.Codecov.Tests.dll(.NETCoreApp,Version=v2.0)
+...
+```
+
+In this way you can add `Debug.Launch()` inside coverlet source and debug.

--- a/src/coverlet.core/CoveragePrepareResult.cs
+++ b/src/coverlet.core/CoveragePrepareResult.cs
@@ -1,40 +1,39 @@
-﻿using System.IO;
-using System.Text;
-
+﻿using System;
+using System.IO;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters.Binary;
 using Coverlet.Core.Instrumentation;
-using Newtonsoft.Json;
 
 namespace Coverlet.Core
 {
+    // Followed safe serializer guide, will emit xml format
+    // https://docs.microsoft.com/en-us/visualstudio/code-quality/ca2300-do-not-use-insecure-deserializer-binaryformatter?view=vs-2019
+    // https://docs.microsoft.com/en-us/visualstudio/code-quality/ca2301-do-not-call-binaryformatter-deserialize-without-first-setting-binaryformatter-binder?view=vs-2019
+    [DataContract]
     public class CoveragePrepareResult
     {
+        [DataMember]
         public string Identifier { get; set; }
+        [DataMember]
         public string Module { get; set; }
+        [DataMember]
         public string MergeWith { get; set; }
+        [DataMember]
         public bool UseSourceLink { get; set; }
+        [DataMember]
         public InstrumenterResult[] Results { get; set; }
 
         public static CoveragePrepareResult Deserialize(Stream serializedInstrumentState)
         {
-            var serializer = new JsonSerializer();
-            using (var sr = new StreamReader(serializedInstrumentState))
-            using (var jsonTextReader = new JsonTextReader(sr))
-            {
-                return serializer.Deserialize<CoveragePrepareResult>(jsonTextReader);
-            }
+            return (CoveragePrepareResult)new DataContractSerializer(typeof(CoveragePrepareResult)).ReadObject(serializedInstrumentState);
         }
 
         public static Stream Serialize(CoveragePrepareResult instrumentState)
         {
-            var serializer = new JsonSerializer();
             MemoryStream ms = new MemoryStream();
-            using (var sw = new StreamWriter(ms, Encoding.UTF8, 1024, true))
-            {
-                serializer.Serialize(sw, instrumentState);
-                sw.Flush();
-                ms.Position = 0;
-                return ms;
-            }
+            new DataContractSerializer(typeof(CoveragePrepareResult)).WriteObject(ms, instrumentState);
+            ms.Position = 0;
+            return ms;
         }
     }
 }

--- a/src/coverlet.core/Instrumentation/InstrumenterResult.cs
+++ b/src/coverlet.core/Instrumentation/InstrumenterResult.cs
@@ -1,52 +1,44 @@
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.Globalization;
-using System.IO;
-using Newtonsoft.Json;
+using System.Runtime.Serialization;
 
 namespace Coverlet.Core.Instrumentation
 {
+    [DataContract]
     public class Line
     {
+        [DataMember]
         public int Number;
+        [DataMember]
         public string Class;
+        [DataMember]
         public string Method;
+        [DataMember]
         public int Hits;
     }
 
+    [DataContract]
     public class Branch : Line
     {
+        [DataMember]
         public int Offset;
+        [DataMember]
         public int EndOffset;
+        [DataMember]
         public int Path;
+        [DataMember]
         public uint Ordinal;
     }
 
-    public class BranchKeyConverter : TypeConverter
-    {
-        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
-        {
-            return sourceType == typeof(string);
-        }
-
-        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
-        {
-            return JsonConvert.DeserializeObject<BranchKey>(value.ToString());
-        }
-
-        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
-        {
-            return destinationType == typeof(BranchKey);
-        }
-    }
-
-    [TypeConverter(typeof(BranchKeyConverter))]
+    // Implements IEquatable because is used by dictionary key https://docs.microsoft.com/en-us/dotnet/api/system.iequatable-1?view=netcore-2.2#remarks
+    [DataContract]
     public class BranchKey : IEquatable<BranchKey>
     {
         public BranchKey(int line, int ordinal) => (Line, Ordinal) = (line, ordinal);
 
+        [DataMember]
         public int Line { get; set; }
+        [DataMember]
         public int Ordinal { get; set; }
 
         public override bool Equals(object obj) => Equals(obj);
@@ -57,13 +49,9 @@ namespace Coverlet.Core.Instrumentation
         {
             return (this.Line, this.Ordinal).GetHashCode();
         }
-
-        public override string ToString()
-        {
-            return JsonConvert.SerializeObject(this);
-        }
     }
 
+    [DataContract]
     public class Document
     {
         public Document()
@@ -72,22 +60,32 @@ namespace Coverlet.Core.Instrumentation
             Branches = new Dictionary<BranchKey, Branch>();
         }
 
+        [DataMember]
         public string Path;
+        [DataMember]
         public int Index;
+        [DataMember]
         public Dictionary<int, Line> Lines { get; private set; }
+        [DataMember]
         public Dictionary<BranchKey, Branch> Branches { get; private set; }
     }
 
+    [DataContract]
     public class HitCandidate
     {
         public HitCandidate(bool isBranch, int docIndex, int start, int end) => (this.isBranch, this.docIndex, this.start, this.end) = (isBranch, docIndex, start, end);
 
+        [DataMember]
         public bool isBranch { get; set; }
+        [DataMember]
         public int docIndex { get; set; }
+        [DataMember]
         public int start { get; set; }
+        [DataMember]
         public int end { get; set; }
     }
 
+    [DataContract]
     public class InstrumenterResult
     {
         public InstrumenterResult()
@@ -96,12 +94,19 @@ namespace Coverlet.Core.Instrumentation
             HitCandidates = new List<HitCandidate>();
         }
 
+        [DataMember]
         public string Module;
+        [DataMember]
         public string[] AsyncMachineStateMethod;
+        [DataMember]
         public string HitsFilePath;
+        [DataMember]
         public string ModulePath;
+        [DataMember]
         public string SourceLink;
+        [DataMember]
         public Dictionary<string, Document> Documents { get; private set; }
+        [DataMember]
         public List<HitCandidate> HitCandidates { get; private set; }
     }
 }

--- a/src/coverlet.core/coverlet.core.csproj
+++ b/src/coverlet.core/coverlet.core.csproj
@@ -9,7 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="Mono.Cecil" Version="0.10.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.1" />
+    <!-- Do not upgrade this version or we won't support old SDK -->
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <!--
               Do not change System.Reflection.Metadata version since we need to support VSTest DataCollectors. Goto https://www.nuget.org/packages/System.Reflection.Metadata to check versions.
               We need to load assembly version 1.4.2.0 to properly work

--- a/test/coverlet.core.tests/Instrumentation/InstrumenterResultTests.cs
+++ b/test/coverlet.core.tests/Instrumentation/InstrumenterResultTests.cs
@@ -1,6 +1,8 @@
 
 using Xunit;
 using Coverlet.Core.Instrumentation;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Coverlet.Core.Instrumentation.Tests
 {
@@ -19,6 +21,148 @@ namespace Coverlet.Core.Instrumentation.Tests
             Document document = new Document();
             Assert.NotNull(document.Lines);
             Assert.NotNull(document.Branches);
+        }
+
+        [Fact]
+        public void CoveragePrepareResult_SerializationRoundTrip()
+        {
+            CoveragePrepareResult cpr = new CoveragePrepareResult();
+            cpr.Identifier = "Identifier";
+            cpr.MergeWith = "MergeWith";
+            cpr.Module = "Module";
+            cpr.UseSourceLink = true;
+
+            InstrumenterResult ir = new InstrumenterResult();
+            ir.HitsFilePath = "HitsFilePath";
+            ir.Module = "Module";
+            ir.ModulePath = "ModulePath";
+            ir.SourceLink = "SourceLink";
+            ir.AsyncMachineStateMethod = new string[] { "A", "B" };
+
+            ir.HitCandidates.Add(new HitCandidate(true, 1, 2, 3));
+            ir.HitCandidates.Add(new HitCandidate(false, 4, 5, 6));
+
+            var doc = new Document()
+            {
+                Index = 0,
+                Path = "Path0"
+            };
+            doc.Lines.Add(0, new Line()
+            {
+                Class = "Class0",
+                Hits = 0,
+                Method = "Method0",
+                Number = 0
+            });
+            doc.Branches.Add(new BranchKey(0, 0),
+            new Branch()
+            {
+                Class = "Class0",
+                EndOffset = 0,
+                Hits = 0,
+                Method = "Method",
+                Number = 0,
+                Offset = 0,
+                Ordinal = 0,
+                Path = 0
+            });
+
+            var doc2 = new Document()
+            {
+                Index = 1,
+                Path = "Path1"
+            };
+            doc2.Lines.Add(1, new Line()
+            {
+                Class = "Class1",
+                Hits = 1,
+                Method = "Method1",
+                Number = 1
+            });
+            doc2.Branches.Add(new BranchKey(1, 1),
+            new Branch()
+            {
+                Class = "Class1",
+                EndOffset = 1,
+                Hits = 1,
+                Method = "Method1",
+                Number = 1,
+                Offset = 1,
+                Ordinal = 1,
+                Path = 1
+            });
+
+            ir.Documents.Add("key", doc);
+            ir.Documents.Add("key2", doc2);
+            cpr.Results = new InstrumenterResult[] { ir };
+
+            CoveragePrepareResult roundTrip = CoveragePrepareResult.Deserialize(CoveragePrepareResult.Serialize(cpr));
+
+            Assert.Equal(cpr.Identifier, roundTrip.Identifier);
+            Assert.Equal(cpr.MergeWith, roundTrip.MergeWith);
+            Assert.Equal(cpr.Module, roundTrip.Module);
+            Assert.Equal(cpr.UseSourceLink, roundTrip.UseSourceLink);
+
+            for (int i = 0; i < cpr.Results.Length; i++)
+            {
+                Assert.Equal(cpr.Results[i].HitsFilePath, roundTrip.Results[i].HitsFilePath);
+                Assert.Equal(cpr.Results[i].Module, roundTrip.Results[i].Module);
+                Assert.Equal(cpr.Results[i].ModulePath, roundTrip.Results[i].ModulePath);
+                Assert.Equal(cpr.Results[i].SourceLink, roundTrip.Results[i].SourceLink);
+
+                for (int k = 0; k < cpr.Results[i].AsyncMachineStateMethod.Length; k++)
+                {
+                    Assert.Equal(cpr.Results[i].AsyncMachineStateMethod[k], roundTrip.Results[i].AsyncMachineStateMethod[k]);
+                }
+
+                for (int k = 0; k < cpr.Results[i].HitCandidates.Count; k++)
+                {
+                    Assert.Equal(cpr.Results[i].HitCandidates[k].start, roundTrip.Results[i].HitCandidates[k].start);
+                    Assert.Equal(cpr.Results[i].HitCandidates[k].isBranch, roundTrip.Results[i].HitCandidates[k].isBranch);
+                    Assert.Equal(cpr.Results[i].HitCandidates[k].end, roundTrip.Results[i].HitCandidates[k].end);
+                    Assert.Equal(cpr.Results[i].HitCandidates[k].docIndex, roundTrip.Results[i].HitCandidates[k].docIndex);
+                }
+
+                for (int k = 0; k < cpr.Results[i].Documents.Count; k++)
+                {
+                    var documents = cpr.Results[i].Documents.ToArray();
+                    var documentsRoundTrip = roundTrip.Results[i].Documents.ToArray();
+                    for (int j = 0; j < documents.Length; j++)
+                    {
+                        Assert.Equal(documents[j].Key, documentsRoundTrip[j].Key);
+                        Assert.Equal(documents[j].Value.Index, documentsRoundTrip[j].Value.Index);
+                        Assert.Equal(documents[j].Value.Path, documentsRoundTrip[j].Value.Path);
+
+                        for (int v = 0; v < documents[j].Value.Lines.Count; v++)
+                        {
+                            var lines = documents[j].Value.Lines.ToArray();
+                            var linesRoundTrip = documentsRoundTrip[j].Value.Lines.ToArray();
+
+                            Assert.Equal(lines[v].Key, linesRoundTrip[v].Key);
+                            Assert.Equal(lines[v].Value.Class, lines[v].Value.Class);
+                            Assert.Equal(lines[v].Value.Hits, lines[v].Value.Hits);
+                            Assert.Equal(lines[v].Value.Method, lines[v].Value.Method);
+                            Assert.Equal(lines[v].Value.Number, lines[v].Value.Number);
+                        }
+
+                        for (int v = 0; v < documents[j].Value.Branches.Count; v++)
+                        {
+                            var branches = documents[j].Value.Branches.ToArray();
+                            var branchesRoundTrip = documentsRoundTrip[j].Value.Branches.ToArray();
+
+                            Assert.Equal(branches[v].Key, branchesRoundTrip[v].Key);
+                            Assert.Equal(branches[v].Value.Class, branchesRoundTrip[v].Value.Class);
+                            Assert.Equal(branches[v].Value.EndOffset, branchesRoundTrip[v].Value.EndOffset);
+                            Assert.Equal(branches[v].Value.Hits, branchesRoundTrip[v].Value.Hits);
+                            Assert.Equal(branches[v].Value.Method, branchesRoundTrip[v].Value.Method);
+                            Assert.Equal(branches[v].Value.Number, branchesRoundTrip[v].Value.Number);
+                            Assert.Equal(branches[v].Value.Offset, branchesRoundTrip[v].Value.Offset);
+                            Assert.Equal(branches[v].Value.Ordinal, branchesRoundTrip[v].Value.Ordinal);
+                            Assert.Equal(branches[v].Value.Path, branchesRoundTrip[v].Value.Path);
+                        }
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/tonerdo/coverlet/issues/452

* I changed serializer, now we use `DataContractSerializer` that doesn't need converters and follow guidelines 
https://docs.microsoft.com/en-us/visualstudio/code-quality/ca2300-do-not-use-insecure-deserializer-binaryformatter?view=vs-2019
 https://docs.microsoft.com/en-us/visualstudio/code-quality/ca2301-do-not-call-binaryformatter-deserialize-without-first-setting-binaryformatter-binder?view=vs-2019

* Downgraded Newtosoft.Json ref in core dll because we risk to have issue with old SDK.
* Updated debug doc with new `/p:CoverletToolsPath` usage thank's to @AArnott update, very useful.

Tested with @AdmiringWorm repo
```
D:\git\Cake.Codecov\Source\Cake.Codecov.Tests (develop -> origin)
λ dotnet --info
.NET Core SDK (reflecting any global.json):
 Version:   2.1.603
 Commit:    ae71c68742
...
D:\git\Cake.Codecov\Source\Cake.Codecov.Tests (develop -> origin)
λ dotnet test /p:CollectCoverage=true /p:Exclude="[xunit.*]*" /p:CoverletToolsPath=D:\git\coverlet\src\coverlet.msbuild.tasks\bin\Debug\netstandard2.0\
Test run for D:\git\Cake.Codecov\Source\Cake.Codecov.Tests\bin\Debug\netcoreapp2.0\Cake.Codecov.Tests.dll(.NETCoreApp,Version=v2.0)
Microsoft (R) Test Execution Command Line Tool Version 16.0.1
Copyright (c) Microsoft Corporation.  All rights reserved.

Starting test execution, please wait...
[xUnit.net 00:00:00.76]     Cake.Codecov.Tests.CodecovRunnerTests.Should_Use_Codecov_Runner_From_Tool_Path_If_Provided_On_Unix [SKIP]
Skipped  Cake.Codecov.Tests.CodecovRunnerTests.Should_Use_Codecov_Runner_From_Tool_Path_If_Provided_On_Unix

Total tests: 33. Passed: 32. Failed: 0. Skipped: 1.
Test Run Successful.
Test execution time: 1.8148 Seconds

Calculating coverage result...
  Generating report 'D:\git\Cake.Codecov\Source\Cake.Codecov.Tests\coverage.json'

+--------------+------+--------+--------+
| Module       | Line | Branch | Method |
+--------------+------+--------+--------+
| Cake.Codecov | 100% | 100%   | 100%   |
+--------------+------+--------+--------+

+---------+------+--------+--------+
|         | Line | Branch | Method |
+---------+------+--------+--------+
| Total   | 100% | 100%   | 100%   |
+---------+------+--------+--------+
| Average | 100% | 100%   | 100%   |
+---------+------+--------+--------+

Test run for D:\git\Cake.Codecov\Source\Cake.Codecov.Tests\bin\Debug\net46\Cake.Codecov.Tests.dll(.NETFramework,Version=v4.6)
Microsoft (R) Test Execution Command Line Tool Version 16.0.1
Copyright (c) Microsoft Corporation.  All rights reserved.

Starting test execution, please wait...
[xUnit.net 00:00:00.76]     Cake.Codecov.Tests.CodecovRunnerTests.Should_Use_Codecov_Runner_From_Tool_Path_If_Provided_On_Unix [SKIP]
Skipped  Cake.Codecov.Tests.CodecovRunnerTests.Should_Use_Codecov_Runner_From_Tool_Path_If_Provided_On_Unix

Total tests: 33. Passed: 32. Failed: 0. Skipped: 1.
Test Run Successful.
Test execution time: 2.0821 Seconds

Calculating coverage result...
  Generating report 'D:\git\Cake.Codecov\Source\Cake.Codecov.Tests\coverage.json'

+--------------+------+--------+--------+
| Module       | Line | Branch | Method |
+--------------+------+--------+--------+
| Cake.Codecov | 100% | 100%   | 100%   |
+--------------+------+--------+--------+

+---------+------+--------+--------+
|         | Line | Branch | Method |
+---------+------+--------+--------+
| Total   | 100% | 100%   | 100%   |
+---------+------+--------+--------+
| Average | 100% | 100%   | 100%   |
+---------+------+--------+--------+

```
Tested also with "old" code and it break with sdk 2.1.603 as expected.

cc: @tonerdo 