### PR TITLE
Fixed issue with ReportGenerator.Core when using .NET Core 3.1

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -14,7 +14,7 @@
     <!-- Do not upgrade this version or we won't support old SDK -->
     <PackageReference Update="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Update="NuGet.Packaging" Version="5.4.0" />
-    <PackageReference Update="ReportGenerator.Core" Version="4.4.4" />
+    <PackageReference Update="ReportGenerator.Core" Version="4.4.5" />
     <!--
         Do not change System.Reflection.Metadata version since we need to support VSTest DataCollectors. Goto https://www.nuget.org/packages/System.Reflection.Metadata to check versions.
         We need to load assembly version 1.4.2.0 to properly work

--- a/test/coverlet.core.tests/Coverage/CoverageTests.cs
+++ b/test/coverlet.core.tests/Coverage/CoverageTests.cs
@@ -111,7 +111,7 @@ namespace Coverlet.Core.Tests
                 CoverageResult result = TestInstrumentationHelper.GetCoverageResult(path);
 
                 // Generate html report to check
-                // TestInstrumentationHelper.GenerateHtmlReport(result);
+                TestInstrumentationHelper.GenerateHtmlReport(result);
 
                 // Asserts on doc/lines/branches
                 result.Document("Instrumentation.SelectionStatements.cs")
@@ -433,14 +433,14 @@ namespace Coverlet.Core.Tests
                     return 0;
                 }, path).Dispose();
 
-               TestInstrumentationHelper.GetCoverageResult(path)
-               .Document("Instrumentation.ExcludeFilter.cs")
-               .AssertLinesCovered(BuildConfiguration.Debug, (12, 1), (13, 1), (14, 1))
-               .AssertLinesCovered(BuildConfiguration.Debug, (27, 1), (28, 1), (29, 1), (30, 1), (31, 1))
-               .AssertLinesCovered(BuildConfiguration.Debug, (39, 2), (40, 2), (41, 2), (43, 5))
-               .AssertLinesCovered(BuildConfiguration.Debug, (50, 1), (51, 1), (52, 1))
-               .AssertNonInstrumentedLines(BuildConfiguration.Debug, 17, 21)
-               .AssertNonInstrumentedLines(BuildConfiguration.Debug, 33, 36);
+                TestInstrumentationHelper.GetCoverageResult(path)
+                .Document("Instrumentation.ExcludeFilter.cs")
+                .AssertLinesCovered(BuildConfiguration.Debug, (12, 1), (13, 1), (14, 1))
+                .AssertLinesCovered(BuildConfiguration.Debug, (27, 1), (28, 1), (29, 1), (30, 1), (31, 1))
+                .AssertLinesCovered(BuildConfiguration.Debug, (39, 2), (40, 2), (41, 2), (43, 5))
+                .AssertLinesCovered(BuildConfiguration.Debug, (50, 1), (51, 1), (52, 1))
+                .AssertNonInstrumentedLines(BuildConfiguration.Debug, 17, 21)
+                .AssertNonInstrumentedLines(BuildConfiguration.Debug, 33, 36);
             }
             finally
             {

--- a/test/coverlet.core.tests/Coverage/CoverageTests.cs
+++ b/test/coverlet.core.tests/Coverage/CoverageTests.cs
@@ -111,7 +111,7 @@ namespace Coverlet.Core.Tests
                 CoverageResult result = TestInstrumentationHelper.GetCoverageResult(path);
 
                 // Generate html report to check
-                TestInstrumentationHelper.GenerateHtmlReport(result);
+                // TestInstrumentationHelper.GenerateHtmlReport(result);
 
                 // Asserts on doc/lines/branches
                 result.Document("Instrumentation.SelectionStatements.cs")
@@ -433,14 +433,14 @@ namespace Coverlet.Core.Tests
                     return 0;
                 }, path).Dispose();
 
-                TestInstrumentationHelper.GetCoverageResult(path)
-                .Document("Instrumentation.ExcludeFilter.cs")
-                .AssertLinesCovered(BuildConfiguration.Debug, (12, 1), (13, 1), (14, 1))
-                .AssertLinesCovered(BuildConfiguration.Debug, (27, 1), (28, 1), (29, 1), (30, 1), (31, 1))
-                .AssertLinesCovered(BuildConfiguration.Debug, (39, 2), (40, 2), (41, 2), (43, 5))
-                .AssertLinesCovered(BuildConfiguration.Debug, (50, 1), (51, 1), (52, 1))
-                .AssertNonInstrumentedLines(BuildConfiguration.Debug, 17, 21)
-                .AssertNonInstrumentedLines(BuildConfiguration.Debug, 33, 36);
+               TestInstrumentationHelper.GetCoverageResult(path)
+               .Document("Instrumentation.ExcludeFilter.cs")
+               .AssertLinesCovered(BuildConfiguration.Debug, (12, 1), (13, 1), (14, 1))
+               .AssertLinesCovered(BuildConfiguration.Debug, (27, 1), (28, 1), (29, 1), (30, 1), (31, 1))
+               .AssertLinesCovered(BuildConfiguration.Debug, (39, 2), (40, 2), (41, 2), (43, 5))
+               .AssertLinesCovered(BuildConfiguration.Debug, (50, 1), (51, 1), (52, 1))
+               .AssertNonInstrumentedLines(BuildConfiguration.Debug, 17, 21)
+               .AssertNonInstrumentedLines(BuildConfiguration.Debug, 33, 36);
             }
             finally
             {


### PR DESCRIPTION
Fixed issue with ReportGenerator.Core when using .NET Core 3.1 (see https://github.com/tonerdo/coverlet/pull/694)