### PR TITLE
Move log to verbose for automatic excluded instrumented libs

### DIFF
--- a/src/coverlet.core/Instrumentation/Instrumenter.cs
+++ b/src/coverlet.core/Instrumentation/Instrumenter.cs
@@ -76,7 +76,7 @@ namespace Coverlet.Core.Instrumentation
                         }
                         else
                         {
-                            _logger.LogWarning($"Unable to instrument module: {_module}, embedded pdb without local source files, [{firstNotFoundDocument}]");
+                            _logger.LogVerbose($"Unable to instrument module: {_module}, embedded pdb without local source files, [{firstNotFoundDocument}]");
                             return false;
                         }
                     }
@@ -88,7 +88,7 @@ namespace Coverlet.Core.Instrumentation
                         }
                         else
                         {
-                            _logger.LogWarning($"Unable to instrument module: {_module}, pdb without local source files, [{firstNotFoundDocument}]");
+                            _logger.LogVerbose($"Unable to instrument module: {_module}, pdb without local source files, [{firstNotFoundDocument}]");
                             return false;
                         }
                     }

--- a/test/coverlet.core.tests/Instrumentation/InstrumenterTests.cs
+++ b/test/coverlet.core.tests/Instrumentation/InstrumenterTests.cs
@@ -353,7 +353,7 @@ namespace Coverlet.Core.Instrumentation.Tests
             Assert.True(_instrumentationHelper.HasPdb(xunitDll, out bool embedded));
             Assert.True(embedded);
             Assert.False(instrumenter.CanInstrument());
-            loggerMock.Verify(l => l.LogWarning(It.IsAny<string>()));
+            loggerMock.Verify(l => l.LogVerbose(It.IsAny<string>()));
 
             // Default case
             string coverletCoreDll = Directory.GetFiles(Directory.GetCurrentDirectory(), "coverlet.core.dll").First();
@@ -380,7 +380,7 @@ namespace Coverlet.Core.Instrumentation.Tests
             Assert.True(_instrumentationHelper.HasPdb(coverletLib, out bool embedded));
             Assert.False(embedded);
             Assert.False(instrumenter.CanInstrument());
-            loggerMock.Verify(l => l.LogWarning(It.IsAny<string>()));
+            loggerMock.Verify(l => l.LogVerbose(It.IsAny<string>()));
         }
 
         [Fact]


### PR DESCRIPTION
Now that we exlude instrumentation for "invalid" libs we'll get warning every time due to xunit.
I'll move from log warning to log verbose to avoid too much noise and better experience.

cc: @tonerdo @petli 