### PR TITLE
Update and consolidate NuGet dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,10 +7,8 @@
     <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.9.50" />
   </ItemGroup>
   <PropertyGroup>
-    <MicrosoftBuildVersion>17.11.48</MicrosoftBuildVersion>
-    <!-- .NET 8.0 support -->
-    <MicrosoftCodeAnalysisVersion>5.3.0</MicrosoftCodeAnalysisVersion>
-    <!-- .NET 8.0 support -->
+    <MicrosoftBuildVersion>17.11.48</MicrosoftBuildVersion> <!-- .NET 8.0 support -->
+    <MicrosoftCodeAnalysisVersion>5.3.0</MicrosoftCodeAnalysisVersion> <!-- .NET 8.0 support -->
     <NugetPackageVersion>7.3.0</NugetPackageVersion>
     <!-- Test Platform, .NET Test SDK and Object Model  -->
     <MicrosoftNETTestSdkVersion>18.0.1</MicrosoftNETTestSdkVersion>
@@ -21,21 +19,21 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="DotNetConfig" Version="1.2.0" />
-    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.3" /> <!-- latest stable version netstandard2.0, netstandard2.1, net462 -->
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.5" /> <!-- latest stable version netstandard2.0, netstandard2.1, net462 -->
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildVersion)" />
     <PackageVersion Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildVersion)" />
     <PackageVersion Include="Microsoft.Build.Locator" Version="1.11.2" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="5.0.0-1.25277.114" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" /> <!-- latest stable version net10.0, net9.0, net8.0 -->
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" /> <!-- latest stable version net10.0, net9.0, net8.0 -->
+    <PackageVersion Include="Microsoft.Extensions.DependencyModel" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" /> <!-- latest stable version net10.0, net9.0, net8.0 -->
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" /> <!-- latest stable version net10.0, net9.0, net8.0 -->
      <!-- For test TestInstrument_NetstandardAwareAssemblyResolver_PreserveCompilationContext -->
-    <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="10.0.5" />
     <!--For test TestInstrument_NetstandardAwareAssemblyResolver_PreserveCompilationContext-->
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.5" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" />
     <PackageVersion Include="Microsoft.Sbom.Targets" Version="4.1.5" />
     <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="$(MicrosoftNETTestSdkVersion)" />
@@ -54,7 +52,7 @@
     <PackageVersion Include="NuGet.Versioning" Version="$(NugetPackageVersion)" />
     <PackageVersion Include="Mono.Cecil" Version="0.11.6" />
     <PackageVersion Include="Moq" Version="$(MoqVersion)" />
-    <PackageVersion Include="ReportGenerator.Core" Version="5.5.1" />
+    <PackageVersion Include="ReportGenerator.Core" Version="5.5.4" />
     <!--For test issue 809 https://github.com/coverlet-coverage/coverlet/issues/809-->
     <PackageVersion Include="LinqKit.Microsoft.EntityFrameworkCore" Version="10.0.11" />
     <PackageVersion Include="System.CommandLine" Version="2.0.5" />
@@ -64,19 +62,19 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="$(XunitRunnerVisualstudioVersion)" />
     <PackageVersion Include="System.Buffers" Version="4.6.1" />
     <PackageVersion Include="System.Collections.Immutable" Version="10.0.5" />
-    <PackageVersion Include="System.Configuration.ConfigurationManager" Version="10.0.3" />
-    <PackageVersion Include="System.Diagnostics.EventLog" Version="10.0.3" />
-    <PackageVersion Include="System.Formats.Asn1" Version="10.0.3" />
-    <PackageVersion Include="System.IO.Pipelines" Version="10.0.3" />
+    <PackageVersion Include="System.Configuration.ConfigurationManager" Version="10.0.5" />
+    <PackageVersion Include="System.Diagnostics.EventLog" Version="10.0.5" />
+    <PackageVersion Include="System.Formats.Asn1" Version="10.0.5" />
+    <PackageVersion Include="System.IO.Pipelines" Version="10.0.5" />
     <PackageVersion Include="System.Linq.Async" Version="7.0.0" />
     <PackageVersion Include="System.Memory" Version="4.6.3" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Reflection.Metadata" Version="10.0.5" />
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
     <PackageVersion Include="System.Security.AccessControl" Version="6.0.1" />
-    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="10.0.3" />
-    <PackageVersion Include="System.Text.Encoding.CodePages" Version="10.0.3" />
-    <PackageVersion Include="System.Text.Json" Version="10.0.3" />
+    <PackageVersion Include="System.Security.Cryptography.Pkcs" Version="10.0.5" />
+    <PackageVersion Include="System.Text.Encoding.CodePages" Version="10.0.5" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.5" />
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
   </ItemGroup>

--- a/src/coverlet.core/coverlet.core.csproj
+++ b/src/coverlet.core/coverlet.core.csproj
@@ -42,7 +42,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="NuGet.Versioning" VersionOverride="6.14.0"/>
+    <PackageReference Include="NuGet.Versioning" VersionOverride="6.14.0"/> <!-- lastest version which supports netstandard2.0 -->
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
     <PackageReference Include="System.Collections.Immutable" />
     <PackageReference Include="System.Memory" />

--- a/src/coverlet.core/coverlet.core.csproj
+++ b/src/coverlet.core/coverlet.core.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
@@ -42,7 +42,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="NuGet.Versioning" VersionOverride="6.14.0"/> <!-- lastest version which supports netstandard2.0 -->
+    <PackageReference Include="NuGet.Versioning" VersionOverride="6.14.0"/> <!-- latest version that supports netstandard2.0 -->
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
     <PackageReference Include="System.Collections.Immutable" />
     <PackageReference Include="System.Memory" />

--- a/src/legacy/coverlet.collector/coverlet.collector.csproj
+++ b/src/legacy/coverlet.collector/coverlet.collector.csproj
@@ -65,7 +65,6 @@
   <!-- NuGet package layout -->
   <!-- NuGet folders https://learn.microsoft.com/nuget/create-packages/creating-a-package#from-a-convention-based-working-directory -->
   <ItemGroup>
-    <PackageReference Include="System.Reflection.Metadata" />
     <TfmSpecificPackageFile Include="build/**">
       <PackagePath>build/$(TargetFramework)</PackagePath>
     </TfmSpecificPackageFile>

--- a/test/coverlet.core.tests/coverlet.core.tests.csproj
+++ b/test/coverlet.core.tests/coverlet.core.tests.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" VersionOverride="10.0.3"/>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" VersionOverride="10.0.5"/>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Moq" />
     <PackageReference Include="ReportGenerator.Core" />

--- a/test/coverlet.integration.MTP.tests/coverlet.integration.MTP.tests.csproj
+++ b/test/coverlet.integration.MTP.tests/coverlet.integration.MTP.tests.csproj
@@ -11,15 +11,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
     <!-- Microsoft.TestPlatform.TestHost (v18.0.1) depends on Newtonsoft.Json -->
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.5" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="NuGet.Packaging" Version="$(NugetPackageVersion)" />
     <PackageReference Include="NuGet.Versioning" Version="$(NugetPackageVersion)" />
     <PackageReference Include="xunit.v3.mtp-v2" Version="$(XunitV3Version)" />
-    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="10.0.3"/>
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="10.0.5"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/coverlet.integration.template/coverlet.integration.template.csproj
+++ b/test/coverlet.integration.template/coverlet.integration.template.csproj
@@ -21,7 +21,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Text.Json" Version="10.0.3"/>
+    <PackageReference Include="System.Text.Json" Version="10.0.5"/>
     <PackageReference Include="Microsoft.Testing.Platform.MSBuild" Version="2.1.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Bump various Microsoft.* and System.* packages from 10.0.3 to 10.0.5 across projects, and update ReportGenerator.Core to 5.5.4. Also clarify and reformat some comments. No functional changes; ensures use of latest compatible libraries.