### PR TITLE
Fix missing quotation mark for test command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Clone this repo:
 Building, testing, and packing use all the standard dotnet commands:
 
     dotnet build
-    dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Include=[coverlet.*]*"
+    dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Include="[coverlet.*]*"
     dotnet pack
 
 ## Performance testing


### PR DESCRIPTION
Add the missing quotation mark to the test command in the contributing guide