### PR TITLE
Add ReportGenerator helper

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -12,6 +12,7 @@
     <PackageReference Update="Moq" Version="4.10.1" />
     <!-- Do not upgrade this version or we won't support old SDK -->
     <PackageReference Update="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Update="ReportGenerator.Core" Version="4.2.15" />
     <!--
         Do not change System.Reflection.Metadata version since we need to support VSTest DataCollectors. Goto https://www.nuget.org/packages/System.Reflection.Metadata to check versions.
         We need to load assembly version 1.4.2.0 to properly work

--- a/test/coverlet.core.tests/CoverageTests.cs
+++ b/test/coverlet.core.tests/CoverageTests.cs
@@ -96,6 +96,9 @@ namespace Coverlet.Core.Tests
                       .AssertLinesCovered((11, 1), (15, 0))
                       // (line,ordinal,hits)
                       .AssertBranchesCovered((9, 0, 1), (9, 1, 0));
+
+                // if need to generate html report for debugging purpose
+                // TestInstrumentationHelper.GenerateHtmlReport(result);
             }
             finally
             {

--- a/test/coverlet.core.tests/InstrumenterHelper.cs
+++ b/test/coverlet.core.tests/InstrumenterHelper.cs
@@ -111,6 +111,7 @@ namespace Coverlet.Core.Tests
     public static class TestInstrumentationHelper
     {
         /// <summary>
+        /// Install report generator "dotnet tool install --global dotnet-reportgenerator-globaltool" https://danielpalme.github.io/ReportGenerator/usage.html
         /// caller sample:  TestInstrumentationHelper.GenerateHtmlReport(result, sourceFileFilter: @"+**\Samples\Instrumentation.cs");
         ///                 TestInstrumentationHelper.GenerateHtmlReport(result);
         /// </summary>

--- a/test/coverlet.core.tests/InstrumenterHelper.cs
+++ b/test/coverlet.core.tests/InstrumenterHelper.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -14,6 +13,7 @@ using Coverlet.Core.Logging;
 using Coverlet.Core.Reporters;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
+using Palmmedia.ReportGenerator.Core;
 using Xunit.Sdk;
 
 namespace Coverlet.Core.Tests
@@ -111,7 +111,6 @@ namespace Coverlet.Core.Tests
     public static class TestInstrumentationHelper
     {
         /// <summary>
-        /// Install report generator "dotnet tool install --global dotnet-reportgenerator-globaltool" https://danielpalme.github.io/ReportGenerator/usage.html
         /// caller sample:  TestInstrumentationHelper.GenerateHtmlReport(result, sourceFileFilter: @"+**\Samples\Instrumentation.cs");
         ///                 TestInstrumentationHelper.GenerateHtmlReport(result);
         /// </summary>
@@ -124,7 +123,18 @@ namespace Coverlet.Core.Tests
             string reportFile = Path.Combine(dir.FullName, Path.ChangeExtension("report", reporter.Extension));
             File.WriteAllText(reportFile, reporter.Report(coverageResult));
             // i.e. reportgenerator -reports:"C:\git\coverlet\test\coverlet.core.tests\bin\Debug\netcoreapp2.0\Condition_If\report.cobertura.xml" -targetdir:"C:\git\coverlet\test\coverlet.core.tests\bin\Debug\netcoreapp2.0\Condition_If" -filefilters:+**\Samples\Instrumentation.cs
-            Process.Start("reportgenerator", $"-reports:\"{reportFile}\" -targetdir:\"{dir.FullName}\" {(string.IsNullOrEmpty(sourceFileFilter) ? "" : $" -filefilters:{sourceFileFilter}")}");
+            new Generator().GenerateReport(new ReportConfiguration(
+            new[] { reportFile },
+            dir.FullName,
+            new string[0],
+            null,
+            new string[0],
+            new string[0],
+            new string[0],
+            new string[0],
+            string.IsNullOrEmpty(sourceFileFilter) ? new string[0] : new[] { sourceFileFilter },
+            null,
+            null));
         }
 
         public static CoverageResult GetCoverageResult(string filePath)

--- a/test/coverlet.core.tests/coverlet.core.tests.csproj
+++ b/test/coverlet.core.tests/coverlet.core.tests.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <IsPackable>false</IsPackable>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/coverlet.core.tests/coverlet.core.tests.csproj
+++ b/test/coverlet.core.tests/coverlet.core.tests.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />
+    <PackageReference Include="ReportGenerator.Core" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>


### PR DESCRIPTION
contributes to https://github.com/tonerdo/coverlet/issues/387

Added report generator helper, in this way we can generate during debugging and testing full report to better understand if results are ok.

cc: @tonerdo @petli 

@danielpalme I saw that report generator supports plugin...I would like "run generator" from my code base(adding core package) can you point me to some code sample?
I don't wan to create a custom report, only run, for instance `ReportGenerator.Run(reportfile,reportdirectory)`
BTW code below works well, but we could avoid global tool install.
