### PR TITLE
Fix Cake Add-In anchor in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Coverlet is a cross platform code coverage framework for .NET, with support for 
 * [Known Issues](#Known-Issues)
 * [Consume nightly build](#Consume-nightly-build)
 * [Feature samples](Documentation/Examples.md)
-* [Cake Add-In](#Cake.-Add-In)
+* [Cake Add-In](#Cake-Add-In)
 * [Changelog](Documentation/Changelog.md)
 
 ## Quick Start


### PR DESCRIPTION
There seems to be an extra "." in the anchor here that prevents it from working properly when clicked.