### PR TITLE
Allow to prevent RestoreOriginalModule when GetCoverageResult is called

### DIFF
--- a/src/coverlet.core/Coverage.cs
+++ b/src/coverlet.core/Coverage.cs
@@ -128,7 +128,7 @@ namespace Coverlet.Core
             };
         }
 
-        public CoverageResult GetCoverageResult(bool revertModules = true)
+        public CoverageResult GetCoverageResult(bool restoreModules = true)
         {
             CalculateCoverage();
 
@@ -214,7 +214,7 @@ namespace Coverlet.Core
                 }
 
                 modules.Add(Path.GetFileName(result.ModulePath), documents);
-                if (revertModules) _instrumentationHelper.RestoreOriginalModule(result.ModulePath, _identifier);
+                if (restoreModules) _instrumentationHelper.RestoreOriginalModule(result.ModulePath, _identifier);
             }
 
             var coverageResult = new CoverageResult { Identifier = _identifier, Modules = modules, InstrumentedResults = _results };

--- a/src/coverlet.core/Coverage.cs
+++ b/src/coverlet.core/Coverage.cs
@@ -128,7 +128,7 @@ namespace Coverlet.Core
             };
         }
 
-        public CoverageResult GetCoverageResult()
+        public CoverageResult GetCoverageResult(bool revertModules = true)
         {
             CalculateCoverage();
 
@@ -214,7 +214,7 @@ namespace Coverlet.Core
                 }
 
                 modules.Add(Path.GetFileName(result.ModulePath), documents);
-                _instrumentationHelper.RestoreOriginalModule(result.ModulePath, _identifier);
+                if (revertModules) _instrumentationHelper.RestoreOriginalModule(result.ModulePath, _identifier);
             }
 
             var coverageResult = new CoverageResult { Identifier = _identifier, Modules = modules, InstrumentedResults = _results };


### PR DESCRIPTION
There are specific situations when you want to preserve the Instrumentation. For example fuzzing techniques, we are working on an fuzzer using this library for the coverage and we need this change.

Thanks for your amazing work