### PR TITLE
Force semver 2 for nuget packages

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,6 +10,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <MSBuildTreatWarningsAsErrors>true</MSBuildTreatWarningsAsErrors>
     <LangVersion>preview</LangVersion>
+     <NoWarn>$(NoWarn);NU5105</NoWarn>
     <RestoreSources>
       https://api.nuget.org/v3/index.json;
     </RestoreSources>

--- a/src/coverlet.collector/version.json
+++ b/src/coverlet.collector/version.json
@@ -3,5 +3,8 @@
   "version": "1.3.0-preview.{height}",
   "publicReleaseRefSpec": [
     "^refs/heads/master$"
-  ]
+  ],
+  "nugetPackageVersion":{
+    "semVer": 2
+  }
 }

--- a/src/coverlet.console/version.json
+++ b/src/coverlet.console/version.json
@@ -3,5 +3,8 @@
   "version": "1.7.2-preview.{height}",
   "publicReleaseRefSpec": [
     "^refs/heads/master$"
-  ]
+  ],
+  "nugetPackageVersion":{
+    "semVer": 2
+  }
 }

--- a/src/coverlet.msbuild.tasks/version.json
+++ b/src/coverlet.msbuild.tasks/version.json
@@ -3,5 +3,8 @@
   "version": "2.9.0-preview.{height}",
   "publicReleaseRefSpec": [
     "^refs/heads/master$"
-  ]
+  ],
+  "nugetPackageVersion":{
+    "semVer": 2
+  }
 }


### PR DESCRIPTION
Force semver 2 for nuget package.

Thank's @clairernovotny