### PR TITLE
Fixed an issue where the AspNetCoreSharedFrameworkResolver was never called in .net core 3.1

### DIFF
--- a/src/coverlet.core/Instrumentation/CecilAssemblyResolver.cs
+++ b/src/coverlet.core/Instrumentation/CecilAssemblyResolver.cs
@@ -180,9 +180,24 @@ namespace Coverlet.Core.Instrumentation
                         continue;
                     }
 
+                    //Workaround for .NET Core 3.1 deps file changes
+                    var compilationLibrary = library;
+                    if (compilationLibrary.Assemblies.Count == 0)
+                    {
+                        compilationLibrary = new CompilationLibrary(library.Type,
+                            library.Name,
+                            library.Version,
+                            library.Hash,
+                            new[] { library.Name + ".dll" },
+                            library.Dependencies,
+                            library.Serviceable,
+                            library.Path,
+                            library.HashPath);
+                    }
+
                     try
                     {
-                        string path = library.ResolveReferencePaths(_compositeResolver.Value).FirstOrDefault();
+                        string path = compilationLibrary.ResolveReferencePaths(_compositeResolver.Value).FirstOrDefault();
                         if (string.IsNullOrEmpty(path))
                         {
                             continue;


### PR DESCRIPTION
Continuing from https://github.com/tonerdo/coverlet/issues/654#issuecomment-565076523

See also CecilAssemblyResolver:185:
`string path = library.ResolveReferencePaths(_compositeResolver.Value).FirstOrDefault();`

AspNetCoreSharedFrameworkResolver.TryResolveAssemblyPaths() was never called when it was the last entry in the compositeResolver. Just moving it up to be the first resolver fixes the issue.