### PR TITLE
Change default --coverlet-skip-auto-props to false

### DIFF
--- a/Documentation/Coverlet.MTP.Integration.md
+++ b/Documentation/Coverlet.MTP.Integration.md
@@ -86,7 +86,7 @@ dotnet exec <test-assembly.dll> --help
 | `--coverlet-exclude-by-attribute <attribute>` | Exclude methods/classes decorated with attributes. Can be specified multiple times. User-specified attributes are merged with defaults. (default: `ExcludeFromCodeCoverage`, `ExcludeFromCodeCoverageAttribute`, `GeneratedCodeAttribute`, `CompilerGeneratedAttribute`) |
 | `--coverlet-include-test-assembly` | Include test assembly in coverage. (default: `false`) |
 | `--coverlet-single-hit` | Limit the number of hits to one for each location. (default: `false`) |
-| `--coverlet-skip-auto-props` | Skip auto-implemented properties. (default: `true`) |
+| `--coverlet-skip-auto-props` | Skip auto-implemented properties. (default: `false`) |
 | `--coverlet-does-not-return-attribute <attribute>` | Attributes that mark methods as not returning. Can be specified multiple times. (default: `none`) |
 | `--coverlet-exclude-assemblies-without-sources <value>` | Exclude assemblies without source code. Values: `MissingAll`, `MissingAny`, `None`. (default: `None`) |
 

--- a/src/coverlet.MTP/Configuration/CoverageConfiguration.cs
+++ b/src/coverlet.MTP/Configuration/CoverageConfiguration.cs
@@ -146,7 +146,7 @@ internal sealed class CoverageConfiguration
     GetBoolOptionWithDefault(CoverletOptionNames.IncludeTestAssembly, defaultValue: false);
 
   public bool SkipAutoProps =>
-    GetBoolOptionWithDefault(CoverletOptionNames.SkipAutoProps, defaultValue: true);
+    GetBoolOptionWithDefault(CoverletOptionNames.SkipAutoProps, defaultValue: false);
 
   public string[] GetDoesNotReturnAttributes()
   {

--- a/test/coverlet.MTP.tests/Configuration/CoverageConfigurationTests.cs
+++ b/test/coverlet.MTP.tests/Configuration/CoverageConfigurationTests.cs
@@ -547,13 +547,13 @@ public sealed class CoverageConfigurationTests
   }
 
   [Fact]
-  public void SkipAutoPropsWhenOptionNotSetReturnsDefaultTrue()
+  public void SkipAutoPropsWhenOptionNotSetReturnsDefaultFalse()
   {
     _mockCommandLineOptions.Setup(x => x.IsOptionSet(CoverletOptionNames.SkipAutoProps)).Returns(false);
 
     var config = new CoverageConfiguration(_mockCommandLineOptions.Object, _mockLogger.Object);
 
-    Assert.True(config.SkipAutoProps);
+    Assert.False(config.SkipAutoProps);
   }
 
   [Fact]


### PR DESCRIPTION
The default for --coverlet-skip-auto-props is now false, so auto-implemented properties are included in coverage unless explicitly skipped. Updated documentation and unit tests to reflect this new default.
#1878 