### PR TITLE
Changed to calculate based on the average coverage of the modules

### DIFF
--- a/src/coverlet.console/ConsoleTables/ConsoleTable.cs
+++ b/src/coverlet.console/ConsoleTables/ConsoleTable.cs
@@ -150,10 +150,10 @@ namespace ConsoleTables
             var format = Format(columnLengths, delimiter);
 
             // find the longest formatted line
-            var columnHeaders = string.Format(format, Columns.ToArray());
+            var columnHeaders = string.Format(format["Header"], Columns.ToArray());
 
             // add each row
-            var results = Rows.Select(row => string.Format(format, row)).ToList();
+            var results = Rows.Select(row => string.Format(format["Body"], row)).ToList();
 
             // create the divider
             var divider = Regex.Replace(columnHeaders, @"[^|]", "-");
@@ -181,10 +181,10 @@ namespace ConsoleTables
             var format = Format(columnLengths);
 
             // find the longest formatted line
-            var columnHeaders = string.Format(format, Columns.ToArray());
+            var columnHeaders = string.Format(format["Header"], Columns.ToArray());
 
             // add each row
-            var results = Rows.Select(row => string.Format(format, row)).ToList();
+            var results = Rows.Select(row => string.Format(format["Body"], row)).ToList();
 
             // create the divider
             var divider = Regex.Replace(columnHeaders, @"[^|]", "-");
@@ -203,13 +203,33 @@ namespace ConsoleTables
             return builder.ToString();
         }
 
-        private string Format(List<int> columnLengths, char delimiter = '|')
+        private Dictionary<string, string> Format(List<int> columnLengths, char delimiter = '|')
         {
             var delimiterStr = delimiter == char.MinValue ? string.Empty : delimiter.ToString();
             var format = (Enumerable.Range(0, Columns.Count)
                 .Select(i => " " + delimiterStr + " {" + i + ",-" + columnLengths[i] + "}")
                 .Aggregate((s, a) => s + a) + " " + delimiterStr).Trim();
-            return format;
+
+            return new Dictionary<string, string>()
+            {
+                { "Header", format },
+                { "Body", NumberRightAligment(format) }
+            };
+        }
+
+        private string NumberRightAligment(string format)
+        {
+            int index = 0;
+            return Regex.Replace(
+                format,
+                @"\-\d+",
+                m => Replacement(m.Captures[0].Value, index++)
+            );
+        }
+
+        private string Replacement(string matchValue, int index)
+        {
+            return string.Format("{0}", index > 0 ? matchValue.Replace("-", "") : matchValue);
         }
 
         private List<int> ColumnLengths()

--- a/src/coverlet.console/ConsoleTables/ConsoleTable.cs
+++ b/src/coverlet.console/ConsoleTables/ConsoleTable.cs
@@ -150,10 +150,10 @@ namespace ConsoleTables
             var format = Format(columnLengths, delimiter);
 
             // find the longest formatted line
-            var columnHeaders = string.Format(format["Header"], Columns.ToArray());
+            var columnHeaders = string.Format(format, Columns.ToArray());
 
             // add each row
-            var results = Rows.Select(row => string.Format(format["Body"], row)).ToList();
+            var results = Rows.Select(row => string.Format(format, row)).ToList();
 
             // create the divider
             var divider = Regex.Replace(columnHeaders, @"[^|]", "-");
@@ -181,10 +181,10 @@ namespace ConsoleTables
             var format = Format(columnLengths);
 
             // find the longest formatted line
-            var columnHeaders = string.Format(format["Header"], Columns.ToArray());
+            var columnHeaders = string.Format(format, Columns.ToArray());
 
             // add each row
-            var results = Rows.Select(row => string.Format(format["Body"], row)).ToList();
+            var results = Rows.Select(row => string.Format(format, row)).ToList();
 
             // create the divider
             var divider = Regex.Replace(columnHeaders, @"[^|]", "-");
@@ -203,33 +203,13 @@ namespace ConsoleTables
             return builder.ToString();
         }
 
-        private Dictionary<string, string> Format(List<int> columnLengths, char delimiter = '|')
+        private string Format(List<int> columnLengths, char delimiter = '|')
         {
             var delimiterStr = delimiter == char.MinValue ? string.Empty : delimiter.ToString();
             var format = (Enumerable.Range(0, Columns.Count)
                 .Select(i => " " + delimiterStr + " {" + i + ",-" + columnLengths[i] + "}")
                 .Aggregate((s, a) => s + a) + " " + delimiterStr).Trim();
-
-            return new Dictionary<string, string>()
-            {
-                { "Header", format },
-                { "Body", NumberRightAligment(format) }
-            };
-        }
-
-        private string NumberRightAligment(string format)
-        {
-            int index = 0;
-            return Regex.Replace(
-                format,
-                @"\-\d+",
-                m => Replacement(m.Captures[0].Value, index++)
-            );
-        }
-
-        private string Replacement(string matchValue, int index)
-        {
-            return string.Format("{0}", index > 0 ? matchValue.Replace("-", "") : matchValue);
+            return format;
         }
 
         private List<int> ColumnLengths()

--- a/src/coverlet.console/Program.cs
+++ b/src/coverlet.console/Program.cs
@@ -172,9 +172,9 @@ namespace Coverlet.Console
                 var totalBranchPercent = summary.CalculateBranchCoverage(result.Modules).Percent;
                 var totalMethodPercent = summary.CalculateMethodCoverage(result.Modules).Percent;
 
-                var averageLinePercent = summary.CalculateLineCoverage(result.Modules).AveragePercent;
-                var averageBranchPercent = summary.CalculateBranchCoverage(result.Modules).AveragePercent;
-                var averageMethodPercent = summary.CalculateMethodCoverage(result.Modules).AveragePercent;
+                var averageLinePercent = summary.CalculateLineCoverage(result.Modules).AverageModulePercent;
+                var averageBranchPercent = summary.CalculateBranchCoverage(result.Modules).AverageModulePercent;
+                var averageMethodPercent = summary.CalculateMethodCoverage(result.Modules).AverageModulePercent;
 
                 foreach (var _module in result.Modules)
                 {

--- a/src/coverlet.console/Program.cs
+++ b/src/coverlet.console/Program.cs
@@ -172,13 +172,17 @@ namespace Coverlet.Console
                 var totalBranchPercent = summary.CalculateBranchCoverage(result.Modules).Percent;
                 var totalMethodPercent = summary.CalculateMethodCoverage(result.Modules).Percent;
 
+                var averageLinePercent = summary.CalculateLineCoverage(result.Modules).AveragePercent;
+                var averageBranchPercent = summary.CalculateBranchCoverage(result.Modules).AveragePercent;
+                var averageMethodPercent = summary.CalculateMethodCoverage(result.Modules).AveragePercent;
+
                 foreach (var _module in result.Modules)
                 {
                     var linePercent = summary.CalculateLineCoverage(_module.Value).Percent;
                     var branchPercent = summary.CalculateBranchCoverage(_module.Value).Percent;
                     var methodPercent = summary.CalculateMethodCoverage(_module.Value).Percent;
 
-                    coverageTable.AddRow(Path.GetFileNameWithoutExtension(_module.Key), $"{linePercent}%", $"{branchPercent}%", $"{methodPercent}%");
+                    coverageTable.AddRow(Path.GetFileNameWithoutExtension(_module.Key), $"{linePercent.ToString("0.00")}%", $"{branchPercent.ToString("0.00")}%", $"{methodPercent.ToString("0.00")}%");
                 }
 
                 logger.LogInformation(coverageTable.ToStringAlternative());
@@ -187,8 +191,8 @@ namespace Coverlet.Console
                 coverageTable.Rows.Clear();
 
                 coverageTable.AddColumn(new[] { "", "Line", "Branch", "Method" });
-                coverageTable.AddRow("Total", $"{totalLinePercent}%", $"{totalBranchPercent}%", $"{totalMethodPercent}%");
-                coverageTable.AddRow("Average", $"{totalLinePercent / numModules}%", $"{totalBranchPercent / numModules}%", $"{totalMethodPercent / numModules}%");
+                coverageTable.AddRow("Total", $"{totalLinePercent.ToString("0.00")}%", $"{totalBranchPercent.ToString("0.00")}%", $"{totalMethodPercent.ToString("0.00")}%");
+                coverageTable.AddRow("Average", $"{averageLinePercent.ToString("0.00")}%", $"{averageBranchPercent.ToString("0.00")}%", $"{averageMethodPercent.ToString("0.00")}%");
 
                 logger.LogInformation(coverageTable.ToStringAlternative());
 

--- a/src/coverlet.console/Program.cs
+++ b/src/coverlet.console/Program.cs
@@ -168,13 +168,17 @@ namespace Coverlet.Console
                 var summary = new CoverageSummary();
                 int numModules = result.Modules.Count;
 
-                var totalLinePercent = summary.CalculateLineCoverage(result.Modules).Percent;
-                var totalBranchPercent = summary.CalculateBranchCoverage(result.Modules).Percent;
-                var totalMethodPercent = summary.CalculateMethodCoverage(result.Modules).Percent;
+                var linePercentCalculation = summary.CalculateLineCoverage(result.Modules);
+                var branchPercentCalculation = summary.CalculateBranchCoverage(result.Modules);
+                var methodPercentCalculation = summary.CalculateMethodCoverage(result.Modules);
 
-                var averageLinePercent = summary.CalculateLineCoverage(result.Modules).AverageModulePercent;
-                var averageBranchPercent = summary.CalculateBranchCoverage(result.Modules).AverageModulePercent;
-                var averageMethodPercent = summary.CalculateMethodCoverage(result.Modules).AverageModulePercent;
+                var totalLinePercent = linePercentCalculation.Percent;
+                var totalBranchPercent = branchPercentCalculation.Percent;
+                var totalMethodPercent = methodPercentCalculation.Percent;
+
+                var averageLinePercent = linePercentCalculation.AverageModulePercent;
+                var averageBranchPercent = branchPercentCalculation.AverageModulePercent;
+                var averageMethodPercent = methodPercentCalculation.AverageModulePercent;
 
                 foreach (var _module in result.Modules)
                 {
@@ -182,7 +186,7 @@ namespace Coverlet.Console
                     var branchPercent = summary.CalculateBranchCoverage(_module.Value).Percent;
                     var methodPercent = summary.CalculateMethodCoverage(_module.Value).Percent;
 
-                    coverageTable.AddRow(Path.GetFileNameWithoutExtension(_module.Key), $"{linePercent.ToString("0.00")}%", $"{branchPercent.ToString("0.00")}%", $"{methodPercent.ToString("0.00")}%");
+                    coverageTable.AddRow(Path.GetFileNameWithoutExtension(_module.Key), $"{linePercent}%", $"{branchPercent}%", $"{methodPercent}%");
                 }
 
                 logger.LogInformation(coverageTable.ToStringAlternative());
@@ -191,8 +195,8 @@ namespace Coverlet.Console
                 coverageTable.Rows.Clear();
 
                 coverageTable.AddColumn(new[] { "", "Line", "Branch", "Method" });
-                coverageTable.AddRow("Total", $"{totalLinePercent.ToString("0.00")}%", $"{totalBranchPercent.ToString("0.00")}%", $"{totalMethodPercent.ToString("0.00")}%");
-                coverageTable.AddRow("Average", $"{averageLinePercent.ToString("0.00")}%", $"{averageBranchPercent.ToString("0.00")}%", $"{averageMethodPercent.ToString("0.00")}%");
+                coverageTable.AddRow("Total", $"{totalLinePercent}%", $"{totalBranchPercent}%", $"{totalMethodPercent}%");
+                coverageTable.AddRow("Average", $"{averageLinePercent}%", $"{averageBranchPercent}%", $"{averageMethodPercent}%");
 
                 logger.LogInformation(coverageTable.ToStringAlternative());
 

--- a/src/coverlet.core/CoverageDetails.cs
+++ b/src/coverlet.core/CoverageDetails.cs
@@ -6,7 +6,13 @@ namespace Coverlet.Core
     {
         public double Covered { get; internal set; }
         public int Total { get; internal set; }
-        public double AverageModulePercent { get; internal set; }
+        private double averageModulePercent;
+        public double AverageModulePercent
+        {
+            get { return Math.Round(averageModulePercent, 2); ; }
+            internal set { averageModulePercent = value; }
+        }
+
         public double Percent => Total == 0 ? 100D : Math.Floor((Covered / Total) * 10000) / 100;
     }
 }

--- a/src/coverlet.core/CoverageDetails.cs
+++ b/src/coverlet.core/CoverageDetails.cs
@@ -6,6 +6,7 @@ namespace Coverlet.Core
     {
         public double Covered { get; internal set; }
         public int Total { get; internal set; }
+        public double AveragePercent { get; internal set; }
         public double Percent => Total == 0 ? 100D : Math.Floor((Covered / Total) * 10000) / 100;
     }
 }

--- a/src/coverlet.core/CoverageDetails.cs
+++ b/src/coverlet.core/CoverageDetails.cs
@@ -6,7 +6,7 @@ namespace Coverlet.Core
     {
         public double Covered { get; internal set; }
         public int Total { get; internal set; }
-        public double AveragePercent { get; internal set; }
+        public double AverageModulePercent { get; internal set; }
         public double Percent => Total == 0 ? 100D : Math.Floor((Covered / Total) * 10000) / 100;
     }
 }

--- a/src/coverlet.core/CoverageDetails.cs
+++ b/src/coverlet.core/CoverageDetails.cs
@@ -4,13 +4,13 @@ namespace Coverlet.Core
 {
     public class CoverageDetails
     {
+        private double _averageModulePercent;
         public double Covered { get; internal set; }
         public int Total { get; internal set; }
-        private double averageModulePercent;
         public double AverageModulePercent
         {
-            get { return Math.Floor(averageModulePercent * 100) / 100; }
-            internal set { averageModulePercent = value; }
+            get { return Math.Floor(_averageModulePercent * 100) / 100; }
+            internal set { _averageModulePercent = value; }
         }
 
         public double Percent => Total == 0 ? 100D : Math.Floor((Covered / Total) * 10000) / 100;

--- a/src/coverlet.core/CoverageDetails.cs
+++ b/src/coverlet.core/CoverageDetails.cs
@@ -9,7 +9,7 @@ namespace Coverlet.Core
         private double averageModulePercent;
         public double AverageModulePercent
         {
-            get { return Math.Round(averageModulePercent, 2); ; }
+            get { return Math.Floor(averageModulePercent * 100) / 100; }
             internal set { averageModulePercent = value; }
         }
 

--- a/src/coverlet.core/CoverageResult.cs
+++ b/src/coverlet.core/CoverageResult.cs
@@ -196,9 +196,9 @@ namespace Coverlet.Core
                     break;
                 case ThresholdStatistic.Average:
                     {
-                        var line = summary.CalculateLineCoverage(Modules).AverageModulePercent;
-                        var branch = summary.CalculateBranchCoverage(Modules).AverageModulePercent;
-                        var method = summary.CalculateMethodCoverage(Modules).AverageModulePercent;
+                        double line = summary.CalculateLineCoverage(Modules).AverageModulePercent;
+                        double branch = summary.CalculateBranchCoverage(Modules).AverageModulePercent;
+                        double method = summary.CalculateMethodCoverage(Modules).AverageModulePercent;
                         int numModules = Modules.Count;
 
                         if ((thresholdTypes & ThresholdTypeFlags.Line) != ThresholdTypeFlags.None)

--- a/src/coverlet.core/CoverageResult.cs
+++ b/src/coverlet.core/CoverageResult.cs
@@ -170,9 +170,9 @@ namespace Coverlet.Core
                     {
                         foreach (var module in Modules)
                         {
-                            var line = summary.CalculateLineCoverage(module.Value).Percent;
-                            var branch = summary.CalculateBranchCoverage(module.Value).Percent;
-                            var method = summary.CalculateMethodCoverage(module.Value).Percent;
+                            double line = summary.CalculateLineCoverage(module.Value).Percent;
+                            double branch = summary.CalculateBranchCoverage(module.Value).Percent;
+                            double method = summary.CalculateMethodCoverage(module.Value).Percent;
 
                             if ((thresholdTypes & ThresholdTypeFlags.Line) != ThresholdTypeFlags.None)
                             {
@@ -199,7 +199,6 @@ namespace Coverlet.Core
                         double line = summary.CalculateLineCoverage(Modules).AverageModulePercent;
                         double branch = summary.CalculateBranchCoverage(Modules).AverageModulePercent;
                         double method = summary.CalculateMethodCoverage(Modules).AverageModulePercent;
-                        int numModules = Modules.Count;
 
                         if ((thresholdTypes & ThresholdTypeFlags.Line) != ThresholdTypeFlags.None)
                         {
@@ -222,9 +221,9 @@ namespace Coverlet.Core
                     break;
                 case ThresholdStatistic.Total:
                     {
-                        var line = summary.CalculateLineCoverage(Modules).Percent;
-                        var branch = summary.CalculateBranchCoverage(Modules).Percent;
-                        var method = summary.CalculateMethodCoverage(Modules).Percent;
+                        double line = summary.CalculateLineCoverage(Modules).Percent;
+                        double branch = summary.CalculateBranchCoverage(Modules).Percent;
+                        double method = summary.CalculateMethodCoverage(Modules).Percent;
 
                         if ((thresholdTypes & ThresholdTypeFlags.Line) != ThresholdTypeFlags.None)
                         {

--- a/src/coverlet.core/CoverageResult.cs
+++ b/src/coverlet.core/CoverageResult.cs
@@ -196,33 +196,26 @@ namespace Coverlet.Core
                     break;
                 case ThresholdStatistic.Average:
                     {
-                        double line = 0;
-                        double branch = 0;
-                        double method = 0;
+                        var line = summary.CalculateLineCoverage(Modules).AverageModulePercent;
+                        var branch = summary.CalculateBranchCoverage(Modules).AverageModulePercent;
+                        var method = summary.CalculateMethodCoverage(Modules).AverageModulePercent;
                         int numModules = Modules.Count;
-
-                        foreach (var module in Modules)
-                        {
-                            line += summary.CalculateLineCoverage(module.Value).Percent;
-                            branch += summary.CalculateBranchCoverage(module.Value).Percent;
-                            method += summary.CalculateMethodCoverage(module.Value).Percent;
-                        }
 
                         if ((thresholdTypes & ThresholdTypeFlags.Line) != ThresholdTypeFlags.None)
                         {
-                            if ((line / numModules) < threshold)
+                            if (line < threshold)
                                 thresholdTypeFlags |= ThresholdTypeFlags.Line;
                         }
 
                         if ((thresholdTypes & ThresholdTypeFlags.Branch) != ThresholdTypeFlags.None)
                         {
-                            if ((branch / numModules) < threshold)
+                            if (branch < threshold)
                                 thresholdTypeFlags |= ThresholdTypeFlags.Branch;
                         }
 
                         if ((thresholdTypes & ThresholdTypeFlags.Method) != ThresholdTypeFlags.None)
                         {
-                            if ((method / numModules) < threshold)
+                            if (method < threshold)
                                 thresholdTypeFlags |= ThresholdTypeFlags.Method;
                         }
                     }

--- a/src/coverlet.core/CoverageSummary.cs
+++ b/src/coverlet.core/CoverageSummary.cs
@@ -61,7 +61,7 @@ namespace Coverlet.Core
                 details.Total += moduleCoverage.Total;
                 accumPercent += moduleCoverage.Percent;
             }
-            details.AveragePercent = accumPercent / modules.Count();
+            details.AverageModulePercent = accumPercent / modules.Count();
             return details;
         }
 
@@ -160,7 +160,7 @@ namespace Coverlet.Core
                 details.Total += moduleCoverage.Total;
                 accumPercent += moduleCoverage.Percent;
             }
-            details.AveragePercent = accumPercent / modules.Count();
+            details.AverageModulePercent = accumPercent / modules.Count();
             return details;
         }
 
@@ -220,7 +220,7 @@ namespace Coverlet.Core
                 details.Total += moduleCoverage.Total;
                 accumPercent += moduleCoverage.Percent;
             }
-            details.AveragePercent = accumPercent / modules.Count();
+            details.AverageModulePercent = accumPercent / modules.Count();
             return details;
         }
     }

--- a/src/coverlet.core/CoverageSummary.cs
+++ b/src/coverlet.core/CoverageSummary.cs
@@ -53,12 +53,15 @@ namespace Coverlet.Core
         public CoverageDetails CalculateLineCoverage(Modules modules)
         {
             var details = new CoverageDetails();
+            var accumPercent = 0.0;
             foreach (var module in modules)
             {
                 var moduleCoverage = CalculateLineCoverage(module.Value);
                 details.Covered += moduleCoverage.Covered;
                 details.Total += moduleCoverage.Total;
+                accumPercent += moduleCoverage.Percent;
             }
+            details.AveragePercent = accumPercent / modules.Count();
             return details;
         }
 
@@ -149,12 +152,15 @@ namespace Coverlet.Core
         public CoverageDetails CalculateBranchCoverage(Modules modules)
         {
             var details = new CoverageDetails();
+            var accumPercent = 0.0;
             foreach (var module in modules)
             {
                 var moduleCoverage = CalculateBranchCoverage(module.Value);
                 details.Covered += moduleCoverage.Covered;
                 details.Total += moduleCoverage.Total;
+                accumPercent += moduleCoverage.Percent;
             }
+            details.AveragePercent = accumPercent / modules.Count();
             return details;
         }
 
@@ -206,12 +212,15 @@ namespace Coverlet.Core
         public CoverageDetails CalculateMethodCoverage(Modules modules)
         {
             var details = new CoverageDetails();
+            var accumPercent = 0.0;
             foreach (var module in modules)
             {
                 var moduleCoverage = CalculateMethodCoverage(module.Value);
                 details.Covered += moduleCoverage.Covered;
                 details.Total += moduleCoverage.Total;
+                accumPercent += moduleCoverage.Percent;
             }
+            details.AveragePercent = accumPercent / modules.Count();
             return details;
         }
     }

--- a/src/coverlet.core/CoverageSummary.cs
+++ b/src/coverlet.core/CoverageSummary.cs
@@ -53,7 +53,7 @@ namespace Coverlet.Core
         public CoverageDetails CalculateLineCoverage(Modules modules)
         {
             var details = new CoverageDetails();
-            var accumPercent = 0.0;
+            var accumPercent = 0.0D;
             foreach (var module in modules)
             {
                 var moduleCoverage = CalculateLineCoverage(module.Value);
@@ -61,7 +61,7 @@ namespace Coverlet.Core
                 details.Total += moduleCoverage.Total;
                 accumPercent += moduleCoverage.Percent;
             }
-            details.AverageModulePercent = accumPercent / modules.Count();
+            details.AverageModulePercent = accumPercent / modules.Count;
             return details;
         }
 
@@ -152,7 +152,7 @@ namespace Coverlet.Core
         public CoverageDetails CalculateBranchCoverage(Modules modules)
         {
             var details = new CoverageDetails();
-            var accumPercent = 0.0;
+            var accumPercent = 0.0D;
             foreach (var module in modules)
             {
                 var moduleCoverage = CalculateBranchCoverage(module.Value);
@@ -160,7 +160,7 @@ namespace Coverlet.Core
                 details.Total += moduleCoverage.Total;
                 accumPercent += moduleCoverage.Percent;
             }
-            details.AverageModulePercent = accumPercent / modules.Count();
+            details.AverageModulePercent = accumPercent / modules.Count;
             return details;
         }
 
@@ -212,7 +212,7 @@ namespace Coverlet.Core
         public CoverageDetails CalculateMethodCoverage(Modules modules)
         {
             var details = new CoverageDetails();
-            var accumPercent = 0.0;
+            var accumPercent = 0.0D;
             foreach (var module in modules)
             {
                 var moduleCoverage = CalculateMethodCoverage(module.Value);
@@ -220,7 +220,7 @@ namespace Coverlet.Core
                 details.Total += moduleCoverage.Total;
                 accumPercent += moduleCoverage.Percent;
             }
-            details.AverageModulePercent = accumPercent / modules.Count();
+            details.AverageModulePercent = accumPercent / modules.Count;
             return details;
         }
     }

--- a/test/coverlet.core.tests/CoverageSummaryTests.cs
+++ b/test/coverlet.core.tests/CoverageSummaryTests.cs
@@ -75,7 +75,7 @@ namespace Coverlet.Core.Tests
             _modules.Add("module", documents);
         }
 
-        private void SetupAditionalData()
+        private void SetupDataForAverageCalculation()
         {
             Lines lines = new Lines
             {
@@ -139,7 +139,7 @@ namespace Coverlet.Core.Tests
         [Fact]
         public void TestCalculateLineCoverage_Modules()
         {
-            SetupAditionalData();
+            SetupDataForAverageCalculation();
 
             CoverageSummary summary = new CoverageSummary();
             var documentsFirstModule = _modules["module"];
@@ -173,7 +173,7 @@ namespace Coverlet.Core.Tests
         [Fact]
         public void TestCalculateBranchCoverage_Modules()
         {
-            SetupAditionalData();
+            SetupDataForAverageCalculation();
 
             CoverageSummary summary = new CoverageSummary();
             var documentsFirstModule = _modules["module"];
@@ -204,7 +204,7 @@ namespace Coverlet.Core.Tests
         [Fact]
         public void TestCalculateMethodCoverage_Modules()
         {
-            SetupAditionalData();
+            SetupDataForAverageCalculation();
 
             CoverageSummary summary = new CoverageSummary();
             var documentsFirstModule = _modules["module"];

--- a/test/coverlet.core.tests/CoverageSummaryTests.cs
+++ b/test/coverlet.core.tests/CoverageSummaryTests.cs
@@ -81,22 +81,22 @@ namespace Coverlet.Core.Tests
         {
             Lines lines = new Lines
             {
-                { 1, 1 },//covered
-                { 2, 0 },//not covered
-                { 3, 0 }//not covered
+                { 1, 1 }, // covered
+                { 2, 0 }, // not covered
+                { 3, 0 } // not covered
             };
 
             Branches branches = new Branches
             {
-                new BranchInfo { Line = 1, Hits = 1, Offset = 1, Path = 0, Ordinal = 1 },//covered
-                new BranchInfo { Line = 1, Hits = 1, Offset = 1, Path = 1, Ordinal = 2 },//covered
-                new BranchInfo { Line = 1, Hits = 0, Offset = 1, Path = 1, Ordinal = 2 }//not covered
+                new BranchInfo { Line = 1, Hits = 1, Offset = 1, Path = 0, Ordinal = 1 }, // covered
+                new BranchInfo { Line = 1, Hits = 1, Offset = 1, Path = 1, Ordinal = 2 }, // covered
+                new BranchInfo { Line = 1, Hits = 0, Offset = 1, Path = 1, Ordinal = 2 } // not covered
             };
 
             Methods methods = new Methods();
             string[] methodString = {
-                "System.Void Coverlet.Core.Tests.CoverageSummaryTests::TestCalculateSummary()",//covered
-                "System.Void Coverlet.Core.Tests.CoverageSummaryTests::TestAditionalCalculateSummary()"//not covered
+                "System.Void Coverlet.Core.Tests.CoverageSummaryTests::TestCalculateSummary()", // covered
+                "System.Void Coverlet.Core.Tests.CoverageSummaryTests::TestAditionalCalculateSummary()" // not covered
             };
             methods.Add(methodString[0], new Method());
             methods[methodString[0]].Lines = lines;
@@ -105,7 +105,7 @@ namespace Coverlet.Core.Tests
             methods.Add(methodString[1], new Method());
             methods[methodString[1]].Lines = new Lines
             {
-                { 1, 0 }//not covered
+                { 1, 0 } // not covered
             };
 
             Classes classes = new Classes
@@ -152,9 +152,9 @@ namespace Coverlet.Core.Tests
             Assert.Equal(37.5, summary.CalculateLineCoverage(_averageCalculationMultiModule).AverageModulePercent);
             Assert.Equal(50, summary.CalculateLineCoverage(documentsFirstModule.First().Value).Percent);
 
-            Assert.Equal(33.33, summary.CalculateLineCoverage(documentsSecondModule.First().Value.First().Value.ElementAt(0).Value.Lines).Percent);//covered 1 of 3
-            Assert.Equal(0, summary.CalculateLineCoverage(documentsSecondModule.First().Value.First().Value.ElementAt(1).Value.Lines).Percent);//covered 0 of 1
-            Assert.Equal(25, summary.CalculateLineCoverage(documentsSecondModule.First().Value).Percent);//covered 1 of 4 lines
+            Assert.Equal(33.33, summary.CalculateLineCoverage(documentsSecondModule.First().Value.First().Value.ElementAt(0).Value.Lines).Percent); // covered 1 of 3
+            Assert.Equal(0, summary.CalculateLineCoverage(documentsSecondModule.First().Value.First().Value.ElementAt(1).Value.Lines).Percent); // covered 0 of 1
+            Assert.Equal(25, summary.CalculateLineCoverage(documentsSecondModule.First().Value).Percent); // covered 1 of 4 lines
         }
 
         [Fact]

--- a/test/coverlet.core.tests/CoverageSummaryTests.cs
+++ b/test/coverlet.core.tests/CoverageSummaryTests.cs
@@ -10,12 +10,14 @@ namespace Coverlet.Core.Tests
 {
     public class CoverageSummaryTests
     {
-        private Modules _modules;
+        private Modules _averageCalculationSingleModule;
+        private Modules _averageCalculationMultiModule;
         private Modules _moduleArithmeticPrecision;
 
         public CoverageSummaryTests()
         {
-            SetupData();
+            SetupDataSingleModule();
+            SetupDataMultipleModule();
             SetupDataForArithmeticPrecision();
         }
 
@@ -50,7 +52,7 @@ namespace Coverlet.Core.Tests
             _moduleArithmeticPrecision.Add("module", documents);
         }
 
-        private void SetupData()
+        private void SetupDataSingleModule()
         {
             Lines lines = new Lines();
             lines.Add(1, 1);
@@ -71,11 +73,11 @@ namespace Coverlet.Core.Tests
             Documents documents = new Documents();
             documents.Add("doc.cs", classes);
 
-            _modules = new Modules();
-            _modules.Add("module", documents);
+            _averageCalculationSingleModule = new Modules();
+            _averageCalculationSingleModule.Add("module", documents);
         }
 
-        private void SetupDataForAverageCalculation()
+        private void SetupDataMultipleModule()
         {
             Lines lines = new Lines
             {
@@ -116,20 +118,24 @@ namespace Coverlet.Core.Tests
                 { "doc.cs", classes }
             };
 
-            _modules.Add("aditionalModule", documents);
+            _averageCalculationMultiModule = new Modules
+            {
+                { "module", _averageCalculationSingleModule["module"] },
+                { "aditionalModule", documents }
+            };
         }
 
         [Fact]
-        public void TestCalculateLineCoverage_OneModule()
+        public void TestCalculateLineCoverage_SingleModule()
         {
             CoverageSummary summary = new CoverageSummary();
 
-            var module = _modules.First();
+            var module = _averageCalculationSingleModule.First();
             var document = module.Value.First();
             var @class = document.Value.First();
             var method = @class.Value.First();
 
-            Assert.Equal(50, summary.CalculateLineCoverage(_modules).AverageModulePercent);
+            Assert.Equal(50, summary.CalculateLineCoverage(_averageCalculationSingleModule).AverageModulePercent);
             Assert.Equal(50, summary.CalculateLineCoverage(module.Value).Percent);
             Assert.Equal(50, summary.CalculateLineCoverage(document.Value).Percent);
             Assert.Equal(50, summary.CalculateLineCoverage(@class.Value).Percent);
@@ -137,15 +143,13 @@ namespace Coverlet.Core.Tests
         }
 
         [Fact]
-        public void TestCalculateLineCoverage_Modules()
+        public void TestCalculateLineCoverage_MultiModule()
         {
-            SetupDataForAverageCalculation();
-
             CoverageSummary summary = new CoverageSummary();
-            var documentsFirstModule = _modules["module"];
-            var documentsSecondModule = _modules["aditionalModule"];
+            var documentsFirstModule = _averageCalculationMultiModule["module"];
+            var documentsSecondModule = _averageCalculationMultiModule["aditionalModule"];
 
-            Assert.Equal(37.5, summary.CalculateLineCoverage(_modules).AverageModulePercent);
+            Assert.Equal(37.5, summary.CalculateLineCoverage(_averageCalculationMultiModule).AverageModulePercent);
             Assert.Equal(50, summary.CalculateLineCoverage(documentsFirstModule.First().Value).Percent);
 
             Assert.Equal(33.33, summary.CalculateLineCoverage(documentsSecondModule.First().Value.First().Value.ElementAt(0).Value.Lines).Percent);//covered 1 of 3
@@ -154,16 +158,16 @@ namespace Coverlet.Core.Tests
         }
 
         [Fact]
-        public void TestCalculateBranchCoverage_OneModule()
+        public void TestCalculateBranchCoverage_SingleModule()
         {
             CoverageSummary summary = new CoverageSummary();
 
-            var module = _modules.First();
+            var module = _averageCalculationSingleModule.First();
             var document = module.Value.First();
             var @class = document.Value.First();
             var method = @class.Value.First();
 
-            Assert.Equal(100, summary.CalculateBranchCoverage(_modules).AverageModulePercent);
+            Assert.Equal(100, summary.CalculateBranchCoverage(_averageCalculationSingleModule).AverageModulePercent);
             Assert.Equal(100, summary.CalculateBranchCoverage(module.Value).Percent);
             Assert.Equal(100, summary.CalculateBranchCoverage(document.Value).Percent);
             Assert.Equal(100, summary.CalculateBranchCoverage(@class.Value).Percent);
@@ -171,30 +175,28 @@ namespace Coverlet.Core.Tests
         }
 
         [Fact]
-        public void TestCalculateBranchCoverage_Modules()
+        public void TestCalculateBranchCoverage_MultiModule()
         {
-            SetupDataForAverageCalculation();
-
             CoverageSummary summary = new CoverageSummary();
-            var documentsFirstModule = _modules["module"];
-            var documentsSecondModule = _modules["aditionalModule"];
+            var documentsFirstModule = _averageCalculationMultiModule["module"];
+            var documentsSecondModule = _averageCalculationMultiModule["aditionalModule"];
 
-            Assert.Equal(83.33, summary.CalculateBranchCoverage(_modules).AverageModulePercent);
+            Assert.Equal(83.33, summary.CalculateBranchCoverage(_averageCalculationMultiModule).AverageModulePercent);
             Assert.Equal(100, summary.CalculateBranchCoverage(documentsFirstModule.First().Value).Percent);
             Assert.Equal(66.66, summary.CalculateBranchCoverage(documentsSecondModule.First().Value).Percent);
         }
 
         [Fact]
-        public void TestCalculateMethodCoverage_OneModule()
+        public void TestCalculateMethodCoverage_SingleModule()
         {
             CoverageSummary summary = new CoverageSummary();
 
-            var module = _modules.First();
+            var module = _averageCalculationSingleModule.First();
             var document = module.Value.First();
             var @class = document.Value.First();
             var method = @class.Value.First();
 
-            Assert.Equal(100, summary.CalculateMethodCoverage(_modules).AverageModulePercent);
+            Assert.Equal(100, summary.CalculateMethodCoverage(_averageCalculationSingleModule).AverageModulePercent);
             Assert.Equal(100, summary.CalculateMethodCoverage(module.Value).Percent);
             Assert.Equal(100, summary.CalculateMethodCoverage(document.Value).Percent);
             Assert.Equal(100, summary.CalculateMethodCoverage(@class.Value).Percent);
@@ -202,15 +204,13 @@ namespace Coverlet.Core.Tests
         }
 
         [Fact]
-        public void TestCalculateMethodCoverage_Modules()
+        public void TestCalculateMethodCoverage_MultiModule()
         {
-            SetupDataForAverageCalculation();
-
             CoverageSummary summary = new CoverageSummary();
-            var documentsFirstModule = _modules["module"];
-            var documentsSecondModule = _modules["aditionalModule"];
+            var documentsFirstModule = _averageCalculationMultiModule["module"];
+            var documentsSecondModule = _averageCalculationMultiModule["aditionalModule"];
 
-            Assert.Equal(75, summary.CalculateMethodCoverage(_modules).AverageModulePercent);
+            Assert.Equal(75, summary.CalculateMethodCoverage(_averageCalculationMultiModule).AverageModulePercent);
             Assert.Equal(100, summary.CalculateMethodCoverage(documentsFirstModule.First().Value).Percent);
             Assert.Equal(50, summary.CalculateMethodCoverage(documentsSecondModule.First().Value).Percent);
         }


### PR DESCRIPTION
Fixes https://github.com/tonerdo/coverlet/issues/346

Minor changes to calculate Average (console's table) based on average from all projects. Im not sure if it is ok only to modify CalculateLineCoverage(Modules modules) functions.
Also a change in CoverageResult.cs just to keep same logic, because its switch-case (ThresholdStatistic.Average)  was working well (average based on average from all projects).