### PR TITLE
fix hits file share

### DIFF
--- a/src/coverlet.core/Coverage.cs
+++ b/src/coverlet.core/Coverage.cs
@@ -247,7 +247,7 @@ namespace Coverlet.Core
                     }
                 }
 
-                using (var fs = new FileStream(result.HitsFilePath, FileMode.Open))
+                using (var fs = new FileStream(result.HitsFilePath, FileMode.Open, FileAccess.Read, FileShare.Read))
                 using (var br = new BinaryReader(fs))
                 {
                     int hitCandidatesCount = br.ReadInt32();


### PR DESCRIPTION
Exclude the possibility of modifying or deleting a hits file while reading.

Probably, will fix 'Unable to read beyond end of stream' problem. 
We encountered this annoying problem in our project