### PR TITLE
Allow coverlet integration with other MSBuild test strategies

### DIFF
--- a/src/coverlet.msbuild.tasks/coverlet.msbuild.targets
+++ b/src/coverlet.msbuild.tasks/coverlet.msbuild.targets
@@ -3,9 +3,8 @@
   <UsingTask TaskName="Coverlet.MSbuild.Tasks.InstrumentationTask" AssemblyFile="$(CoverletToolsPath)coverlet.msbuild.tasks.dll"/>
   <UsingTask TaskName="Coverlet.MSbuild.Tasks.CoverageResultTask" AssemblyFile="$(CoverletToolsPath)coverlet.msbuild.tasks.dll"/>
 
-  <Target Name="InstrumentModulesNoBuild" BeforeTargets="VSTest">
+  <Target Name="InstrumentModules">
     <Coverlet.MSbuild.Tasks.InstrumentationTask
-      Condition="'$(VSTestNoBuild)' == 'true' and $(CollectCoverage) == 'true'"
       Path="$(TargetPath)"
       Include="$(Include)"
       IncludeDirectory="$(IncludeDirectory)"
@@ -20,26 +19,18 @@
     </Coverlet.MSbuild.Tasks.InstrumentationTask>
   </Target>
 
-  <Target Name="InstrumentModulesAfterBuild" AfterTargets="BuildProject">
-    <Coverlet.MSbuild.Tasks.InstrumentationTask
-      Condition="'$(VSTestNoBuild)' != 'true' and $(CollectCoverage) == 'true'"
-      Path="$(TargetPath)"
-      Include="$(Include)"
-      IncludeDirectory="$(IncludeDirectory)"
-      Exclude="$(Exclude)"
-      ExcludeByFile="$(ExcludeByFile)"
-      ExcludeByAttribute="$(ExcludeByAttribute)"
-      IncludeTestAssembly="$(IncludeTestAssembly)"
-      SingleHit="$(SingleHit)"
-      MergeWith="$(MergeWith)"
-      UseSourceLink="$(UseSourceLink)" >
-      <Output TaskParameter="InstrumenterState" PropertyName="InstrumenterState"/>
-    </Coverlet.MSbuild.Tasks.InstrumentationTask>
-  </Target>
+  <Target Name="InstrumentModulesNoBuild"
+          BeforeTargets="VSTest"
+          DependsOnTargets="InstrumentModules"
+          Condition="'$(VSTestNoBuild)' == 'true' and '$(CollectCoverage)' == 'true'" />
 
-  <Target Name="GenerateCoverageResult" AfterTargets="VSTest">
+  <Target Name="InstrumentModulesAfterBuild"
+          AfterTargets="BuildProject"
+          DependsOnTargets="InstrumentModules"
+          Condition="'$(VSTestNoBuild)' != 'true' and '$(CollectCoverage)' == 'true'" />
+
+  <Target Name="GenerateCoverageResult">
     <Coverlet.MSbuild.Tasks.CoverageResultTask
-      Condition="$(CollectCoverage) == 'true'"
       Output="$(CoverletOutput)"
       OutputFormat="$(CoverletOutputFormat)"
       Threshold="$(Threshold)"
@@ -48,4 +39,8 @@
       InstrumenterState="$(InstrumenterState)"/>
   </Target>
 
+  <Target Name="GenerateCoverageResultAfterTest"
+          AfterTargets="VSTest"
+          DependsOnTargets="GenerateCoverageResult"
+          Condition="'$(CollectCoverage)' == 'true'" />
 </Project>


### PR DESCRIPTION
This change exposes the InstrumentModules and GenerateCoverageResult targets which execute unconditionally, and can then be tied into build steps using conditional logic. The previous logic for supporting the VSTest target is retained through conditional targets.