### PR TITLE
Fix setter only property instrumentation

### DIFF
--- a/src/coverlet.core/Instrumentation/Instrumenter.cs
+++ b/src/coverlet.core/Instrumentation/Instrumenter.cs
@@ -279,7 +279,7 @@ namespace Coverlet.Core.Instrumentation
 
                 if (actualMethod.IsGetter || actualMethod.IsSetter)
                 {
-                    PropertyDefinition prop = type.Properties.FirstOrDefault(p => p.GetMethod.FullName.Equals(actualMethod.FullName));
+                    PropertyDefinition prop = type.Properties.FirstOrDefault(p => (p.GetMethod ?? p.SetMethod).FullName.Equals(actualMethod.FullName));
                     if (prop?.HasCustomAttributes == true)
                         customAttributes = customAttributes.Union(prop.CustomAttributes);
                 }


### PR DESCRIPTION
Properties can have a setter without a getter which causes the current type instrumentation code to crash. Fixing this by using the SetMethod if GetMethod is null.

cc @MarcoRossignoli @tonerdo 