### PR TITLE
VSTest collector: target netstandard

### DIFF
--- a/src/coverlet.collector/coverlet.collector.csproj
+++ b/src/coverlet.collector/coverlet.collector.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" >
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyTitle>coverlet.collector</AssemblyTitle>
     <PackageId>coverlet.collector</PackageId>
     <Title>coverlet.collector</Title>


### PR DESCRIPTION
Instead of netcoreapp.

This allows our VSTest collector to be used within Visual Studio (e.g. v16.1.3). Without this, said collector only seems to work from the VSTest console application.