### PR TITLE
Add support for line branch coverage in OpenCover format

### DIFF
--- a/src/coverlet.core/Reporters/OpenCoverReporter.cs
+++ b/src/coverlet.core/Reporters/OpenCoverReporter.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -113,6 +112,9 @@ namespace Coverlet.Core.Reporters
 
                             foreach (var lines in meth.Value.Lines)
                             {
+                                var lineBranches = meth.Value.Branches.Where(branchInfo => branchInfo.Line == lines.Key).ToArray();
+                                var branchCoverage = summary.CalculateBranchCoverage(lineBranches);
+                                
                                 XElement sequencePoint = new XElement("SequencePoint");
                                 sequencePoint.Add(new XAttribute("vc", lines.Value.ToString()));
                                 sequencePoint.Add(new XAttribute("uspid", lines.Key.ToString()));
@@ -121,8 +123,8 @@ namespace Coverlet.Core.Reporters
                                 sequencePoint.Add(new XAttribute("sc", "1"));
                                 sequencePoint.Add(new XAttribute("el", lines.Key.ToString()));
                                 sequencePoint.Add(new XAttribute("ec", "2"));
-                                sequencePoint.Add(new XAttribute("bec", "0"));
-                                sequencePoint.Add(new XAttribute("bev", "0"));
+                                sequencePoint.Add(new XAttribute("bec", branchCoverage.Total));
+                                sequencePoint.Add(new XAttribute("bev", branchCoverage.Covered));
                                 sequencePoint.Add(new XAttribute("fileid", i.ToString()));
                                 sequencePoints.Add(sequencePoint);
 

--- a/test/coverlet.core.tests/Reporters/OpenCoverReporterTests.cs
+++ b/test/coverlet.core.tests/Reporters/OpenCoverReporterTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -43,6 +42,30 @@ namespace Coverlet.Core.Reporters.Tests
 
             Assert.Contains(@"<FileRef uid=""1"" />", xml);
             Assert.Contains(@"<FileRef uid=""2"" />", xml);
+        }
+
+        [Fact]
+        public void TestLineBranchCoverage()
+        {
+            var result = new CoverageResult
+            {
+                Identifier = Guid.NewGuid().ToString(),
+                Modules = new Modules { {"Coverlet.Core.Reporters.Tests", CreateBranchCoverageDocuments()} }
+            };
+            
+            var xml = new OpenCoverReporter().Report(result);
+            
+            // Line 1: Two branches, no coverage (bec = 2, bev = 0)
+            Assert.Contains(@"<SequencePoint vc=""1"" uspid=""1"" ordinal=""0"" sl=""1"" sc=""1"" el=""1"" ec=""2"" bec=""2"" bev=""0"" fileid=""1"" />", xml);
+            
+            // Line 2: Two branches, one covered (bec = 2, bev = 1)
+            Assert.Contains(@"<SequencePoint vc=""1"" uspid=""2"" ordinal=""1"" sl=""2"" sc=""1"" el=""2"" ec=""2"" bec=""2"" bev=""1"" fileid=""1"" />", xml);
+            
+            // Line 3: Two branches, all covered (bec = 2, bev = 2)
+            Assert.Contains(@"<SequencePoint vc=""1"" uspid=""3"" ordinal=""2"" sl=""3"" sc=""1"" el=""3"" ec=""2"" bec=""2"" bev=""2"" fileid=""1"" />", xml);
+            
+            // Line 4: Three branches, two covered (bec = 3, bev = 2)
+            Assert.Contains(@"<SequencePoint vc=""1"" uspid=""4"" ordinal=""3"" sl=""4"" sc=""1"" el=""4"" ec=""2"" bec=""3"" bev=""2"" fileid=""1"" />", xml);
         }
 
         private static Documents CreateFirstDocuments()
@@ -91,6 +114,48 @@ namespace Coverlet.Core.Reporters.Tests
             documents.Add("TestClass.cs", classes2);
 
             return documents;
+        }
+
+        private static Documents CreateBranchCoverageDocuments()
+        {
+            var lines = new Lines
+            {
+                {1, 1}, 
+                {2, 1}, 
+                {3, 1},
+                {4, 1},
+            };
+
+            var branches = new Branches
+            {
+                // Two branches, no coverage
+                new BranchInfo {Line = 1, Hits = 0, Offset = 23, EndOffset = 24, Path = 0, Ordinal = 1},
+                new BranchInfo {Line = 1, Hits = 0, Offset = 23, EndOffset = 27, Path = 1, Ordinal = 2},
+                
+                // Two branches, one covered
+                new BranchInfo {Line = 2, Hits = 1, Offset = 40, EndOffset = 41, Path = 0, Ordinal = 3},
+                new BranchInfo {Line = 2, Hits = 0, Offset = 40, EndOffset = 44, Path = 1, Ordinal = 4},
+                
+                // Two branches, all covered
+                new BranchInfo {Line = 3, Hits = 1, Offset = 40, EndOffset = 41, Path = 0, Ordinal = 3},
+                new BranchInfo {Line = 3, Hits = 3, Offset = 40, EndOffset = 44, Path = 1, Ordinal = 4},
+                
+                // Three branches, two covered
+                new BranchInfo {Line = 4, Hits = 5, Offset = 40, EndOffset = 44, Path = 1, Ordinal = 4},
+                new BranchInfo {Line = 4, Hits = 2, Offset = 40, EndOffset = 44, Path = 1, Ordinal = 4},
+                new BranchInfo {Line = 4, Hits = 0, Offset = 40, EndOffset = 44, Path = 1, Ordinal = 4}
+            };
+            
+            const string methodString = "System.Void Coverlet.Core.Reporters.Tests.OpenCoverReporterTests.TestReport()";
+            var methods = new Methods
+            {
+                {methodString, new Method { Lines = lines, Branches = branches}}
+            };
+
+            return new Documents
+            {
+                {"doc.cs", new Classes {{"Coverlet.Core.Reporters.Tests.OpenCoverReporterTests", methods}}}
+            };
         }
     }
 }


### PR DESCRIPTION
Fixes #769

This will populate the `bec` (branch exit count) and `bev` (branch exit visits) for the `SequencePoint` elements in `OpenCover` format.

OpenCover model can be found here: https://github.com/OpenCover/opencover/blob/94c7e572a907ac1873b8f48324d0cbc0cf1e7456/main/OpenCover.Framework/Model/SequencePoint.cs#L49