### PR TITLE
Add extension for getservice and replace usages

### DIFF
--- a/src/coverlet.collector/DataCollection/CoverageWrapper.cs
+++ b/src/coverlet.collector/DataCollection/CoverageWrapper.cs
@@ -1,6 +1,7 @@
 ﻿using Coverlet.Collector.Utilities.Interfaces;
 using Coverlet.Core;
 using Coverlet.Core.Abstracts;
+using coverlet.core.Extensions;
 using Coverlet.Core.Logging;
 
 namespace Coverlet.Collector.DataCollection
@@ -30,8 +31,8 @@ namespace Coverlet.Collector.DataCollection
                 settings.MergeWith,
                 settings.UseSourceLink,
                 coverletLogger,
-                (IInstrumentationHelper)DependencyInjection.Current.GetService(typeof(IInstrumentationHelper)),
-                (IFileSystem)DependencyInjection.Current.GetService(typeof(IFileSystem)));
+                DependencyInjection.Current.GetService<IInstrumentationHelper>(),
+                DependencyInjection.Current.GetService<IFileSystem>());
         }
 
         /// <summary>

--- a/src/coverlet.collector/DataCollection/CoverageWrapper.cs
+++ b/src/coverlet.collector/DataCollection/CoverageWrapper.cs
@@ -1,7 +1,7 @@
 ﻿using Coverlet.Collector.Utilities.Interfaces;
 using Coverlet.Core;
 using Coverlet.Core.Abstracts;
-using coverlet.core.Extensions;
+using Coverlet.Core.Extensions;
 using Coverlet.Core.Logging;
 
 namespace Coverlet.Collector.DataCollection

--- a/src/coverlet.console/Program.cs
+++ b/src/coverlet.console/Program.cs
@@ -10,7 +10,7 @@ using Coverlet.Console.Logging;
 using Coverlet.Core;
 using Coverlet.Core.Abstracts;
 using Coverlet.Core.Enums;
-using coverlet.core.Extensions;
+using Coverlet.Core.Extensions;
 using Coverlet.Core.Reporters;
 using McMaster.Extensions.CommandLineUtils;
 

--- a/src/coverlet.console/Program.cs
+++ b/src/coverlet.console/Program.cs
@@ -10,6 +10,7 @@ using Coverlet.Console.Logging;
 using Coverlet.Core;
 using Coverlet.Core.Abstracts;
 using Coverlet.Core.Enums;
+using coverlet.core.Extensions;
 using Coverlet.Core.Reporters;
 using McMaster.Extensions.CommandLineUtils;
 
@@ -59,7 +60,7 @@ namespace Coverlet.Console
                     // Adjust log level based on user input.
                     logger.Level = verbosity.ParsedValue;
                 }
-                var fileSystem = (IFileSystem)DependencyInjection.Current.GetService(typeof(IFileSystem));
+                var fileSystem = DependencyInjection.Current.GetService<IFileSystem>();
                 Coverage coverage = new Coverage(module.Value,
                     includeFilters.Values.ToArray(),
                     includeDirectories.Values.ToArray(),
@@ -71,7 +72,7 @@ namespace Coverlet.Console
                     mergeWith.Value(),
                     useSourceLink.HasValue(),
                     logger,
-                    (IInstrumentationHelper)DependencyInjection.Current.GetService(typeof(IInstrumentationHelper)),
+                    DependencyInjection.Current.GetService<IInstrumentationHelper>(),
                     fileSystem);
                 coverage.PrepareModules();
 

--- a/src/coverlet.core/Extensions/DependencyInjectionExtensions.cs
+++ b/src/coverlet.core/Extensions/DependencyInjectionExtensions.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using Coverlet.Core.Attributes;
+
+namespace coverlet.core.Extensions
+{
+    public static class DependencyInjectionExtensions
+    {
+        [ExcludeFromCoverage]
+        public static T GetService<T>(this IServiceProvider serviceProvider)
+        {
+            return (T)serviceProvider.GetService(typeof(T));
+        }
+    }
+}

--- a/src/coverlet.core/Extensions/DependencyInjectionExtensions.cs
+++ b/src/coverlet.core/Extensions/DependencyInjectionExtensions.cs
@@ -1,11 +1,9 @@
 ﻿using System;
-using Coverlet.Core.Attributes;
 
-namespace coverlet.core.Extensions
+namespace Coverlet.Core.Extensions
 {
     public static class DependencyInjectionExtensions
     {
-        [ExcludeFromCoverage]
         public static T GetService<T>(this IServiceProvider serviceProvider)
         {
             return (T)serviceProvider.GetService(typeof(T));

--- a/src/coverlet.msbuild.tasks/CoverageResultTask.cs
+++ b/src/coverlet.msbuild.tasks/CoverageResultTask.cs
@@ -6,7 +6,7 @@ using ConsoleTables;
 using Coverlet.Core;
 using Coverlet.Core.Abstracts;
 using Coverlet.Core.Enums;
-using coverlet.core.Extensions;
+using Coverlet.Core.Extensions;
 using Coverlet.Core.Reporters;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;

--- a/src/coverlet.msbuild.tasks/CoverageResultTask.cs
+++ b/src/coverlet.msbuild.tasks/CoverageResultTask.cs
@@ -6,6 +6,7 @@ using ConsoleTables;
 using Coverlet.Core;
 using Coverlet.Core.Abstracts;
 using Coverlet.Core.Enums;
+using coverlet.core.Extensions;
 using Coverlet.Core.Reporters;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
@@ -75,7 +76,7 @@ namespace Coverlet.MSbuild.Tasks
             {
                 Console.WriteLine("\nCalculating coverage result...");
 
-                IFileSystem fileSystem = (IFileSystem)DependencyInjection.Current.GetService(typeof(IFileSystem));
+                IFileSystem fileSystem = DependencyInjection.Current.GetService<IFileSystem>();
                 if (InstrumenterState is null || !fileSystem.Exists(InstrumenterState.ItemSpec))
                 {
                     _logger.LogError("Result of instrumentation task not found");
@@ -85,7 +86,7 @@ namespace Coverlet.MSbuild.Tasks
                 Coverage coverage = null;
                 using (Stream instrumenterStateStream = fileSystem.NewFileStream(InstrumenterState.ItemSpec, FileMode.Open))
                 {
-                    coverage = new Coverage(CoveragePrepareResult.Deserialize(instrumenterStateStream), this._logger, (IInstrumentationHelper)DependencyInjection.Current.GetService(typeof(IInstrumentationHelper)), fileSystem);
+                    coverage = new Coverage(CoveragePrepareResult.Deserialize(instrumenterStateStream), this._logger, DependencyInjection.Current.GetService<IInstrumentationHelper>(), fileSystem);
                 }
 
                 CoverageResult result = coverage.GetCoverageResult();

--- a/src/coverlet.msbuild.tasks/InstrumentationTask.cs
+++ b/src/coverlet.msbuild.tasks/InstrumentationTask.cs
@@ -3,7 +3,7 @@ using System.IO;
 
 using Coverlet.Core;
 using Coverlet.Core.Abstracts;
-using coverlet.core.Extensions;
+using Coverlet.Core.Extensions;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 

--- a/src/coverlet.msbuild.tasks/InstrumentationTask.cs
+++ b/src/coverlet.msbuild.tasks/InstrumentationTask.cs
@@ -3,6 +3,7 @@ using System.IO;
 
 using Coverlet.Core;
 using Coverlet.Core.Abstracts;
+using coverlet.core.Extensions;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
@@ -105,7 +106,7 @@ namespace Coverlet.MSbuild.Tasks
                 var excludeFilters = _exclude?.Split(',');
                 var excludedSourceFiles = _excludeByFile?.Split(',');
                 var excludeAttributes = _excludeByAttribute?.Split(',');
-                var fileSystem = (IFileSystem)DependencyInjection.Current.GetService(typeof(IFileSystem));
+                var fileSystem = DependencyInjection.Current.GetService<IFileSystem>();
 
                 Coverage coverage = new Coverage(_path,
                     includeFilters,
@@ -118,7 +119,7 @@ namespace Coverlet.MSbuild.Tasks
                     _mergeWith,
                     _useSourceLink,
                     _logger,
-                    (IInstrumentationHelper)DependencyInjection.Current.GetService(typeof(IInstrumentationHelper)),
+                    DependencyInjection.Current.GetService<IInstrumentationHelper>(),
                     fileSystem);
 
                 CoveragePrepareResult prepareResult = coverage.PrepareModules();

--- a/test/coverlet.collector.tests/CoverletCoverageDataCollectorTests.cs
+++ b/test/coverlet.collector.tests/CoverletCoverageDataCollectorTests.cs
@@ -15,6 +15,7 @@ using Xunit;
 using Coverlet.Collector.DataCollection;
 using Coverlet.Core.Reporters;
 using Coverlet.Core.Abstracts;
+using coverlet.core.Extensions;
 
 namespace Coverlet.Collector.Tests
 {
@@ -74,7 +75,10 @@ namespace Coverlet.Collector.Tests
                     null,
                     _context);
             IDictionary<string, object> sessionStartProperties = new Dictionary<string, object>();
-            Coverage coverage = new Coverage("abc.dll", null, null, null, null, null, true, true, "abc.json", true, It.IsAny<ILogger>(), (IInstrumentationHelper)DependencyInjection.Current.GetService(typeof(IInstrumentationHelper)), (IFileSystem)DependencyInjection.Current.GetService(typeof(IFileSystem)));
+            Coverage coverage = new Coverage("abc.dll", null, null, null, null, null, true, true, "abc.json", true,
+                It.IsAny<ILogger>(),
+                DependencyInjection.Current.GetService<IInstrumentationHelper>(),
+                DependencyInjection.Current.GetService<IFileSystem>());
 
             sessionStartProperties.Add("TestSources", new List<string> { "abc.dll" });
             _mockCoverageWrapper.Setup(x => x.CreateCoverage(It.IsAny<CoverletSettings>(), It.IsAny<ILogger>())).Returns(coverage);

--- a/test/coverlet.collector.tests/CoverletCoverageDataCollectorTests.cs
+++ b/test/coverlet.collector.tests/CoverletCoverageDataCollectorTests.cs
@@ -15,7 +15,7 @@ using Xunit;
 using Coverlet.Collector.DataCollection;
 using Coverlet.Core.Reporters;
 using Coverlet.Core.Abstracts;
-using coverlet.core.Extensions;
+using Coverlet.Core.Extensions;
 
 namespace Coverlet.Collector.Tests
 {
@@ -75,10 +75,7 @@ namespace Coverlet.Collector.Tests
                     null,
                     _context);
             IDictionary<string, object> sessionStartProperties = new Dictionary<string, object>();
-            Coverage coverage = new Coverage("abc.dll", null, null, null, null, null, true, true, "abc.json", true,
-                It.IsAny<ILogger>(),
-                DependencyInjection.Current.GetService<IInstrumentationHelper>(),
-                DependencyInjection.Current.GetService<IFileSystem>());
+            Coverage coverage = new Coverage("abc.dll", null, null, null, null, null, true, true, "abc.json", true, It.IsAny<ILogger>(), DependencyInjection.Current.GetService<IInstrumentationHelper>(), DependencyInjection.Current.GetService<IFileSystem>());
 
             sessionStartProperties.Add("TestSources", new List<string> { "abc.dll" });
             _mockCoverageWrapper.Setup(x => x.CreateCoverage(It.IsAny<CoverletSettings>(), It.IsAny<ILogger>())).Returns(coverage);


### PR DESCRIPTION
Fix #554 this issue.
Add extension `GetService<T>` to DependencyInjection for better readability and replaced all usages. 