### PR TITLE
Update GitHub Actions to use latest versions of stale and github-scri…

### DIFF
--- a/.github/workflows/issue-close.yml
+++ b/.github/workflows/issue-close.yml
@@ -17,7 +17,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10
         with:
           exempt-issue-labels: "bug,tracking-external-issue,Known Issue"
           days-before-issue-close: ${{ env.DAYS_BEFORE_ISSUE_CLOSE }}

--- a/.github/workflows/issue-inactive.yml
+++ b/.github/workflows/issue-inactive.yml
@@ -3,7 +3,7 @@ on:
   schedule:
     - cron: "0 1 * * 0"
   workflow_dispatch:
-  
+
 env:
   DAYS_BEFORE_ISSUE_STALE: 90
 
@@ -17,7 +17,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10
         with:
           exempt-issue-labels: "bug,tracking-external-issue,Known Issue,stale"
           days-before-issue-stale: ${{ env.DAYS_BEFORE_ISSUE_STALE }}

--- a/.github/workflows/issue-untriaged.yml
+++ b/.github/workflows/issue-untriaged.yml
@@ -17,7 +17,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v8
         with:
           script: |
             github.rest.issues.addLabels({


### PR DESCRIPTION
fix: 
>[close-issues](https://github.com/coverlet-coverage/coverlet/actions/runs/19398432856/job/55501901256#step:2:286)
Error delete _state: [403] Resource not accessible by integration