### PR TITLE
Improve lambda scenario coverage

### DIFF
--- a/src/coverlet.core/Helpers/InstrumentationHelper.cs
+++ b/src/coverlet.core/Helpers/InstrumentationHelper.cs
@@ -198,7 +198,7 @@ namespace Coverlet.Core.Helpers
             }
         }
 
-        public void RestoreOriginalModule(string module, string identifier)
+        public virtual void RestoreOriginalModule(string module, string identifier)
         {
             var backupPath = GetBackupPath(module, identifier);
             var backupSymbolPath = Path.ChangeExtension(backupPath, ".pdb");
@@ -226,7 +226,7 @@ namespace Coverlet.Core.Helpers
             }, retryStrategy, 10);
         }
 
-        public void RestoreOriginalModules()
+        public virtual void RestoreOriginalModules()
         {
             // Restore the original module - retry up to 10 times, since the destination file could be locked
             // See: https://github.com/tonerdo/coverlet/issues/25

--- a/src/coverlet.core/Instrumentation/InstrumenterResult.cs
+++ b/src/coverlet.core/Instrumentation/InstrumenterResult.cs
@@ -5,6 +5,7 @@ using System.Runtime.Serialization;
 
 namespace Coverlet.Core.Instrumentation
 {
+    [DebuggerDisplay("Number = {Number} Hits = {Hits} Class = {Class} Method = {Method}")]
     [DataContract]
     public class Line
     {
@@ -73,6 +74,7 @@ namespace Coverlet.Core.Instrumentation
         public Dictionary<BranchKey, Branch> Branches { get; private set; }
     }
 
+    [DebuggerDisplay("isBranch = {isBranch} docIndex = {docIndex} start = {start} end = {end}")]
     [DataContract]
     public class HitCandidate
     {
@@ -99,6 +101,8 @@ namespace Coverlet.Core.Instrumentation
 
         [DataMember]
         public string Module;
+        [DataMember]
+        public string[] BranchesInCompiledGeneratedClass;
         [DataMember]
         public string HitsFilePath;
         [DataMember]

--- a/test/coverlet.core.tests/Helpers/InstrumentationHelperTests.cs
+++ b/test/coverlet.core.tests/Helpers/InstrumentationHelperTests.cs
@@ -141,6 +141,22 @@ namespace Coverlet.Core.Helpers.Tests
         }
 
         [Fact]
+        public void TestIsTypeExcludedNamespace()
+        {
+            var result = _instrumentationHelper.IsTypeExcluded("Module.dll", "Namespace.Namespace.Type", new string[]{ "[Module]Namespace.Namespace.*" });
+            Assert.True(result);
+
+            result = _instrumentationHelper.IsTypeExcluded("Module.dll", "Namespace.Namespace.TypeB", new string[] { "[Module]Namespace.Namespace.*" });
+            Assert.True(result);
+
+            result = _instrumentationHelper.IsTypeExcluded("Module.dll", "Namespace.Namespace.Type", new string[] { "[Module]Namespace.*" });
+            Assert.True(result);
+
+            result = _instrumentationHelper.IsTypeExcluded("Module.dll", "Namespace.Namespace.Type", new string[] { "[Module]Namespace.WrongNamespace.*" });
+            Assert.False(result);
+        }
+
+        [Fact]
         public void TestIsTypeIncludedWithoutFilter()
         {
             var result = _instrumentationHelper.IsTypeIncluded("Module.dll", "a.b.Dto", new string[0]);

--- a/test/coverlet.core.tests/Helpers/InstrumentationHelperTests.cs
+++ b/test/coverlet.core.tests/Helpers/InstrumentationHelperTests.cs
@@ -141,22 +141,6 @@ namespace Coverlet.Core.Helpers.Tests
         }
 
         [Fact]
-        public void TestIsTypeExcludedNamespace()
-        {
-            var result = _instrumentationHelper.IsTypeExcluded("Module.dll", "Namespace.Namespace.Type", new string[]{ "[Module]Namespace.Namespace.*" });
-            Assert.True(result);
-
-            result = _instrumentationHelper.IsTypeExcluded("Module.dll", "Namespace.Namespace.TypeB", new string[] { "[Module]Namespace.Namespace.*" });
-            Assert.True(result);
-
-            result = _instrumentationHelper.IsTypeExcluded("Module.dll", "Namespace.Namespace.Type", new string[] { "[Module]Namespace.*" });
-            Assert.True(result);
-
-            result = _instrumentationHelper.IsTypeExcluded("Module.dll", "Namespace.Namespace.Type", new string[] { "[Module]Namespace.WrongNamespace.*" });
-            Assert.False(result);
-        }
-
-        [Fact]
         public void TestIsTypeIncludedWithoutFilter()
         {
             var result = _instrumentationHelper.IsTypeIncluded("Module.dll", "a.b.Dto", new string[0]);

--- a/test/coverlet.core.tests/InstrumenterHelper.cs
+++ b/test/coverlet.core.tests/InstrumenterHelper.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -78,6 +79,21 @@ namespace Coverlet.Core.Tests
             return document;
         }
 
+        public static string ToStringBranches(this Document document)
+        {
+            if (document is null)
+            {
+                throw new ArgumentNullException(nameof(document));
+            }
+
+            StringBuilder builder = new StringBuilder();
+            foreach (KeyValuePair<BranchKey, Branch> branch in document.Branches)
+            {
+                builder.AppendLine($"({branch.Value.Number}, {branch.Value.Ordinal}, {branch.Value.Hits}),");
+            }
+            return builder.ToString();
+        }
+
         public static Document AssertBranchesCovered(this Document document, BuildConfiguration configuration, params (int line, int ordinal, int hits)[] lines)
         {
             if (document is null)
@@ -123,6 +139,47 @@ namespace Coverlet.Core.Tests
         public static Document AssertLinesCovered(this Document document, params (int line, int hits)[] lines)
         {
             return AssertLinesCovered(document, BuildConfiguration.Debug | BuildConfiguration.Release, lines);
+        }
+
+        public static Document AssertLinesCoveredAllBut(this Document document, BuildConfiguration configuration, params int[] linesNumber)
+        {
+            if (document is null)
+            {
+                throw new ArgumentNullException(nameof(document));
+            }
+
+            BuildConfiguration buildConfiguration = GetAssemblyBuildConfiguration();
+
+            if ((buildConfiguration & configuration) != buildConfiguration)
+            {
+                return document;
+            }
+
+            foreach (KeyValuePair<int, Line> line in document.Lines)
+            {
+                bool skip = false;
+                foreach (int number in linesNumber)
+                {
+                    if (line.Value.Number == number)
+                    {
+                        skip = true;
+                        if (line.Value.Hits > 0)
+                        {
+                            throw new XunitException($"Hits not expected for line {line.Value.Number}");
+                        }
+                    }
+                }
+
+                if (skip)
+                    continue;
+
+                if (line.Value.Hits == 0)
+                {
+                    throw new XunitException($"Hits expected for line: {line.Value.Number}");
+                }
+            }
+
+            return document;
         }
 
         public static Document AssertLinesCovered(this Document document, BuildConfiguration configuration, params (int line, int hits)[] lines)
@@ -189,11 +246,14 @@ namespace Coverlet.Core.Tests
         /// </summary>
         public static void GenerateHtmlReport(CoverageResult coverageResult, IReporter reporter = null, string sourceFileFilter = "", [CallerMemberName]string directory = "")
         {
+            JsonReporter defaultReporter = new JsonReporter();
             reporter ??= new CoberturaReporter();
             DirectoryInfo dir = Directory.CreateDirectory(directory);
             dir.Delete(true);
             dir.Create();
-            string reportFile = Path.Combine(dir.FullName, Path.ChangeExtension("report", reporter.Extension));
+            string reportFile = Path.Combine(dir.FullName, Path.ChangeExtension("report", defaultReporter.Extension));
+            File.WriteAllText(reportFile, defaultReporter.Report(coverageResult));
+            reportFile = Path.Combine(dir.FullName, Path.ChangeExtension("report", reporter.Extension));
             File.WriteAllText(reportFile, reporter.Report(coverageResult));
             // i.e. reportgenerator -reports:"C:\git\coverlet\test\coverlet.core.tests\bin\Debug\netcoreapp2.0\Condition_If\report.cobertura.xml" -targetdir:"C:\git\coverlet\test\coverlet.core.tests\bin\Debug\netcoreapp2.0\Condition_If" -filefilters:+**\Samples\Instrumentation.cs
             new Generator().GenerateReport(new ReportConfiguration(
@@ -215,20 +275,29 @@ namespace Coverlet.Core.Tests
             using (var result = new FileStream(filePath, FileMode.Open))
             {
                 CoveragePrepareResult coveragePrepareResultLoaded = CoveragePrepareResult.Deserialize(result);
-                Coverage coverage = new Coverage(coveragePrepareResultLoaded, new Mock<ILogger>().Object, new InstrumentationHelper(new ProcessExitHandler(), new RetryHelper(), new FileSystem()), new FileSystem());
+                Coverage coverage = new Coverage(coveragePrepareResultLoaded, new Mock<ILogger>().Object, DependencyInjection.Current.GetService<IInstrumentationHelper>(), new FileSystem());
                 return coverage.GetCoverageResult();
             }
         }
 
-        async public static Task<CoveragePrepareResult> Run<T>(Func<dynamic, Task> callMethod, string persistPrepareResultToFile)
+        async public static Task<CoveragePrepareResult> Run<T>(Func<dynamic, Task> callMethod, string persistPrepareResultToFile, bool disableRestoreModules = false)
         {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddTransient<IRetryHelper, CustomRetryHelper>();
+            serviceCollection.AddTransient<IProcessExitHandler, CustomProcessExitHandler>();
+            serviceCollection.AddTransient<IFileSystem, FileSystem>();
+            if (disableRestoreModules)
+            {
+                serviceCollection.AddSingleton<IInstrumentationHelper, InstrumentationHelperForDebugging>();
+            }
+            else
+            {
+                serviceCollection.AddSingleton<IInstrumentationHelper, InstrumentationHelper>();
+            }
+
             // Setup correct retry helper to avoid exception in InstrumentationHelper.RestoreOriginalModules on remote process exit
-            DependencyInjection.Set(new ServiceCollection()
-            .AddTransient<IRetryHelper, CustomRetryHelper>()
-            .AddTransient<IProcessExitHandler, CustomProcessExitHandler>()
-            .AddTransient<IFileSystem, FileSystem>()
-            .AddSingleton<IInstrumentationHelper, InstrumentationHelper>()
-            .BuildServiceProvider());
+            DependencyInjection.Set(serviceCollection.BuildServiceProvider());
+
 
             // Rename test file to avoid locks
             string location = typeof(T).Assembly.Location;
@@ -243,7 +312,7 @@ namespace Coverlet.Core.Tests
             Coverage coverage = new Coverage(newPath,
             new string[]
             {
-                $"[{Path.GetFileNameWithoutExtension(fileName)}*]{typeof(T).FullName}"
+                $"[{Path.GetFileNameWithoutExtension(fileName)}*]{typeof(T).FullName}*"
             },
             Array.Empty<string>(),
             new string[]
@@ -361,6 +430,25 @@ namespace Coverlet.Core.Tests
         public void LogWarning(string message)
         {
             File.AppendAllText(_logFile, message + Environment.NewLine);
+        }
+    }
+
+    class InstrumentationHelperForDebugging : InstrumentationHelper
+    {
+        public InstrumentationHelperForDebugging(IProcessExitHandler processExitHandler, IRetryHelper retryHelper, IFileSystem fileSystem)
+            : base(processExitHandler, retryHelper, fileSystem)
+        {
+
+        }
+
+        public override void RestoreOriginalModule(string module, string identifier)
+        {
+            // DO NOT RESTORE
+        }
+
+        public override void RestoreOriginalModules()
+        {
+            // DO NOT RESTORE
         }
     }
 }

--- a/test/coverlet.core.tests/Samples/Instrumentation.Lambda.cs
+++ b/test/coverlet.core.tests/Samples/Instrumentation.Lambda.cs
@@ -1,0 +1,64 @@
+﻿// Remember to use full name because adding new using directives change line numbers
+
+using System.Threading.Tasks;
+
+namespace Coverlet.Core.Samples.Tests
+{
+    public class Lambda_Issue343
+    {
+        protected T WriteToStream<T>(System.Func<System.IO.Stream, bool, T> getResultFunction)
+        {
+            using (var stream = new System.IO.MemoryStream())
+            {
+                var result = getResultFunction(stream, false);
+                return result;
+            }
+        }
+
+        public bool InvokeAnonymous()
+        {
+            return WriteToStream((stream, condition) =>
+            {
+                if (condition)
+                    stream.WriteByte(1);
+                else
+                    stream.WriteByte(0);
+                return condition;
+            }
+            );
+        }
+
+        public bool InvokeAnonymous_Test()
+        {
+            Lambda_Issue343 demoClass = new Lambda_Issue343();
+            return demoClass.InvokeAnonymous();
+        }
+
+        protected async Task<T> WriteToStreamAsync<T>(System.Func<System.IO.Stream, bool, Task<T>> getResultFunction)
+        {
+            using (var stream = new System.IO.MemoryStream())
+            {
+                var result = await getResultFunction(stream, false);
+                return result;
+            }
+        }
+
+        async public Task<bool> InvokeAnonymousAsync()
+        {
+            return await WriteToStreamAsync(async (stream, condition) =>
+            {
+                if (condition)
+                    stream.WriteByte(1);
+                else
+                    stream.WriteByte(0);
+                return await Task.FromResult(condition);
+            });
+        }
+
+        async public Task<bool> InvokeAnonymousAsync_Test()
+        {
+            Lambda_Issue343 demoClass = new Lambda_Issue343();
+            return await demoClass.InvokeAnonymousAsync();
+        }
+    }
+}


### PR DESCRIPTION
contributes to https://github.com/tonerdo/coverlet/issues/343

This code fix the issue of "false covered lines/branches" for lambda and async lambda bit complex scenario.

![Capture](https://user-images.githubusercontent.com/7894084/66411769-91dd4400-e9f4-11e9-8134-91aa44e5f98f.PNG)


We've again some issue with unexpected reported branch, but for now is better than nothing.
Other solution I found trim out valid branches so for now I prefer false positive uncovered branch than covered.

cc: @driseley @tonerdo @petli @SteveGilham 

@daveMueller take a look if you're interested in the intrumentation part, you can start from test, are debuggable pass true to `TestInstrumentationHelper.Run(.,disableRestoreModule` and `RemoteExecutor.Invoke(...,invokeLocal`), if you're in throuble let me know.