### PR TITLE
Hide report generator strong name warning

### DIFF
--- a/test/coverlet.collector.tests/coverlet.collector.tests.csproj
+++ b/test/coverlet.collector.tests/coverlet.collector.tests.csproj
@@ -5,7 +5,6 @@
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <IsPackable>false</IsPackable>
     <LangVersion>preview</LangVersion>
-    <NoWarn>$(NoWarn);CS8002</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/coverlet.collector.tests/coverlet.collector.tests.csproj
+++ b/test/coverlet.collector.tests/coverlet.collector.tests.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <IsPackable>false</IsPackable>
     <LangVersion>preview</LangVersion>
+    <NoWarn>$(NoWarn);CS8002</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/coverlet.core.tests/coverlet.core.tests.csproj
+++ b/test/coverlet.core.tests/coverlet.core.tests.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <LangVersion>preview</LangVersion>
+    <NoWarn>$(NoWarn);CS8002</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
We use report generator core to help on debugging, it's not signed, we'll suppress warning at project level.

cc: @tonerdo @danielpalme