### PR TITLE
Add `[xunit*]*` to default excluded modules filter if not specified

### DIFF
--- a/src/coverlet.collector/DataCollection/CoverletSettingsParser.cs
+++ b/src/coverlet.collector/DataCollection/CoverletSettingsParser.cs
@@ -131,6 +131,13 @@ namespace Coverlet.Collector.DataCollection
                 }
             }
 
+            // if we've only one element mean that we only added CoverletConstants.DefaultExcludeFilter
+            // so add default exclusions
+            if (excludeFilters.Count == 1)
+            {
+                excludeFilters.Add("[xunit*]*");
+            }
+
             return excludeFilters.ToArray();
         }
 

--- a/src/coverlet.console/Program.cs
+++ b/src/coverlet.console/Program.cs
@@ -57,6 +57,12 @@ namespace Coverlet.Console
                     logger.Level = verbosity.ParsedValue;
                 }
 
+                // We add default exclusion filter if no specified
+                if (excludeFilters.Values.Count == 0)
+                {
+                    excludeFilters.Values.Add("[xunit*]*");
+                }
+
                 Coverage coverage = new Coverage(module.Value,
                     includeFilters.Values.ToArray(),
                     includeDirectories.Values.ToArray(),

--- a/src/coverlet.msbuild.tasks/InstrumentationTask.cs
+++ b/src/coverlet.msbuild.tasks/InstrumentationTask.cs
@@ -104,6 +104,12 @@ namespace Coverlet.MSbuild.Tasks
                 var excludedSourceFiles = _excludeByFile?.Split(',');
                 var excludeAttributes = _excludeByAttribute?.Split(',');
 
+                // We add default exclusion filter if no specified
+                if (excludeFilters is null || excludeFilters.Length == 0)
+                {
+                    excludeFilters = new string[] { "[xunit*]*" };
+                }
+
                 Coverage coverage = new Coverage(_path, includeFilters, includeDirectories, excludeFilters, excludedSourceFiles, excludeAttributes, _includeTestAssembly, _singleHit, _mergeWith, _useSourceLink, _logger);
                 CoveragePrepareResult prepareResult = coverage.PrepareModules();
                 InstrumenterState = new TaskItem(System.IO.Path.GetTempFileName());

--- a/test/coverlet.collector.tests/CoverletSettingsParserTests.cs
+++ b/test/coverlet.collector.tests/CoverletSettingsParserTests.cs
@@ -88,6 +88,7 @@ namespace Coverlet.Collector.Tests
 
             Assert.Equal("[coverlet.*]*", coverletSettings.ExcludeFilters[0]);
             Assert.Equal("[xunit*]*", coverletSettings.ExcludeFilters[1]);
+            Assert.Equal(2, coverletSettings.ExcludeFilters.Length);
         }
 
         [Fact]

--- a/test/coverlet.collector.tests/CoverletSettingsParserTests.cs
+++ b/test/coverlet.collector.tests/CoverletSettingsParserTests.cs
@@ -78,5 +78,32 @@ namespace Coverlet.Collector.Tests
             node.InnerText = nodeValue;
             configElement.AppendChild(node);
         }
+
+        [Fact]
+        public void ParseShouldSkipXunitModulesIfEmptyExclude()
+        {
+            var testModules = new List<string> { "abc.dll" };
+
+            CoverletSettings coverletSettings = _coverletSettingsParser.Parse(null, testModules);
+
+            Assert.Equal("[coverlet.*]*", coverletSettings.ExcludeFilters[0]);
+            Assert.Equal("[xunit*]*", coverletSettings.ExcludeFilters[1]);
+        }
+
+        [Fact]
+        public void ParseShouldNotSkipXunitModulesIfNotEmptyExclude()
+        {
+            var testModules = new List<string> { "abc.dll" };
+            var doc = new XmlDocument();
+            var configElement = doc.CreateElement("Configuration");
+            this.CreateCoverletNodes(doc, configElement, CoverletConstants.ExcludeFiltersElementName, "[coverlet.*.tests?]*");
+
+            CoverletSettings coverletSettings = _coverletSettingsParser.Parse(configElement, testModules);
+
+            Assert.Equal("[coverlet.*]*", coverletSettings.ExcludeFilters[0]);
+            Assert.Equal("[coverlet.*.tests?]*", coverletSettings.ExcludeFilters[1]);
+            Assert.Equal(2, coverletSettings.ExcludeFilters.Length);
+            Assert.DoesNotContain("[xunit*]*", coverletSettings.ExcludeFilters);
+        }
     }
 }


### PR DESCRIPTION
closes https://github.com/tonerdo/coverlet/issues/461

cc: @tonerdo @vagisha-nidhi @onovotny