### PR TITLE
Add .NET Standard 2.0 support

### DIFF
--- a/src/coverlet.MTP/Collector/CollectorExtension.cs
+++ b/src/coverlet.MTP/Collector/CollectorExtension.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) Toni Solarin-Sodara
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETSTANDARD2_0
+using System.Diagnostics;
+#endif
 using System.Text;
 using Coverlet.Core;
 using Coverlet.Core.Abstractions;
@@ -64,7 +67,11 @@ internal sealed class CollectorExtension : ITestHostProcessLifetimeHandler, ITes
     _logger = new CoverletLoggerAdapter(_loggerFactory);
 
     _logger.LogVerbose("[DIAG] CoverletExtensionCollector constructor - running in controller process");
+#if NETSTANDARD2_0
+    _logger.LogVerbose($"[DIAG]   .NET Version: {Process.GetCurrentProcess().Id}");
+#else
     _logger.LogVerbose($"[DIAG]   Process ID: {Environment.ProcessId}");
+#endif
   }
 
   /// <summary>
@@ -74,7 +81,11 @@ internal sealed class CollectorExtension : ITestHostProcessLifetimeHandler, ITes
   Task ITestHostProcessLifetimeHandler.BeforeTestHostProcessStartAsync(CancellationToken cancellationToken)
   {
     _logger.LogVerbose("=== BeforeTestHostProcessStartAsync START ===");
+#if NETSTANDARD2_0
+    _logger.LogVerbose($"Controller PID: {Process.GetCurrentProcess().Id}");
+#else
     _logger.LogVerbose($"Controller PID: {Environment.ProcessId}");
+#endif
 
     try
     {
@@ -283,7 +294,7 @@ internal sealed class CollectorExtension : ITestHostProcessLifetimeHandler, ITes
       UseSourceLink = _configuration.UseSourceLink
     };
 
-    _logger.LogVerbose($"Coverlet configuration: {_configuration.ToString}");
+    _logger.LogVerbose($"Coverlet configuration: {_configuration}");
 
     // Use factory if available (for testing), otherwise create directly
     if (CoverageFactory is not null)

--- a/src/coverlet.MTP/Diagnostics/DebugHelper.cs
+++ b/src/coverlet.MTP/Diagnostics/DebugHelper.cs
@@ -27,7 +27,13 @@ internal static class DebugHelper
     // Check for wait-for-attach loop
     if (IsEnvironmentVariableEnabled(CoverletMtpDebugConstants.DebugWaitForAttach))
     {
+#pragma warning disable IDE0055
+#if NETSTANDARD2_0
+    int processId = Process.GetCurrentProcess().Id;
+#else
       int processId = Environment.ProcessId;
+#endif
+#pragma warning restore IDE0055
       Console.WriteLine($"[Coverlet.MTP] {componentName}: Waiting for debugger to attach...");
       Console.WriteLine($"[Coverlet.MTP] Process Id: {processId}, Name: {Process.GetCurrentProcess().ProcessName}");
 

--- a/src/coverlet.MTP/coverlet.MTP.csproj
+++ b/src/coverlet.MTP/coverlet.MTP.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(NetMinimum)</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;$(NetMinimum)</TargetFrameworks>
     <AssemblyTitle>Coverlet.MTP</AssemblyTitle>
     <DevelopmentDependency>true</DevelopmentDependency>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>


### PR DESCRIPTION
Enable multi-targeting for netstandard2.0 in Coverlet.MTP. Add conditional compilation for process ID retrieval and diagnostics to support both .NET Standard 2.0 and newer frameworks. Fix Coverlet configuration logging.