### PR TITLE
Issue 736 fix attempt experiment

### DIFF
--- a/src/coverlet.collector/DataCollection/CoverageWrapper.cs
+++ b/src/coverlet.collector/DataCollection/CoverageWrapper.cs
@@ -31,7 +31,8 @@ namespace Coverlet.Collector.DataCollection
                 settings.UseSourceLink,
                 coverletLogger,
                 DependencyInjection.Current.GetService<IInstrumentationHelper>(),
-                DependencyInjection.Current.GetService<IFileSystem>());
+                DependencyInjection.Current.GetService<IFileSystem>(),
+                true);
         }
 
         /// <summary>

--- a/src/coverlet.collector/InProcDataCollection/CoverletInProcDataCollector.cs
+++ b/src/coverlet.collector/InProcDataCollection/CoverletInProcDataCollector.cs
@@ -53,10 +53,10 @@ namespace Coverlet.Collector.DataCollection
 
                 try
                 {
-                    _eqtTrace.Verbose($"Calling ModuleTrackerTemplate.UnloadModule for '{injectedInstrumentationClass.Assembly.FullName}'");
-                    var unloadModule = injectedInstrumentationClass.GetMethod(nameof(ModuleTrackerTemplate.UnloadModule), new[] { typeof(object), typeof(EventArgs) });
-                    unloadModule.Invoke(null, new[] { null, EventArgs.Empty });
-                    _eqtTrace.Verbose($"Called ModuleTrackerTemplate.UnloadModule for '{injectedInstrumentationClass.Assembly.FullName}'");
+                    _eqtTrace.Verbose($"Calling ModuleTrackerTemplate.InProcessCollectorFlush for '{injectedInstrumentationClass.Assembly.FullName}'");
+                    var unloadModule = injectedInstrumentationClass.GetMethod(nameof(ModuleTrackerTemplate.InProcessCollectorFlush));
+                    unloadModule.Invoke(null, new object[0]);
+                    _eqtTrace.Verbose($"Called ModuleTrackerTemplate.InProcessCollectorFlush for '{injectedInstrumentationClass.Assembly.FullName}'");
                 }
                 catch (Exception ex)
                 {

--- a/test/coverlet.core.tests/Coverage/InstrumenterHelper.cs
+++ b/test/coverlet.core.tests/Coverage/InstrumenterHelper.cs
@@ -411,7 +411,7 @@ namespace Coverlet.Core.Tests
             // string hitsFilePath = (string)tracker.GetField("HitsFilePath").GetValue(null);
 
             // Void UnloadModule(System.Object, System.EventArgs)
-            tracker.GetTypeInfo().GetMethod("UnloadModule").Invoke(null, new object[2] { null, null });
+            tracker.GetTypeInfo().GetMethod(nameof(ModuleTrackerTemplate.InProcessCollectorFlush)).Invoke(null, new object[0]);
 
             // Persist CoveragePrepareResult
             using (FileStream fs = new FileStream(persistPrepareResultToFile, FileMode.Open))

--- a/test/coverlet.integration.tests/BaseTest.cs
+++ b/test/coverlet.integration.tests/BaseTest.cs
@@ -92,6 +92,7 @@ namespace Coverlet.Integration.Tests
             psi.WorkingDirectory = workingDirectory;
             psi.RedirectStandardError = true;
             psi.RedirectStandardOutput = true;
+            psi.EnvironmentVariables.Add("COVERLET_ENABLETRACKERLOG", "1");
             Process commandProcess = Process.Start(psi);
             if (!commandProcess.WaitForExit((int)TimeSpan.FromMinutes(5).TotalMilliseconds))
             {


### PR DESCRIPTION
Experiment fix for issue https://github.com/tonerdo/coverlet/issues/736

The issue is related to possible race condition between testhost process exit flush and get coverage result inside datacollector process.

Today we "reflush" hit file on process exit also in case of collectors usage, if we're unlucky there is a chance that we access to hit files from two different process at same time, test host process write to it datacollector process read from it.

This is a bad design ported from msbuild/.net tool usage, we should provide a fix, we shouldn't flush on process exit if we're on collectors.

cc: @abe545 