### PR TITLE
Fixed index out of range bug in CoberturaReporter when method name has two double-colons

### DIFF
--- a/src/coverlet.core/Reporters/CoberturaReporter.cs
+++ b/src/coverlet.core/Reporters/CoberturaReporter.cs
@@ -63,8 +63,8 @@ namespace Coverlet.Core.Reporters
                                 continue;
 
                             XElement method = new XElement("method");
-                            method.Add(new XAttribute("name", meth.Key.Split(':')[2].Split('(')[0]));
-                            method.Add(new XAttribute("signature", "(" + meth.Key.Split(':')[2].Split('(')[1]));
+                            method.Add(new XAttribute("name", meth.Key.Split(':').Last().Split('(').First()));
+                            method.Add(new XAttribute("signature", "(" + meth.Key.Split(':').Last().Split('(').Last()));
                             method.Add(new XAttribute("line-rate", (summary.CalculateLineCoverage(meth.Value.Lines).Percent / 100).ToString(CultureInfo.InvariantCulture)));
                             method.Add(new XAttribute("branch-rate", (summary.CalculateBranchCoverage(meth.Value.Branches).Percent / 100).ToString(CultureInfo.InvariantCulture)));
 


### PR DESCRIPTION
Error message:

```shell
Calculating coverage result...
  Generating report 'C:\Users\xuhon\source\repos\ProtobufCoverlet\XUnitTestProject1\coverage.cobertura.xml'
C:\Users\xuhon\.nuget\packages\coverlet.msbuild\2.6.3\build\coverlet.msbuild.targets(41,5): error : Index was outside the bounds of the array. [C:\Users\xuhon\source\repos\ProtobufCoverlet\XUnitTestProject1\XUnitTestProject1.csproj]
C:\Users\xuhon\.nuget\packages\coverlet.msbuild\2.6.3\build\coverlet.msbuild.targets(41,5): error :    at Coverlet.Core.Reporters.CoberturaReporter.Report(CoverageResult result) in C:\Users\toni\Workspace\coverlet\src\coverlet.core\Reporters\CoberturaReporter.cs:line 20 [C:\Users\xuhon\source\repos\ProtobufCoverlet\XUnitTestProject1\XUnitTestProject1.csproj]
C:\Users\xuhon\.nuget\packages\coverlet.msbuild\2.6.3\build\coverlet.msbuild.targets(41,5): error :    at Coverlet.MSbuild.Tasks.CoverageResultTask.Execute() in C:\Users\toni\Workspace\coverlet\src\coverlet.msbuild.tasks\CoverageResultTask.cs:line 120 [C:\Users\xuhon\source\repos\ProtobufCoverlet\XUnitTestProject1\XUnitTestProject1.csproj]
```

I changed the source code of coverlet, recompiled it and replaced it to test where the exception was thrown:

[Link to CoberturaReporter.cs#L67](https://github.com/tonerdo/coverlet/blob/e1593359497fdfe6befbb86304b8f4e09a656d14/src/coverlet.core/Reporters/CoberturaReporter.cs#L67)

```C#
try
{
    method.Add(new XAttribute("name", meth.Key.Split(':')[2].Split('(')[0]));
    method.Add(new XAttribute("signature", "(" + meth.Key.Split(':')[2].Split('(')[1]));
}
catch
{
    File.WriteAllText("D:/1.txt", meth.Key);
}
```

The content of `D:/1.txt` is:

```text
Google.Protobuf.Reflection.MessageDescriptor Test.SearchRequest::pb::Google.Protobuf.IMessage.get_Descriptor()
```

As you can see, there are two double-colons, which caused the problem.

So, I submitted this PR to fix this by using `First` and `Last` instead of hard-coded index number.