### PR TITLE
Fix source file check for non portable pdb

### DIFF
--- a/src/coverlet.core/Coverage.cs
+++ b/src/coverlet.core/Coverage.cs
@@ -81,6 +81,7 @@ namespace Coverlet.Core
 
             Array.ForEach(_excludeFilters ?? Array.Empty<string>(), filter => _logger.LogVerbose($"Excluded module filter '{filter}'"));
             Array.ForEach(_includeFilters ?? Array.Empty<string>(), filter => _logger.LogVerbose($"Included module filter '{filter}'"));
+            Array.ForEach(_excludedSourceFiles ?? Array.Empty<string>(), filter => _logger.LogVerbose($"Excluded source files filter '{filter}'"));
 
             _excludeFilters = _excludeFilters?.Where(f => _instrumentationHelper.IsValidFilterExpression(f)).ToArray();
             _includeFilters = _includeFilters?.Where(f => _instrumentationHelper.IsValidFilterExpression(f)).ToArray();

--- a/src/coverlet.core/Helpers/InstrumentationHelper.cs
+++ b/src/coverlet.core/Helpers/InstrumentationHelper.cs
@@ -146,7 +146,17 @@ namespace Coverlet.Core.Helpers
                         var codeViewData = peReader.ReadCodeViewDebugDirectoryData(entry);
                         using FileStream pdbStream = new FileStream(codeViewData.Path, FileMode.Open);
                         using MetadataReaderProvider metadataReaderProvider = MetadataReaderProvider.FromPortablePdbStream(pdbStream);
-                        MetadataReader metadataReader = metadataReaderProvider.GetMetadataReader();
+                        MetadataReader metadataReader = null;
+                        try
+                        {
+                            metadataReader = metadataReaderProvider.GetMetadataReader();
+                        }
+                        catch (BadImageFormatException)
+                        {
+                            // TODO log this to warning
+                            // In case of non portable pdb we get exception so we skip file sources check
+                            return true;
+                        }
                         foreach (DocumentHandle docHandle in metadataReader.Documents)
                         {
                             Document document = metadataReader.GetDocument(docHandle);

--- a/src/coverlet.core/Instrumentation/Instrumenter.cs
+++ b/src/coverlet.core/Instrumentation/Instrumenter.cs
@@ -779,7 +779,6 @@ namespace Coverlet.Core.Instrumentation
                     {
                         continue;
                     }
-                    logger.LogVerbose($"Excluded source file rule '{excludeRule}'");
                     _matcher.AddInclude(Path.IsPathRooted(excludeRule) ? excludeRule.Substring(Path.GetPathRoot(excludeRule).Length) : excludeRule);
                 }
             }


### PR DESCRIPTION
Thank's to @adrianhara https://github.com/tonerdo/coverlet/pull/524#issuecomment-532807597 I found an issue on new local source file check during instrumentation.
If pdf is not a portable pdb `metadataReaderProvider.GetMetadataReader()` throws exception `Invalid COR20 header signature.` because cecil can read only portable pdb.

![65247903-87b0df80-daf1-11e9-9187-74e256b94283](https://user-images.githubusercontent.com/7894084/65252583-82579300-daf9-11e9-8721-80486aff2139.png)

For now in case of exception for this reason we'll skip check so we'll instument module.
Return false would block user and in case of issue we'll can skip bad module with exclusion filter, so I think it's a good solution.

cc: @tonerdo @petli 

Thank's a lot Adrian for the repro!

NB: minor change, I fixed redundant verbosity log.
New verbose output

![image](https://user-images.githubusercontent.com/7894084/65252911-09a50680-dafa-11e9-840c-ec1161e30175.png)





