### PR TITLE
Improve dotnet tool output

### DIFF
--- a/src/coverlet.console/Program.cs
+++ b/src/coverlet.console/Program.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
-using System.Threading.Tasks;
+
 using ConsoleTables;
 using Coverlet.Console.Logging;
 using Coverlet.Core;
@@ -239,6 +240,11 @@ namespace Coverlet.Console
                 logger.LogError(ex.Message);
                 app.ShowHelp();
                 return (int)CommandExitCodes.CommandParsingException;
+            }
+            catch (Win32Exception we) when (we.Source == "System.Diagnostics.Process")
+            {
+                logger.LogError($"Start process '{target.Value()}' failed with '{we.Message}'");
+                return exitCode > 0 ? exitCode : (int)CommandExitCodes.Exception;
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Working on https://github.com/tonerdo/coverlet/issues/513 found not so clear where is the problem in case of missing startup process file name.
This PR will improve error message
```
Excluded module filter '[xunit*]*'
Instrumented module: 'C:\git\marcorossignoli.github.io\src\coverlet\Issue0\CoverletTest\bin\Debug\netcoreapp2.1\CoverletSampleLib.dll'
Excluded module: 'C:\git\marcorossignoli.github.io\src\coverlet\Issue0\CoverletTest\bin\Debug\netcoreapp2.1\xunit.runner.reporters.netcoreapp10.dll'
Excluded module: 'C:\git\marcorossignoli.github.io\src\coverlet\Issue0\CoverletTest\bin\Debug\netcoreapp2.1\xunit.runner.utility.netcoreapp10.dll'
Excluded module: 'C:\git\marcorossignoli.github.io\src\coverlet\Issue0\CoverletTest\bin\Debug\netcoreapp2.1\xunit.runner.visualstudio.dotnetcore.testadapter.dll'
Start process 'vstest.console' failed with 'The system cannot find the file specified'
```

cc: @tonerdo @petli @Nusserdt 