### PR TITLE
Revert "Add `[xunit*]*` to default excluded modules filter if not specified"

### DIFF
--- a/src/coverlet.collector/DataCollection/CoverletSettingsParser.cs
+++ b/src/coverlet.collector/DataCollection/CoverletSettingsParser.cs
@@ -131,13 +131,6 @@ namespace Coverlet.Collector.DataCollection
                 }
             }
 
-            // if we've only one element mean that we only added CoverletConstants.DefaultExcludeFilter
-            // so add default exclusions
-            if (excludeFilters.Count == 1)
-            {
-                excludeFilters.Add("[xunit*]*");
-            }
-
             return excludeFilters.ToArray();
         }
 

--- a/src/coverlet.console/Program.cs
+++ b/src/coverlet.console/Program.cs
@@ -58,12 +58,6 @@ namespace Coverlet.Console
                     logger.Level = verbosity.ParsedValue;
                 }
 
-                // We add default exclusion filter if no specified
-                if (excludeFilters.Values.Count == 0)
-                {
-                    excludeFilters.Values.Add("[xunit*]*");
-                }
-
                 Coverage coverage = new Coverage(module.Value,
                     includeFilters.Values.ToArray(),
                     includeDirectories.Values.ToArray(),

--- a/src/coverlet.msbuild.tasks/InstrumentationTask.cs
+++ b/src/coverlet.msbuild.tasks/InstrumentationTask.cs
@@ -104,12 +104,6 @@ namespace Coverlet.MSbuild.Tasks
                 var excludedSourceFiles = _excludeByFile?.Split(',');
                 var excludeAttributes = _excludeByAttribute?.Split(',');
 
-                // We add default exclusion filter if no specified
-                if (excludeFilters is null || excludeFilters.Length == 0)
-                {
-                    excludeFilters = new string[] { "[xunit*]*" };
-                }
-
                 Coverage coverage = new Coverage(_path, includeFilters, includeDirectories, excludeFilters, excludedSourceFiles, excludeAttributes, _includeTestAssembly, _singleHit, _mergeWith, _useSourceLink, _logger);
                 CoveragePrepareResult prepareResult = coverage.PrepareModules();
                 InstrumenterState = new TaskItem(System.IO.Path.GetTempFileName());

--- a/test/coverlet.collector.tests/CoverletSettingsParserTests.cs
+++ b/test/coverlet.collector.tests/CoverletSettingsParserTests.cs
@@ -78,33 +78,5 @@ namespace Coverlet.Collector.Tests
             node.InnerText = nodeValue;
             configElement.AppendChild(node);
         }
-
-        [Fact]
-        public void ParseShouldSkipXunitModulesIfEmptyExclude()
-        {
-            var testModules = new List<string> { "abc.dll" };
-
-            CoverletSettings coverletSettings = _coverletSettingsParser.Parse(null, testModules);
-
-            Assert.Equal("[coverlet.*]*", coverletSettings.ExcludeFilters[0]);
-            Assert.Equal("[xunit*]*", coverletSettings.ExcludeFilters[1]);
-            Assert.Equal(2, coverletSettings.ExcludeFilters.Length);
-        }
-
-        [Fact]
-        public void ParseShouldNotSkipXunitModulesIfNotEmptyExclude()
-        {
-            var testModules = new List<string> { "abc.dll" };
-            var doc = new XmlDocument();
-            var configElement = doc.CreateElement("Configuration");
-            this.CreateCoverletNodes(doc, configElement, CoverletConstants.ExcludeFiltersElementName, "[coverlet.*.tests?]*");
-
-            CoverletSettings coverletSettings = _coverletSettingsParser.Parse(configElement, testModules);
-
-            Assert.Equal("[coverlet.*]*", coverletSettings.ExcludeFilters[0]);
-            Assert.Equal("[coverlet.*.tests?]*", coverletSettings.ExcludeFilters[1]);
-            Assert.Equal(2, coverletSettings.ExcludeFilters.Length);
-            Assert.DoesNotContain("[xunit*]*", coverletSettings.ExcludeFilters);
-        }
     }
 }


### PR DESCRIPTION
Reverts tonerdo/coverlet#462

With https://github.com/tonerdo/coverlet/pull/510 now we exclude from instrumentation module with embedded pdb without local source.
For this reason we could think to remove `xunit` filter from code as @tonerdo told here https://github.com/tonerdo/coverlet/pull/510#issuecomment-521247960
We could keep filter as fallback in case that xunit for some reason will move embedded pdb to local folder(@onovotny talked about it here https://github.com/tonerdo/coverlet/pull/510#issuecomment-518243308)

Personally I would keep filter ***for the moment***, but yes could be unuseful/dead code.

Thoughts? @tonerdo @vagisha-nidhi @onovotny @ViktorHofer 
Maybe @bradwilson could also be useful here to confirm or not something.

Ah one more thing, if someone know the name of nuget package that download pdb on output directory please let me know...so we can write code/test to skip also that case.
