### PR TITLE
Fix property attribute detection

### DIFF
--- a/src/coverlet.core/Instrumentation/Instrumenter.cs
+++ b/src/coverlet.core/Instrumentation/Instrumenter.cs
@@ -273,10 +273,20 @@ namespace Coverlet.Core.Instrumentation
             foreach (var method in methods)
             {
                 MethodDefinition actualMethod = method;
+                IEnumerable<CustomAttribute> customAttributes = method.CustomAttributes;
                 if (InstrumentationHelper.IsLocalMethod(method.Name))
                     actualMethod = methods.FirstOrDefault(m => m.Name == method.Name.Split('>')[0].Substring(1)) ?? method;
 
-                if (!actualMethod.CustomAttributes.Any(IsExcludeAttribute))
+                if (actualMethod.IsGetter || actualMethod.IsSetter)
+                {
+                    var prop = type.Properties.FirstOrDefault(p => p.GetMethod.FullName.Equals(actualMethod.FullName));
+                    if (prop?.HasCustomAttributes == true)
+                    {
+                        customAttributes = customAttributes.Union(prop.CustomAttributes);
+                    }
+                }
+
+                if (!customAttributes.Any(IsExcludeAttribute))
                     InstrumentMethod(method);
             }
 

--- a/src/coverlet.core/Instrumentation/Instrumenter.cs
+++ b/src/coverlet.core/Instrumentation/Instrumenter.cs
@@ -281,9 +281,7 @@ namespace Coverlet.Core.Instrumentation
                 {
                     var prop = type.Properties.FirstOrDefault(p => p.GetMethod.FullName.Equals(actualMethod.FullName));
                     if (prop?.HasCustomAttributes == true)
-                    {
                         customAttributes = customAttributes.Union(prop.CustomAttributes);
-                    }
                 }
 
                 if (!customAttributes.Any(IsExcludeAttribute))

--- a/src/coverlet.core/Instrumentation/Instrumenter.cs
+++ b/src/coverlet.core/Instrumentation/Instrumenter.cs
@@ -279,7 +279,7 @@ namespace Coverlet.Core.Instrumentation
 
                 if (actualMethod.IsGetter || actualMethod.IsSetter)
                 {
-                    var prop = type.Properties.FirstOrDefault(p => p.GetMethod.FullName.Equals(actualMethod.FullName));
+                    PropertyDefinition prop = type.Properties.FirstOrDefault(p => p.GetMethod.FullName.Equals(actualMethod.FullName));
                     if (prop?.HasCustomAttributes == true)
                         customAttributes = customAttributes.Union(prop.CustomAttributes);
                 }

--- a/test/coverlet.core.tests/Instrumentation/InstrumenterTests.cs
+++ b/test/coverlet.core.tests/Instrumentation/InstrumenterTests.cs
@@ -84,7 +84,6 @@ namespace Coverlet.Core.Instrumentation.Tests
             instrumenterTest.Directory.Delete(true);
         }
 
-
         [Theory]
         [InlineData(nameof(ObsoleteAttribute))]
         [InlineData("Obsolete")]
@@ -99,6 +98,47 @@ namespace Coverlet.Core.Instrumentation.Tests
             var found = doc.Lines.Values.Any(l => l.Class.Equals(nameof(ClassExcludedByObsoleteAttr)));
 #pragma warning restore CS0612 // Type or member is obsolete
             Assert.False(found, "Class decorated with with exclude attribute should be excluded");
+
+            instrumenterTest.Directory.Delete(true);
+        }
+
+        [Theory]
+        [InlineData(nameof(ObsoleteAttribute))]
+        [InlineData("Obsolete")]
+        public void TestInstrument_ClassesWithMethodWithCustomExcludeAttributeAreExcluded(string excludedAttribute)
+        {
+            var instrumenterTest = CreateInstrumentor(attributesToIgnore: new string[] { excludedAttribute });
+            var result = instrumenterTest.Instrumenter.Instrument();
+
+            var doc = result.Documents.Values.FirstOrDefault(d => Path.GetFileName(d.Path) == "Samples.cs");
+            Assert.NotNull(doc);
+#pragma warning disable CS0612 // Type or member is obsolete
+            var found = doc.Lines.Values.Any(l => l.Method.Equals("System.String Coverlet.Core.Samples.Tests.ClassWithMethodExcludedByObsoleteAttr::Method(System.String)"));
+#pragma warning restore CS0612 // Type or member is obsolete
+            Assert.False(found, "Method decorated with with exclude attribute should be excluded");
+
+            instrumenterTest.Directory.Delete(true);
+        }
+
+        [Theory]
+        [InlineData(nameof(ObsoleteAttribute))]
+        [InlineData("Obsolete")]
+        public void TestInstrument_ClassesWithPropertyWithCustomExcludeAttributeAreExcluded(string excludedAttribute)
+        {
+            var instrumenterTest = CreateInstrumentor(attributesToIgnore: new string[] { excludedAttribute });
+            var result = instrumenterTest.Instrumenter.Instrument();
+
+            var doc = result.Documents.Values.FirstOrDefault(d => Path.GetFileName(d.Path) == "Samples.cs");
+            Assert.NotNull(doc);
+#pragma warning disable CS0612 // Type or member is obsolete
+            var getFound = doc.Lines.Values.Any(l => l.Method.Equals("System.String Coverlet.Core.Samples.Tests.ClassWithPropertyExcludedByObsoleteAttr::get_Property()"));
+#pragma warning restore CS0612 // Type or member is obsolete
+            Assert.False(getFound, "Property getter decorated with with exclude attribute should be excluded");
+
+#pragma warning disable CS0612 // Type or member is obsolete
+            var setFound = doc.Lines.Values.Any(l => l.Method.Equals("System.String Coverlet.Core.Samples.Tests.ClassWithPropertyExcludedByObsoleteAttr::set_Property()"));
+#pragma warning restore CS0612 // Type or member is obsolete
+            Assert.False(setFound, "Property setter decorated with with exclude attribute should be excluded");
 
             instrumenterTest.Directory.Delete(true);
         }

--- a/test/coverlet.core.tests/Samples/Samples.cs
+++ b/test/coverlet.core.tests/Samples/Samples.cs
@@ -188,7 +188,6 @@ namespace Coverlet.Core.Samples.Tests
     [ExcludeFromCodeCoverage]
     public class ClassExcludedByCodeAnalysisCodeCoverageAttr
     {
-
         public string Method(string input)
         {
             if (string.IsNullOrEmpty(input))
@@ -201,7 +200,6 @@ namespace Coverlet.Core.Samples.Tests
     [Obsolete]
     public class ClassExcludedByObsoleteAttr
     {
-
         public string Method(string input)
         {
             if (string.IsNullOrEmpty(input))
@@ -209,6 +207,24 @@ namespace Coverlet.Core.Samples.Tests
 
             return input;
         }
+    }
+
+    public class ClassWithMethodExcludedByObsoleteAttr
+    {
+        [Obsolete]
+        public string Method(string input)
+        {
+            if (string.IsNullOrEmpty(input))
+                throw new ArgumentException("Cannot be empty", nameof(input));
+
+            return input;
+        }
+    }
+
+    public class ClassWithPropertyExcludedByObsoleteAttr
+    {
+        [Obsolete]
+        public string Property { get; set; }
     }
 
     public class ExceptionFilter


### PR DESCRIPTION
I realized my initial work on #233 and #232 overlooked custom attributes on properties and checking them against each of the generated methods. This resolves that with a few updated tests and may achieve the desired result for #81 if you add `CompilerGenerated` to the list of excluded attributes.

I didn't create a new issue for this per the contribution guidelines since it was technically related to an existing one, but let me know if you want one there.