### PR TITLE
Add a major roll-forward policy

### DIFF
--- a/src/coverlet.console/runtimeconfig.template.json
+++ b/src/coverlet.console/runtimeconfig.template.json
@@ -1,0 +1,3 @@
+{
+  "rollForwardOnNoCandidateFx": 2
+}


### PR DESCRIPTION
Unfortunately there is no way today to specify a roll-forward policy when invoking a repo tool with `dotnet tool run ...`. This is disappointing. Meanwhile this should help people trying to run coverlet.console without having a 2.x SDK installed.

@MarcoRossignoli I would highly appreciate if we could upload a new version to nuget with this fix. If that's not possible I would be willing to use the private feed but usually we try to avoid that in corefx.