### PR TITLE
Upgrade Mono.Cecil to avoid re-order of attributes on re-write.

### DIFF
--- a/src/coverlet.core/coverlet.core.csproj
+++ b/src/coverlet.core/coverlet.core.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mono.Cecil" Version="0.10.1" />
+    <PackageReference Include="Mono.Cecil" Version="0.10.4" />
     <!-- Do not upgrade this version or we won't support old SDK -->
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <!--


### PR DESCRIPTION
Should fix https://github.com/tonerdo/coverlet/issues/282
Related Cecil issue https://github.com/jbevain/cecil/issues/558
cc: @tonerdo 