### PR TITLE
[Housekeeping] Rename Abstracts to Abstractions

### DIFF
--- a/src/coverlet.collector/DataCollection/CoverageManager.cs
+++ b/src/coverlet.collector/DataCollection/CoverageManager.cs
@@ -6,7 +6,7 @@ using coverlet.collector.Resources;
 using Coverlet.Collector.Utilities;
 using Coverlet.Collector.Utilities.Interfaces;
 using Coverlet.Core;
-using Coverlet.Core.Abstracts;
+using Coverlet.Core.Abstractions;
 using Coverlet.Core.Reporters;
 
 namespace Coverlet.Collector.DataCollection

--- a/src/coverlet.collector/DataCollection/CoverageWrapper.cs
+++ b/src/coverlet.collector/DataCollection/CoverageWrapper.cs
@@ -1,6 +1,6 @@
 ﻿using Coverlet.Collector.Utilities.Interfaces;
 using Coverlet.Core;
-using Coverlet.Core.Abstracts;
+using Coverlet.Core.Abstractions;
 using Coverlet.Core.Extensions;
 
 namespace Coverlet.Collector.DataCollection

--- a/src/coverlet.collector/DataCollection/CoverletCoverageCollector.cs
+++ b/src/coverlet.collector/DataCollection/CoverletCoverageCollector.cs
@@ -6,7 +6,7 @@ using System.Xml;
 using Coverlet.Collector.Utilities;
 using Coverlet.Collector.Utilities.Interfaces;
 using Coverlet.Core;
-using Coverlet.Core.Abstracts;
+using Coverlet.Core.Abstractions;
 using Coverlet.Core.Helpers;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.DataCollection;

--- a/src/coverlet.collector/DataCollection/CoverletLogger.cs
+++ b/src/coverlet.collector/DataCollection/CoverletLogger.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 
 using Coverlet.Collector.Utilities;
-using Coverlet.Core.Abstracts;
+using Coverlet.Core.Abstractions;
 
 namespace Coverlet.Collector.DataCollection
 {

--- a/src/coverlet.collector/Utilities/Interfaces/ICoverageWrapper.cs
+++ b/src/coverlet.collector/Utilities/Interfaces/ICoverageWrapper.cs
@@ -1,6 +1,6 @@
 ﻿using Coverlet.Collector.DataCollection;
 using Coverlet.Core;
-using Coverlet.Core.Abstracts;
+using Coverlet.Core.Abstractions;
 
 namespace Coverlet.Collector.Utilities.Interfaces
 {

--- a/src/coverlet.console/Logging/ConsoleLogger.cs
+++ b/src/coverlet.console/Logging/ConsoleLogger.cs
@@ -1,5 +1,5 @@
 using System;
-using Coverlet.Core.Abstracts;
+using Coverlet.Core.Abstractions;
 using static System.Console;
 
 namespace Coverlet.Console.Logging

--- a/src/coverlet.console/Program.cs
+++ b/src/coverlet.console/Program.cs
@@ -8,7 +8,7 @@ using System.Text;
 using ConsoleTables;
 using Coverlet.Console.Logging;
 using Coverlet.Core;
-using Coverlet.Core.Abstracts;
+using Coverlet.Core.Abstractions;
 using Coverlet.Core.Enums;
 using Coverlet.Core.Helpers;
 using Coverlet.Core.Reporters;

--- a/src/coverlet.core/Abstractions/IConsole.cs
+++ b/src/coverlet.core/Abstractions/IConsole.cs
@@ -1,4 +1,4 @@
-﻿namespace Coverlet.Core.Abstracts
+﻿namespace Coverlet.Core.Abstractions
 {
     internal interface IConsole
     {

--- a/src/coverlet.core/Abstractions/IFileSystem.cs
+++ b/src/coverlet.core/Abstractions/IFileSystem.cs
@@ -1,6 +1,6 @@
 ﻿using System.IO;
 
-namespace Coverlet.Core.Abstracts
+namespace Coverlet.Core.Abstractions
 {
     internal interface IFileSystem
     {

--- a/src/coverlet.core/Abstractions/IInstrumentationHelper.cs
+++ b/src/coverlet.core/Abstractions/IInstrumentationHelper.cs
@@ -1,4 +1,4 @@
-﻿namespace Coverlet.Core.Abstracts
+﻿namespace Coverlet.Core.Abstractions
 {
     internal interface IInstrumentationHelper
     {

--- a/src/coverlet.core/Abstractions/ILogger.cs
+++ b/src/coverlet.core/Abstractions/ILogger.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Coverlet.Core.Abstracts
+namespace Coverlet.Core.Abstractions
 {
     internal interface ILogger
     {

--- a/src/coverlet.core/Abstractions/IProcessExitHandler.cs
+++ b/src/coverlet.core/Abstractions/IProcessExitHandler.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Coverlet.Core.Abstracts
+namespace Coverlet.Core.Abstractions
 {
     internal interface IProcessExitHandler
     {

--- a/src/coverlet.core/Abstractions/IRetryHelper.cs
+++ b/src/coverlet.core/Abstractions/IRetryHelper.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Coverlet.Core.Abstracts
+namespace Coverlet.Core.Abstractions
 {
     internal interface IRetryHelper
     {

--- a/src/coverlet.core/Abstractions/ISourceRootTranslator.cs
+++ b/src/coverlet.core/Abstractions/ISourceRootTranslator.cs
@@ -1,4 +1,4 @@
-﻿namespace Coverlet.Core.Abstracts
+﻿namespace Coverlet.Core.Abstractions
 {
     internal interface ISourceRootTranslator
     {

--- a/src/coverlet.core/Coverage.cs
+++ b/src/coverlet.core/Coverage.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using Coverlet.Core.Abstracts;
+using Coverlet.Core.Abstractions;
 using Coverlet.Core.Instrumentation;
 
 using Newtonsoft.Json;

--- a/src/coverlet.core/Helpers/Console.cs
+++ b/src/coverlet.core/Helpers/Console.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-using Coverlet.Core.Abstracts;
+using Coverlet.Core.Abstractions;
 
 namespace Coverlet.Core.Helpers
 {

--- a/src/coverlet.core/Helpers/FileSystem.cs
+++ b/src/coverlet.core/Helpers/FileSystem.cs
@@ -1,4 +1,4 @@
-﻿using Coverlet.Core.Abstracts;
+﻿using Coverlet.Core.Abstractions;
 using System.IO;
 
 namespace Coverlet.Core.Helpers

--- a/src/coverlet.core/Helpers/InstrumentationHelper.cs
+++ b/src/coverlet.core/Helpers/InstrumentationHelper.cs
@@ -9,7 +9,7 @@ using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using System.Text.RegularExpressions;
 
-using Coverlet.Core.Abstracts;
+using Coverlet.Core.Abstractions;
 
 namespace Coverlet.Core.Helpers
 {

--- a/src/coverlet.core/Helpers/ProcessExitHandler.cs
+++ b/src/coverlet.core/Helpers/ProcessExitHandler.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Coverlet.Core.Abstracts;
+using Coverlet.Core.Abstractions;
 
 namespace Coverlet.Core.Helpers
 {

--- a/src/coverlet.core/Helpers/RetryHelper.cs
+++ b/src/coverlet.core/Helpers/RetryHelper.cs
@@ -1,4 +1,4 @@
-using Coverlet.Core.Abstracts;
+using Coverlet.Core.Abstractions;
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/src/coverlet.core/Helpers/SourceRootTranslator.cs
+++ b/src/coverlet.core/Helpers/SourceRootTranslator.cs
@@ -1,4 +1,4 @@
-﻿using Coverlet.Core.Abstracts;
+﻿using Coverlet.Core.Abstractions;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/coverlet.core/Instrumentation/CecilAssemblyResolver.cs
+++ b/src/coverlet.core/Instrumentation/CecilAssemblyResolver.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
-using Coverlet.Core.Abstracts;
+using Coverlet.Core.Abstractions;
 using Coverlet.Core.Exceptions;
 using Microsoft.Extensions.DependencyModel;
 using Microsoft.Extensions.DependencyModel.Resolution;

--- a/src/coverlet.core/Instrumentation/Instrumenter.cs
+++ b/src/coverlet.core/Instrumentation/Instrumenter.cs
@@ -6,7 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 
-using Coverlet.Core.Abstracts;
+using Coverlet.Core.Abstractions;
 using Coverlet.Core.Attributes;
 using Coverlet.Core.Symbols;
 using Microsoft.Extensions.FileSystemGlobbing;

--- a/src/coverlet.msbuild.tasks/CoverageResultTask.cs
+++ b/src/coverlet.msbuild.tasks/CoverageResultTask.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using ConsoleTables;
 using Coverlet.Core;
-using Coverlet.Core.Abstracts;
+using Coverlet.Core.Abstractions;
 using Coverlet.Core.Enums;
 using Coverlet.Core.Extensions;
 using Coverlet.Core.Reporters;

--- a/src/coverlet.msbuild.tasks/InstrumentationTask.cs
+++ b/src/coverlet.msbuild.tasks/InstrumentationTask.cs
@@ -3,12 +3,12 @@ using System.Diagnostics;
 using System.IO;
 
 using Coverlet.Core;
-using Coverlet.Core.Abstracts;
+using Coverlet.Core.Abstractions;
 using Coverlet.Core.Helpers;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Microsoft.Extensions.DependencyInjection;
-using ILogger = Coverlet.Core.Abstracts.ILogger;
+using ILogger = Coverlet.Core.Abstractions.ILogger;
 
 namespace Coverlet.MSbuild.Tasks
 {

--- a/src/coverlet.msbuild.tasks/MSBuildLogger.cs
+++ b/src/coverlet.msbuild.tasks/MSBuildLogger.cs
@@ -2,7 +2,7 @@ using System;
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
-using ILogger = Coverlet.Core.Abstracts.ILogger;
+using ILogger = Coverlet.Core.Abstractions.ILogger;
 
 namespace Coverlet.MSbuild.Tasks
 {

--- a/src/coverlet.msbuild.tasks/ReportWriter.cs
+++ b/src/coverlet.msbuild.tasks/ReportWriter.cs
@@ -1,7 +1,7 @@
 ﻿using System.IO;
 
 using Coverlet.Core;
-using Coverlet.Core.Abstracts;
+using Coverlet.Core.Abstractions;
 using Coverlet.Core.Reporters;
 
 namespace Coverlet.MSbuild.Tasks

--- a/test/coverlet.collector.tests/CoverletCoverageDataCollectorTests.cs
+++ b/test/coverlet.collector.tests/CoverletCoverageDataCollectorTests.cs
@@ -13,7 +13,7 @@ using Coverlet.Collector.Utilities;
 using Xunit;
 using Coverlet.Collector.DataCollection;
 using Coverlet.Core.Reporters;
-using Coverlet.Core.Abstracts;
+using Coverlet.Core.Abstractions;
 using Coverlet.Core.Helpers;
 using Microsoft.Extensions.DependencyInjection;
 

--- a/test/coverlet.core.tests/Coverage/CoverageTests.ExcludeFromCoverageAttribute.cs
+++ b/test/coverlet.core.tests/Coverage/CoverageTests.ExcludeFromCoverageAttribute.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 
-using Coverlet.Core.Abstracts;
+using Coverlet.Core.Abstractions;
 using Coverlet.Core.Helpers;
 using Coverlet.Core.Samples.Tests;
 using Coverlet.Tests.Xunit.Extensions;

--- a/test/coverlet.core.tests/Coverage/CoverageTests.cs
+++ b/test/coverlet.core.tests/Coverage/CoverageTests.cs
@@ -1,7 +1,7 @@
 using System;
 using System.IO;
 
-using Coverlet.Core.Abstracts;
+using Coverlet.Core.Abstractions;
 using Coverlet.Core.Helpers;
 using Moq;
 using Xunit;

--- a/test/coverlet.core.tests/Coverage/InstrumenterHelper.cs
+++ b/test/coverlet.core.tests/Coverage/InstrumenterHelper.cs
@@ -7,7 +7,7 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Coverlet.Core.Abstracts;
+using Coverlet.Core.Abstractions;
 using Coverlet.Core.Helpers;
 using Coverlet.Core.Reporters;
 using Microsoft.Extensions.DependencyInjection;

--- a/test/coverlet.core.tests/Helpers/InstrumentationHelperTests.cs
+++ b/test/coverlet.core.tests/Helpers/InstrumentationHelperTests.cs
@@ -4,7 +4,7 @@ using Xunit;
 using System.Collections.Generic;
 using System.Linq;
 using Moq;
-using Coverlet.Core.Abstracts;
+using Coverlet.Core.Abstractions;
 
 namespace Coverlet.Core.Helpers.Tests
 {

--- a/test/coverlet.core.tests/Helpers/SourceRootTranslatorTests.cs
+++ b/test/coverlet.core.tests/Helpers/SourceRootTranslatorTests.cs
@@ -1,6 +1,6 @@
 ﻿using System.IO;
 
-using Coverlet.Core.Abstracts;
+using Coverlet.Core.Abstractions;
 using Coverlet.Tests.Xunit.Extensions;
 using Moq;
 using Xunit;

--- a/test/coverlet.core.tests/Instrumentation/InstrumenterTests.cs
+++ b/test/coverlet.core.tests/Instrumentation/InstrumenterTests.cs
@@ -6,7 +6,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 
 using Coverlet.Core.Helpers;
-using Coverlet.Core.Abstracts;
+using Coverlet.Core.Abstractions;
 using Coverlet.Core.Samples.Tests;
 using Coverlet.Tests.Xunit.Extensions;
 using Microsoft.CodeAnalysis;

--- a/test/coverlet.core.tests/Reporters/Reporters.cs
+++ b/test/coverlet.core.tests/Reporters/Reporters.cs
@@ -1,6 +1,6 @@
 ﻿using System.IO;
 
-using Coverlet.Core.Abstracts;
+using Coverlet.Core.Abstractions;
 using Coverlet.MSbuild.Tasks;
 using Moq;
 using Xunit;


### PR DESCRIPTION
Mostly just renamed `Coverlet.Core.Abstracts` to `Coverlet.Core.Abstractions`. Also, familiarizing myself with the code. I've been able to get some of my affairs in order and will be more active on this project. Thanks @MarcoRossignoli and @petli for holding down the fort.