### PR TITLE
Add .net tool v2 document design

### DIFF
--- a/Documentation/Design/.NET Tool v2.md
+++ b/Documentation/Design/.NET Tool v2.md
@@ -1,0 +1,71 @@
+# Functional design .NET tool 2.0 `coverlet`
+
+Tracking issue https://github.com/tonerdo/coverlet/issues/683
+
+The idea is to support some new verbs:
+
+# coverlet run
+
+This will support current instrumentation workflow
+
+```
+coverlet run /path/to/test-assembly.dll --target "dotnet" --targetargs "test /path/to/test-project --no-build"
+```
+
+# coverlet mergereports
+
+Merge `json` default coverlet reports because we should otherwise implement merge for every supported format a huge effort for first version and also with the hope to integrate this feature directly inside collectors.
+
+We'll add an alias to `json` format called `coverlet` to distiguish from possible other future json format and also because this report make sense only inside specific test lifecycle.
+The content of this report is releated to internal structure and was not born to be "portable" or "stable" over time.
+
+```
+coverlet mergereports --coverletreport .\**\coverlet.json --targetdir .\Report\coverlet.xml --format cobertura
+```
+
+`--coverletreport`: will support glob pattern filtering  
+`--format`: specify a supported format  
+`--targetDir`: will create directory folder if not present. If specified a path that ends without a filename(no extension specified) we'll create a filename in that directory called `coverage.reportextension`, i.e.  
+
+`--format cobertura --targetDir .\Report` will create `.\Report\coverage.xml`  
+`--format cobertura --targetDir .\Report\MergedCoverage.xml` will create `.\Report\MergedCoverage.xml`  
+`--format cobertura --targetDir .\Report\MergedCoverage` will create `.\Report\MergedCoverage\coverage.xml`
+
+# coverlet validate 
+
+This command do validation on `json` coverlet format, because the structure is internal and we can support a lot of control without replicate alg for every supported format
+
+Validate could support in future different type of validations, for now we support threshold.
+
+```
+coverlet validate --type threshold --... --Fail or --Warn
+```
+`threshold` will support all curren switch plus a pair of new optional switch `--Fail` and `--Warn`.
+If not specified default will be `--Fail`. This allow a user to specify only `--Warn` and avoid CI failure but only a warning in console. This feat was requested by one user and seem useful.
+
+# coverlet test
+
+Coverlet test should substitute `dotnet test` but applying collector coverage on behalf of user. We'll create runsettings and run '`dotnet test --collect "XPlat Code Coverage" --settings tmp\runsettings`'
+
+```
+coverlet test solution.sln --results-directory .\Results --settings runSetting
+```
+We should run
+```
+dotnet test --collect "XPlat Code Coverage" solution.sln --results-directory .\Results --settings [runSetting+tmp\runsettings]
+```
+The example used is the worste one, if a user has got a custom settings we should merge with our.
+
+With this command we can support merge/check threshold directly in same run when process returns.
+```
+coverlet test solution.sln --format cobertura --threshold 80 --threshold-type line --output .\Report
+```
+At the moment it's not super clear in my mind how to find and merge report files, especially if user specify `--results-directory`. Also because a user can specify also every other `dotnet test` driver switch.
+
+## Priority
+
+We can fix a feature priority  
+
+1) mergereports  
+2) validate
+3) test


### PR DESCRIPTION
Follow up discussion https://github.com/tonerdo/coverlet/issues/683

cc: @ViktorHofer because coverlet .net tool is used on dotnet runtime repo. Feel free to cc others if needed and this is a breaking change.

I'm not a native speaker/writer so feel free to correct my typos, thank's to all.