### PR TITLE
Fix back-compat issue with old file report naming

### DIFF
--- a/src/coverlet.msbuild.tasks/ReportWriter.cs
+++ b/src/coverlet.msbuild.tasks/ReportWriter.cs
@@ -35,8 +35,8 @@ namespace Coverlet.MSbuild.Tasks
             else if (Path.HasExtension(filename))
             {
                 // filename with extension for instance c:\reportpath\file.ext
-                // c:\reportpath\file.ext.reportedextension
-                filename = $"{Path.GetFileNameWithoutExtension(filename)}{separatorPoint}{_coverletMultiTargetFrameworksCurrentTFM}{Path.GetExtension(filename)}.{_reporter.Extension}";
+                // we keep user specified name
+                filename = $"{Path.GetFileNameWithoutExtension(filename)}{separatorPoint}{_coverletMultiTargetFrameworksCurrentTFM}{Path.GetExtension(filename)}";
             }
             else
             {

--- a/test/coverlet.core.tests/Reporters/Reporters.cs
+++ b/test/coverlet.core.tests/Reporters/Reporters.cs
@@ -16,15 +16,15 @@ namespace Coverlet.Core.Reporters.Tests
         // single tfm
         [InlineData("", "/folder/reportFolder/", "lcov", "/folder/reportFolder/coverage.info")]
         [InlineData(null, "/folder/reportFolder/", "cobertura", "/folder/reportFolder/coverage.cobertura.xml")]
-        [InlineData(null, "/folder/reportFolder/file.ext", "cobertura", "/folder/reportFolder/file.ext.cobertura.xml")]
-        [InlineData(null, "/folder/reportFolder/file.ext1.ext2", "cobertura", "/folder/reportFolder/file.ext1.ext2.cobertura.xml")]
+        [InlineData(null, "/folder/reportFolder/file.ext", "cobertura", "/folder/reportFolder/file.ext")]
+        [InlineData(null, "/folder/reportFolder/file.ext1.ext2", "cobertura", "/folder/reportFolder/file.ext1.ext2")]
         [InlineData(null, "/folder/reportFolder/file", "cobertura", "/folder/reportFolder/file.cobertura.xml")]
         [InlineData(null, "file", "cobertura", "file.cobertura.xml")]
         // multiple tfm
         [InlineData("netcoreapp2.2", "/folder/reportFolder/", "lcov", "/folder/reportFolder/coverage.netcoreapp2.2.info")]
         [InlineData("netcoreapp2.2", "/folder/reportFolder/", "cobertura", "/folder/reportFolder/coverage.netcoreapp2.2.cobertura.xml")]
-        [InlineData("net472", "/folder/reportFolder/file.ext", "cobertura", "/folder/reportFolder/file.net472.ext.cobertura.xml")]
-        [InlineData("net472", "/folder/reportFolder/file.ext1.ext2", "cobertura", "/folder/reportFolder/file.ext1.net472.ext2.cobertura.xml")]
+        [InlineData("net472", "/folder/reportFolder/file.ext", "cobertura", "/folder/reportFolder/file.net472.ext")]
+        [InlineData("net472", "/folder/reportFolder/file.ext1.ext2", "cobertura", "/folder/reportFolder/file.ext1.net472.ext2")]
         [InlineData("netcoreapp2.2", "/folder/reportFolder/file", "cobertura", "/folder/reportFolder/file.netcoreapp2.2.cobertura.xml")]
         [InlineData("netcoreapp2.2", "file", "cobertura", "file.netcoreapp2.2.cobertura.xml")]
         public void Msbuild_ReportWriter(string coverletMultiTargetFrameworksCurrentTFM, string coverletOutput, string reportFormat, string expectedFileName)

--- a/test/coverlet.integration.tests/BaseTest.cs
+++ b/test/coverlet.integration.tests/BaseTest.cs
@@ -288,7 +288,24 @@ namespace Coverlet.Integration.Tests
 
         public ClonedTemplateProject(string projectRootPath, bool cleanupOnDispose) => (ProjectRootPath, _cleanupOnDispose) = (projectRootPath, cleanupOnDispose);
 
+        public bool IsMultipleTargetFramework()
+        {
+            using var csprojStream = File.OpenRead(ProjectFileNamePath);
+            XDocument xml = XDocument.Load(csprojStream);
+            return xml.Element("Project").Element("PropertyGroup").Element("TargetFramework") == null;
+        }
 
+        public string[] GetTargetFrameworks()
+        {
+            using var csprojStream = File.OpenRead(ProjectFileNamePath);
+            XDocument xml = XDocument.Load(csprojStream);
+            XElement element = xml.Element("Project").Element("PropertyGroup").Element("TargetFramework") ?? xml.Element("Project").Element("PropertyGroup").Element("TargetFrameworks");
+            if (element is null)
+            {
+                throw new ArgumentNullException("No 'TargetFramework' neither 'TargetFrameworks' found in csproj file");
+            }
+            return element.Value.Split(";");
+        }
 
         public string[] GetFiles(string filter)
         {


### PR DESCRIPTION
Fix back-compat issue with old file report naming https://github.com/tonerdo/coverlet/issues/649#issuecomment-568300854

cc: @abbotware
