### PR TITLE
WIP: Inital support for dotcover.

### DIFF
--- a/src/coverlet.core/Reporters/TeamCityReporter.cs
+++ b/src/coverlet.core/Reporters/TeamCityReporter.cs
@@ -1,17 +1,20 @@
 ﻿using System.Globalization;
+using System.Text;
+using System.IO;
+using System.Xml.Linq;
+using System.Linq;
 using Coverlet.Core;
 using Coverlet.Core.Reporters;
-using System.Text;
 
 namespace Coverlet.Core.Reporters
 {
     public class TeamCityReporter : IReporter
     {
-        public ReporterOutputType OutputType => ReporterOutputType.Console;
+        public ReporterOutputType OutputType => ReporterOutputType.File;
 
         public string Format => "teamcity";
 
-        public string Extension => null;
+        public string Extension => "cov.xml";
 
         public string Report(CoverageResult result)
         {
@@ -26,9 +29,133 @@ namespace Coverlet.Core.Reporters
             OutputLineCoverage(overallLineCoverage, stringBuilder);
             OutputBranchCoverage(overallBranchCoverage, stringBuilder);
             OutputMethodCoverage(overallMethodCoverage, stringBuilder);
+            System.Console.WriteLine(stringBuilder);
 
-            // Return a placeholder
-            return stringBuilder.ToString();
+            XDocument xml = new XDocument();
+            XElement modules = new XElement("Root");
+            modules.Add(new XAttribute("ReportType","DetailedXml"));
+            modules.Add(new XAttribute("CoveredStatements", overallBranchCoverage.Covered));
+            modules.Add(new XAttribute("TotalStatements", overallBranchCoverage.Total));
+            modules.Add(new XAttribute("CoveragePercent", overallBranchCoverage.Percent));
+            modules.Add(new XAttribute("DotCoverVersion","2018.2.3"));
+
+            XElement files = new XElement("FileIndices");
+            modules.Add(files);
+            int fileId = 1;
+
+            foreach (var mod in result.Modules)
+            {
+                XElement module = new XElement("Assembly");
+                //module.Add(new XAttribute("hash", Guid.NewGuid().ToString().ToUpper()));
+
+                // XElement time = new XElement("ModuleTime", DateTime.UtcNow.ToString("yyyy-MM-ddThh:mm:ss"));
+                module.Add(new XAttribute("Name", Path.GetFileNameWithoutExtension(mod.Key)));
+
+                var moduleTotalStatements = 0;
+                var moduleCoveredStatements = 0;
+
+                XElement nameSpace = new XElement("Namespace");
+
+                foreach (var doc in mod.Value)
+                {
+                    var nameSpaceTotalStatements = 0;
+                    var nameSpaceCoveredStatements = 0;
+
+                    XElement file = new XElement("File");
+                    file.Add(new XAttribute("Index", fileId.ToString()));
+                    file.Add(new XAttribute("Name", doc.Key));
+                    files.Add(file);
+
+                    foreach (var cls in doc.Value)
+                    {
+                        XElement @class = new XElement("Type");
+
+                        int index = cls.Key.LastIndexOf('.');
+                        string nameSpaceName;
+                        string typeName;
+                        if (index > 0) {
+                            nameSpaceName = cls.Key.Substring(0, index);
+                            typeName = cls.Key.Substring(index + 1);
+                        } else {
+                            typeName = cls.Key;
+                            nameSpaceName = "";
+                        }
+                        @class.Add(new XAttribute("Name", typeName));
+
+                        var typeTotalStatements = 0;
+                        var typeCoveredStatements = 0;
+
+                        foreach (var meth in cls.Value)
+                        {
+                            // Skip all methods with no lines
+                            if (meth.Value.Lines.Count == 0)
+                                continue;
+
+                            var methBranchCoverage = summary.CalculateBranchCoverage(meth.Value.Branches);
+                            
+                            XElement method = new XElement("Method");
+                            method.Add(new XAttribute("Name", meth.Key));
+                            method.Add(new XAttribute("CoveredStatements", methBranchCoverage.Covered));
+                            method.Add(new XAttribute("TotalStatements", methBranchCoverage.Total));
+                            method.Add(new XAttribute("Percent", methBranchCoverage.Percent));
+                            typeTotalStatements += methBranchCoverage.Total;
+                            typeCoveredStatements += (int) methBranchCoverage.Covered;//todo check cast
+
+                            foreach (var line in meth.Value.Branches)
+                            {
+                                XElement methodPoint = new XElement("Statement");
+                                methodPoint.Add(new XAttribute("FileIndex", fileId.ToString()));
+                                methodPoint.Add(new XAttribute("Column", line.Offset));
+                                methodPoint.Add(new XAttribute("Line", line.Path.ToString()));
+                                methodPoint.Add(new XAttribute("EndColumn", line.EndOffset));
+                                methodPoint.Add(new XAttribute("EndLine", line.Ordinal));
+                                methodPoint.Add(new XAttribute("Covered", line.Hits > 0? "True" : "False"));
+
+                                method.Add(methodPoint);
+                            }
+                            @class.Add(method);
+                        }
+
+                        nameSpaceTotalStatements += typeTotalStatements;
+                        nameSpaceCoveredStatements += typeCoveredStatements;
+                        @class.Add(new XAttribute("CoveredStatements", typeCoveredStatements));
+                        @class.Add(new XAttribute("TotalStatements", typeTotalStatements));
+                        @class.Add(new XAttribute("CoveragePercent", Percent(typeCoveredStatements, typeTotalStatements)));
+                        nameSpace.Add(@class);
+                    }
+                    fileId++;
+                    
+                    nameSpace.Add(new XAttribute("CoveredStatements", nameSpaceCoveredStatements));
+                    nameSpace.Add(new XAttribute("TotalStatements", nameSpaceTotalStatements));
+                    nameSpace.Add(new XAttribute("CoveragePercent", Percent(nameSpaceCoveredStatements, nameSpaceTotalStatements)));
+
+                    moduleCoveredStatements += nameSpaceCoveredStatements;
+                    moduleTotalStatements += nameSpaceTotalStatements;
+                }
+
+                module.Add(nameSpace);
+                module.Add(new XAttribute("CoveredStatements", moduleCoveredStatements));
+                module.Add(new XAttribute("TotalStatements", moduleTotalStatements));
+                module.Add(new XAttribute("CoveragePercent", Percent(moduleCoveredStatements, moduleTotalStatements)));
+                modules.Add(module);
+            }
+
+            xml.Add(modules);
+
+            var stream = new MemoryStream();
+            xml.Save(stream);
+
+            return Encoding.UTF8.GetString(stream.ToArray());
+        }
+
+        private string Percent(double covered, double total) {
+            if (total > 0)
+            {
+                var str = (covered / total).ToString("P2");
+                return str.Substring(0, str.Length - 1);
+            } else {
+                return "0.00";
+            }
         }
 
         private void OutputLineCoverage(CoverageDetails coverageDetails, StringBuilder builder)

--- a/test/coverlet.core.tests/Reporters/TeamCityReporter.cs
+++ b/test/coverlet.core.tests/Reporters/TeamCityReporter.cs
@@ -65,7 +65,7 @@ namespace Coverlet.Core.Reporters.Tests
         public void OutputType_IsConsoleOutputType()
         {
             // Assert
-            Assert.Equal(ReporterOutputType.Console, _reporter.OutputType);
+            Assert.Equal(ReporterOutputType.File, _reporter.OutputType);
         }
 
         [Fact]
@@ -76,10 +76,10 @@ namespace Coverlet.Core.Reporters.Tests
         }
 
         [Fact]
-        public void Format_IsNull()
+        public void Format_Has_Extension()
         {
             // Assert
-            Assert.Null(_reporter.Extension);
+            Assert.Equal("cov.xml", _reporter.Extension);
         }
 
         [Fact]
@@ -92,37 +92,56 @@ namespace Coverlet.Core.Reporters.Tests
             Assert.False(string.IsNullOrWhiteSpace(output), "Output is not null or whitespace");
         }
 
-        [Fact]
-        public void Report_ReportsLineCoverage()
-        {
-            // Act
-            var output = _reporter.Report(_result);
+        // [Fact]
+        // public void Report_ReportsLineCoverage()
+        // {
+        //     // Act
+        //     var output = _reporter.Report(_result);
 
-            // Assert
-            Assert.Contains("##teamcity[buildStatisticValue key='CodeCoverageAbsLCovered' value='1']", output);
-            Assert.Contains("##teamcity[buildStatisticValue key='CodeCoverageAbsLTotal' value='2']", output);
-        }
+        //     // Assert
+        //     Assert.Contains("##teamcity[buildStatisticValue key='CodeCoverageAbsLCovered' value='1']", output);
+        //     Assert.Contains("##teamcity[buildStatisticValue key='CodeCoverageAbsLTotal' value='2']", output);
+        // }
 
         [Fact]
         public void Report_ReportsBranchCoverage()
         {
             // Act
-            var output = _reporter.Report(_result);
+            var output = _reporter.Report(_result).Trim();
 
             // Assert
-            Assert.Contains("##teamcity[buildStatisticValue key='CodeCoverageAbsBCovered' value='1']", output);
-            Assert.Contains("##teamcity[buildStatisticValue key='CodeCoverageAbsBTotal' value='3']", output);
-        }
-
-        [Fact]
-        public void Report_ReportsMethodCoverage()
-        {
-            // Act
-            var output = _reporter.Report(_result);
+            var expected = @"<Root ReportType=""DetailedXml"" CoveredStatements=""1"" TotalStatements=""3"" CoveragePercent=""33.33"" DotCoverVersion=""2018.2.3"">
+  <FileIndices>
+    <File Index=""1"" Name=""doc.cs"" />
+  </FileIndices>
+  <Assembly Name=""module"" CoveredStatements=""1"" TotalStatements=""3"" CoveragePercent=""33.33"">
+    <Namespace CoveredStatements=""1"" TotalStatements=""3"" CoveragePercent=""33.33"">
+      <Type Name=""CoberturaReporterTests"" CoveredStatements=""1"" TotalStatements=""3"" CoveragePercent=""33.33"">
+        <Method Name=""System.Void Coverlet.Core.Reporters.Tests.CoberturaReporterTests::TestReport()"" CoveredStatements=""1"" TotalStatements=""3"" Percent=""33.33"">
+          <Statement FileIndex=""1"" Column=""23"" Line=""0"" EndColumn=""24"" EndLine=""1"" Covered=""True"" />
+          <Statement FileIndex=""1"" Column=""23"" Line=""1"" EndColumn=""27"" EndLine=""2"" Covered=""False"" />
+          <Statement FileIndex=""1"" Column=""23"" Line=""1"" EndColumn=""27"" EndLine=""2"" Covered=""False"" />
+        </Method>
+      </Type>
+    </Namespace>
+  </Assembly>
+</Root>";
+            Assert.Contains(expected, output);
 
             // Assert
-            Assert.Contains("##teamcity[buildStatisticValue key='CodeCoverageAbsMCovered' value='1']", output);
-            Assert.Contains("##teamcity[buildStatisticValue key='CodeCoverageAbsMTotal' value='1']", output);
+            // Assert.Contains("##teamcity[buildStatisticValue key='CodeCoverageAbsBCovered' value='1']", output);
+            // Assert.Contains("##teamcity[buildStatisticValue key='CodeCoverageAbsBTotal' value='3']", output);
         }
+
+        // [Fact]
+        // public void Report_ReportsMethodCoverage()
+        // {
+        //     // Act
+        //     var output = _reporter.Report(_result);
+
+        //     // Assert
+        //     Assert.Contains("##teamcity[buildStatisticValue key='CodeCoverageAbsMCovered' value='1']", output);
+        //     Assert.Contains("##teamcity[buildStatisticValue key='CodeCoverageAbsMTotal' value='1']", output);
+        // }
     }
 }


### PR DESCRIPTION
Might need to rework things as the Teamcity reporter is now a file reporter and a console reporter.
I've not included a service message yet to indicate where the file is so that TeamCity can hover it up.
I couldn't see a way to return two coverage measures in cov.xml so for now the default is branch coverage.