### PR TITLE
Update Azure Artifacts feed URL in codeql.yml

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,7 +21,7 @@ on:
     - cron: '23 17 * * 1'
 
 env:
-  AZURE_ARTIFACTS_FEED_URL: https://pkgs.dev.azure.com/bertk0374/_packaging/intern/nuget/v3/index.json
+  AZURE_ARTIFACTS_FEED_URL: https://pkgs.dev.azure.com/tonerdo/coverlet/_packaging/coverlet-nightly/nuget/v3/index.json
 
 permissions:
   contents: read


### PR DESCRIPTION
This pull request updates the Azure Artifacts feed URL in the CodeQL workflow configuration to point to a new package source.

* Workflow configuration update:
  * In `.github/workflows/codeql.yml`, the `AZURE_ARTIFACTS_FEED_URL` environment variable is changed to use the `coverlet-nightly` feed under the `tonerdo/coverlet` project