### PR TITLE
Fix ConfigureAwait state machine generated branches

### DIFF
--- a/src/coverlet.core/Symbols/CecilSymbolHelper.cs
+++ b/src/coverlet.core/Symbols/CecilSymbolHelper.cs
@@ -86,7 +86,11 @@ namespace Coverlet.Core.Symbols
                     // Skip get_IsCompleted to avoid unuseful branch due to async/await state machine
                     if (isAsyncStateMachineMoveNext && instruction.Previous.Operand is MethodReference operand &&
                             operand.Name == "get_IsCompleted" &&
-                            operand.DeclaringType.FullName.StartsWith("System.Runtime.CompilerServices.TaskAwaiter") &&
+                            (
+                                operand.DeclaringType.FullName.StartsWith("System.Runtime.CompilerServices.TaskAwaiter") ||
+                                operand.DeclaringType.FullName.StartsWith("System.Runtime.CompilerServices.ConfiguredTaskAwaitable")
+                            )
+                            &&
                             operand.DeclaringType.Scope.Name == "System.Runtime")
                     {
                         continue;

--- a/test/coverlet.core.tests/CoverageTests.cs
+++ b/test/coverlet.core.tests/CoverageTests.cs
@@ -175,6 +175,7 @@ namespace Coverlet.Core.Tests
                         res = ((Task<int>)instance.AsyncExecution(2)).ConfigureAwait(false).GetAwaiter().GetResult();
                         res = ((Task<int>)instance.AsyncExecution(3)).ConfigureAwait(false).GetAwaiter().GetResult();
                         res = ((Task<int>)instance.ContinuationCalled()).ConfigureAwait(false).GetAwaiter().GetResult();
+                        res = ((Task<int>)instance.ConfigureAwait()).ConfigureAwait(false).GetAwaiter().GetResult();
 
                         return Task.CompletedTask;
                     }, pathSerialize);
@@ -200,7 +201,9 @@ namespace Coverlet.Core.Tests
                                             // ContinuationNotCalled
                                             (74, 0), (75, 0), (76, 0), (77, 0), (78, 0),
                                             // ContinuationCalled -> line 83 should be 1 hit some issue with Continuation state machine
-                                            (81, 1), (82, 1), (83, 2), (84, 1), (85, 1)
+                                            (81, 1), (82, 1), (83, 2), (84, 1), (85, 1),
+                                            // ConfigureAwait
+                                            (89, 1), (90, 1)
                                          )
                       .AssertBranchesCovered(BuildConfiguration.Debug, (16, 0, 0), (16, 1, 1), (43, 0, 3), (43, 1, 1), (43, 2, 1), (43, 3, 1), (43, 4, 0))
                       // Real branch should be 2, we should try to remove compiler generated branch in method ContinuationNotCalled/ContinuationCalled

--- a/test/coverlet.core.tests/Samples/Instrumentation.AsyncAwait.cs
+++ b/test/coverlet.core.tests/Samples/Instrumentation.AsyncAwait.cs
@@ -23,7 +23,7 @@ namespace Coverlet.Core.Samples.Tests
 
         async public Task<int> Async()
         {
-            await Task.Delay(1000);
+            await Task.Delay(100);
             return 42;
         }
 
@@ -82,6 +82,12 @@ namespace Coverlet.Core.Samples.Tests
             int res = 0;
             res += await Async().ContinueWith(x => x.Result);
             return res;
+        }
+
+        async public Task<int> ConfigureAwait()
+        {
+            await Task.Delay(100).ConfigureAwait(false);
+            return 42;
         }
     }
 }


### PR DESCRIPTION
closes https://github.com/tonerdo/coverlet/issues/623

C# compiler use a different state machine class in case of `await task.ConfiguraAwait(bool)`, we added new type to async/await state machine branches filter.

@tfadler thanks for repro, day after merge of this you'll can try fix using nightly build https://github.com/tonerdo/coverlet/blob/master/Documentation/ConsumeNightlyBuild.md

cc @tonerdo @petli 