### PR TITLE
[Bug fix]Fix culture for cobertura xml report

### DIFF
--- a/src/coverlet.core/Reporters/CoberturaReporter.cs
+++ b/src/coverlet.core/Reporters/CoberturaReporter.cs
@@ -1,9 +1,8 @@
 using System;
-using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Xml;
 using System.Xml.Linq;
 
 namespace Coverlet.Core.Reporters
@@ -25,10 +24,10 @@ namespace Coverlet.Core.Reporters
 
             XDocument xml = new XDocument();
             XElement coverage = new XElement("coverage");
-            coverage.Add(new XAttribute("line-rate", (summary.CalculateLineCoverage(result.Modules).Percent / 100).ToString()));
-            coverage.Add(new XAttribute("branch-rate", (summary.CalculateBranchCoverage(result.Modules).Percent / 100).ToString()));
+            coverage.Add(new XAttribute("line-rate", (summary.CalculateLineCoverage(result.Modules).Percent / 100).ToString(CultureInfo.InvariantCulture)));
+            coverage.Add(new XAttribute("branch-rate", (summary.CalculateBranchCoverage(result.Modules).Percent / 100).ToString(CultureInfo.InvariantCulture)));
             coverage.Add(new XAttribute("version", "1.9"));
-            coverage.Add(new XAttribute("timestamp", ((int)(DateTime.UtcNow - new DateTime(1970, 1, 1)).TotalSeconds).ToString()));
+            coverage.Add(new XAttribute("timestamp", (int)(DateTime.UtcNow - new DateTime(1970, 1, 1)).TotalSeconds));
 
             XElement sources = new XElement("sources");
             sources.Add(new XElement("source", string.Empty));
@@ -38,9 +37,9 @@ namespace Coverlet.Core.Reporters
             {
                 XElement package = new XElement("package");
                 package.Add(new XAttribute("name", Path.GetFileNameWithoutExtension(module.Key)));
-                package.Add(new XAttribute("line-rate", (summary.CalculateLineCoverage(module.Value).Percent / 100).ToString()));
-                package.Add(new XAttribute("branch-rate", (summary.CalculateBranchCoverage(module.Value).Percent / 100).ToString()));
-                package.Add(new XAttribute("complexity", summary.CalculateCyclomaticComplexity(module.Value).ToString()));
+                package.Add(new XAttribute("line-rate", (summary.CalculateLineCoverage(module.Value).Percent / 100).ToString(CultureInfo.InvariantCulture)));
+                package.Add(new XAttribute("branch-rate", (summary.CalculateBranchCoverage(module.Value).Percent / 100).ToString(CultureInfo.InvariantCulture)));
+                package.Add(new XAttribute("complexity", summary.CalculateCyclomaticComplexity(module.Value)));
 
                 XElement classes = new XElement("classes");
                 foreach (var document in module.Value)
@@ -50,9 +49,9 @@ namespace Coverlet.Core.Reporters
                         XElement @class = new XElement("class");
                         @class.Add(new XAttribute("name", cls.Key));
                         @class.Add(new XAttribute("filename", document.Key));
-                        @class.Add(new XAttribute("line-rate", (summary.CalculateLineCoverage(cls.Value).Percent / 100).ToString()));
-                        @class.Add(new XAttribute("branch-rate", (summary.CalculateBranchCoverage(cls.Value).Percent / 100).ToString()));
-                        @class.Add(new XAttribute("complexity", summary.CalculateCyclomaticComplexity(cls.Value).ToString()));
+                        @class.Add(new XAttribute("line-rate", (summary.CalculateLineCoverage(cls.Value).Percent / 100).ToString(CultureInfo.InvariantCulture)));
+                        @class.Add(new XAttribute("branch-rate", (summary.CalculateBranchCoverage(cls.Value).Percent / 100).ToString(CultureInfo.InvariantCulture)));
+                        @class.Add(new XAttribute("complexity", summary.CalculateCyclomaticComplexity(cls.Value)));
 
                         XElement classLines = new XElement("lines");
                         XElement methods = new XElement("methods");
@@ -66,8 +65,8 @@ namespace Coverlet.Core.Reporters
                             XElement method = new XElement("method");
                             method.Add(new XAttribute("name", meth.Key.Split(':')[2].Split('(')[0]));
                             method.Add(new XAttribute("signature", "(" + meth.Key.Split(':')[2].Split('(')[1]));
-                            method.Add(new XAttribute("line-rate", (summary.CalculateLineCoverage(meth.Value.Lines).Percent / 100).ToString()));
-                            method.Add(new XAttribute("branch-rate", (summary.CalculateBranchCoverage(meth.Value.Branches).Percent / 100).ToString()));
+                            method.Add(new XAttribute("line-rate", (summary.CalculateLineCoverage(meth.Value.Lines).Percent / 100).ToString(CultureInfo.InvariantCulture)));
+                            method.Add(new XAttribute("branch-rate", (summary.CalculateBranchCoverage(meth.Value.Branches).Percent / 100).ToString(CultureInfo.InvariantCulture)));
 
                             XElement lines = new XElement("lines");
                             foreach (var ln in meth.Value.Lines)
@@ -82,7 +81,7 @@ namespace Coverlet.Core.Reporters
                                 {
                                     var branches = meth.Value.Branches.Where(b => b.Line == ln.Key).ToList();
                                     var branchInfoCoverage = summary.CalculateBranchCoverage(branches);
-                                    line.Add(new XAttribute("condition-coverage", $"{branchInfoCoverage.Percent}% ({branchInfoCoverage.Covered}/{branchInfoCoverage.Total})"));
+                                    line.Add(new XAttribute("condition-coverage", $"{branchInfoCoverage.Percent.ToString(CultureInfo.InvariantCulture)}% ({branchInfoCoverage.Covered.ToString(CultureInfo.InvariantCulture)}/{branchInfoCoverage.Total.ToString(CultureInfo.InvariantCulture)})"));
                                     XElement conditions = new XElement("conditions");
                                     var byOffset = branches.GroupBy(b => b.Offset).ToDictionary(b => b.Key, b => b.ToList());
                                     foreach (var entry in byOffset)
@@ -90,7 +89,7 @@ namespace Coverlet.Core.Reporters
                                         XElement condition = new XElement("condition");
                                         condition.Add(new XAttribute("number", entry.Key));
                                         condition.Add(new XAttribute("type", entry.Value.Count() > 2 ? "switch" : "jump")); // Just guessing here
-                                        condition.Add(new XAttribute("coverage", $"{summary.CalculateBranchCoverage(entry.Value).Percent}%"));
+                                        condition.Add(new XAttribute("coverage", $"{summary.CalculateBranchCoverage(entry.Value).Percent.ToString(CultureInfo.InvariantCulture)}%"));
                                         conditions.Add(condition);
                                     }
 
@@ -116,10 +115,10 @@ namespace Coverlet.Core.Reporters
                 packages.Add(package);
             }
 
-            coverage.Add(new XAttribute("lines-covered", lineCoverage.Covered.ToString()));
-            coverage.Add(new XAttribute("lines-valid", lineCoverage.Total.ToString()));
-            coverage.Add(new XAttribute("branches-covered", branchCoverage.Covered.ToString()));
-            coverage.Add(new XAttribute("branches-valid", branchCoverage.Total.ToString()));
+            coverage.Add(new XAttribute("lines-covered", lineCoverage.Covered.ToString(CultureInfo.InvariantCulture)));
+            coverage.Add(new XAttribute("lines-valid", lineCoverage.Total.ToString(CultureInfo.InvariantCulture)));
+            coverage.Add(new XAttribute("branches-covered", branchCoverage.Covered.ToString(CultureInfo.InvariantCulture)));
+            coverage.Add(new XAttribute("branches-valid", branchCoverage.Total.ToString(CultureInfo.InvariantCulture)));
 
             coverage.Add(sources);
             coverage.Add(packages);

--- a/test/coverlet.core.tests/Reporters/CoberturaReporterTests.cs
+++ b/test/coverlet.core.tests/Reporters/CoberturaReporterTests.cs
@@ -53,6 +53,8 @@ namespace Coverlet.Core.Reporters.Tests
                 CoberturaReporter reporter = new CoberturaReporter();
                 string report = reporter.Report(result);
 
+                Assert.NotEmpty(report);
+
                 var doc = XDocument.Load(new MemoryStream(Encoding.UTF8.GetBytes(report)));
                 Assert.All(doc.Descendants().Attributes().Where(attr => attr.Name.LocalName.EndsWith("-rate")).Select(attr => attr.Value),
                 value =>

--- a/test/coverlet.core.tests/Reporters/CoberturaReporterTests.cs
+++ b/test/coverlet.core.tests/Reporters/CoberturaReporterTests.cs
@@ -46,7 +46,7 @@ namespace Coverlet.Core.Reporters.Tests
             Thread.CurrentThread.CurrentCulture = new CultureInfo("it-IT");
             try
             {
-                // Asserts conversion behaviours to be sure to be in a Italian culture context
+                // Assert conversion behaviour to be sure to be in a Italian culture context
                 // where decimal char is comma.
                 Assert.Equal("1,5", (1.5).ToString());
 

--- a/test/coverlet.core.tests/Reporters/CoberturaReporterTests.cs
+++ b/test/coverlet.core.tests/Reporters/CoberturaReporterTests.cs
@@ -1,5 +1,12 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Xml;
+using System.Xml.Linq;
 using Xunit;
 
 namespace Coverlet.Core.Reporters.Tests
@@ -35,8 +42,30 @@ namespace Coverlet.Core.Reporters.Tests
             result.Modules = new Modules();
             result.Modules.Add("module", documents);
 
-            CoberturaReporter reporter = new CoberturaReporter();
-            Assert.NotEqual(string.Empty, reporter.Report(result));
+            CultureInfo currentCulture = Thread.CurrentThread.CurrentCulture;
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("it-IT");
+            try
+            {
+                // Asserts conversion behaviours to be sure to be in a Italian culture context
+                // where decimal char is comma.
+                Assert.Equal("1,5", (1.5).ToString());
+
+                CoberturaReporter reporter = new CoberturaReporter();
+                string report = reporter.Report(result);
+
+                var doc = XDocument.Load(new MemoryStream(Encoding.UTF8.GetBytes(report)));
+                Assert.All(doc.Descendants().Attributes().Where(attr => attr.Name.LocalName.EndsWith("-rate")).Select(attr => attr.Value),
+                value =>
+                {
+                    Assert.DoesNotContain(",", value);
+                    Assert.Contains(".", value);
+                    Assert.Equal(0.5, double.Parse(value, CultureInfo.InvariantCulture));
+                });
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentCulture = currentCulture;
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/tonerdo/coverlet/issues/463

@boldt comes from Germany where culture uses comma as decimal separator(like Italy).
This PR fix conversion using `InvariantCulture` that is defined as 
`The invariant culture is culture-insensitive; it is associated with the English language but not with any country/region. ` 
doc https://docs.microsoft.com/en-us/dotnet/api/system.globalization.cultureinfo.invariantculture?view=netcore-2.2

Found this useful guide on formats...english languages uses dot. https://docs.oracle.com/cd/E19455-01/806-0169/overview-9/index.html

cc: @tonerdo 