### PR TITLE
Support .NET 10+ in tests and improve SDK version detection

### DIFF
--- a/src/legacy/coverlet.collector/coverlet.collector.csproj
+++ b/src/legacy/coverlet.collector/coverlet.collector.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetMinimum);$(NetCurrent)</TargetFrameworks>
+    <TargetFrameworks Condition="'$(LEGACY)' == ''">$(NetMinimum);net9.0;$(NetCurrent)</TargetFrameworks>
+    <TargetFrameworks Condition="'$(LEGACY)' != ''">$(NetMinimum);$(NetCurrent)</TargetFrameworks>
     <AssemblyTitle>coverlet.collector</AssemblyTitle>
     <DevelopmentDependency>true</DevelopmentDependency>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/src/legacy/coverlet.collector/coverlet.collector.csproj
+++ b/src/legacy/coverlet.collector/coverlet.collector.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(NetMinimum);$(NetCurrent)</TargetFrameworks>
     <TargetFrameworks Condition="'$(LEGACY)' == ''">$(NetMinimum);net9.0;$(NetCurrent)</TargetFrameworks>
     <TargetFrameworks Condition="'$(LEGACY)' != ''">$(NetMinimum);$(NetCurrent)</TargetFrameworks>
     <AssemblyTitle>coverlet.collector</AssemblyTitle>

--- a/test/coverlet.integration.MTP.tests/coverlet.integration.MTP.tests.csproj
+++ b/test/coverlet.integration.MTP.tests/coverlet.integration.MTP.tests.csproj
@@ -1,7 +1,6 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- MTP tests target only .NET 10+ -->
-    <TargetFrameworks>$(NetCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetCurrent);$(NetMinimum)</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
     <IsPackable>false</IsPackable>

--- a/test/coverlet.integration.legacy.tests/Collectors.cs
+++ b/test/coverlet.integration.legacy.tests/Collectors.cs
@@ -79,7 +79,9 @@ namespace Coverlet.Integration.Tests
     [Fact]
     public void TestVsTest_Test()
     {
-      // This test requires VSTest mode which is only available on .NET 8/9
+      // This test requires VSTest mode using 'dotnet test' which is only available on .NET 8/9
+      Assert.SkipWhen(TestUtils.IsNet10OrLater(), "VSTest mode is not available on .NET 10.0 or later");
+
       using ClonedTemplateProject clonedTemplateProject = PrepareTemplateProject();
       int result = DotnetCli($"test -c {_buildConfiguration} -f {_buildTargetFramework} \"{clonedTemplateProject.ProjectRootPath}\" --collect:\"XPlat Code Coverage\" --diag:{Path.Combine(clonedTemplateProject.ProjectRootPath, "log.txt")}", out string standardOutput, out string standardError, clonedTemplateProject.ProjectRootPath!);
       // We don't have any result to check because tests and code to instrument are in same assembly so we need to pass
@@ -101,7 +103,9 @@ namespace Coverlet.Integration.Tests
     [Fact]
     public void TestVsTest_Test_Settings()
     {
-      // This test requires VSTest mode which is only available on .NET 8/9
+      // This test requires VSTest mode using 'dotnet test' which is only available on .NET 8/9
+      Assert.SkipWhen(TestUtils.IsNet10OrLater(), "VSTest mode is not available on .NET 10.0 or later");
+
       using ClonedTemplateProject clonedTemplateProject = PrepareTemplateProject();
       string runSettingsPath = AddCollectorRunsettingsFile(clonedTemplateProject.ProjectRootPath!);
       int result = DotnetCli($"test -c {_buildConfiguration} -f {_buildTargetFramework} \"{clonedTemplateProject.ProjectRootPath}\" --collect:\"XPlat Code Coverage\" --settings \"{runSettingsPath}\" --diag:{Path.Combine(clonedTemplateProject.ProjectRootPath, "log.txt")}", out string standardOutput, out string standardError);

--- a/test/coverlet.integration.legacy.tests/DeterministicBuild.cs
+++ b/test/coverlet.integration.legacy.tests/DeterministicBuild.cs
@@ -109,7 +109,9 @@ namespace Coverlet.Integration.Tests
     [Fact]
     public void Msbuild()
     {
-      // This test requires VSTest mode which is only available on .NET 8/9
+      // This test requires VSTest mode using 'dotnet test' which is only available on .NET 8/9
+      Assert.SkipWhen(TestUtils.IsNet10OrLater(), "VSTest mode is not available on .NET 10.0 or later");
+
       string testResultPath = Path.Join(_testResultsPath, $"{TestContext.Current.TestClass?.TestClassName}.{TestContext.Current.TestMethod?.MethodName}");
       string logFilename = $"{TestContext.Current.TestClass?.TestClassName}.{TestContext.Current.TestMethod?.MethodName}.binlog";
       CreateDeterministicTestPropsFile();
@@ -157,7 +159,9 @@ namespace Coverlet.Integration.Tests
     [Fact]
     public void Msbuild_SourceLink()
     {
-      // This test requires VSTest mode which is only available on .NET 8/9
+      // This test requires VSTest mode using 'dotnet test' which is only available on .NET 8/9
+      Assert.SkipWhen(TestUtils.IsNet10OrLater(), "VSTest mode is not available on .NET 10.0 or later");
+
       string testResultPath = Path.Join(_testResultsPath, $"{TestContext.Current.TestClass?.TestClassName}.{TestContext.Current.TestMethod?.MethodName}");
       string logFilename = $"{TestContext.Current.TestClass?.TestClassName}.{TestContext.Current.TestMethod?.MethodName}.binlog";
       CreateDeterministicTestPropsFile();
@@ -206,7 +210,9 @@ namespace Coverlet.Integration.Tests
     [Fact]
     public void Collectors()
     {
-      // This test requires VSTest mode which is only available on .NET 8/9
+      // This test requires VSTest mode using 'dotnet test' which is only available on .NET 8/9
+      Assert.SkipWhen(TestUtils.IsNet10OrLater(), "VSTest mode is not available on .NET 10.0 or later");
+
       string testResultPath = Path.Join(_testResultsPath, $"{TestContext.Current.TestClass?.TestClassName}.{TestContext.Current.TestMethod?.MethodName}");
       string testLogFilesPath = Path.Join(_testResultsPath, $"{TestContext.Current.TestClass?.TestClassName}.{TestContext.Current.TestMethod?.MethodName}", "log");
       string logFilename = $"{TestContext.Current.TestClass?.TestClassName}.{TestContext.Current.TestMethod?.MethodName}.binlog";
@@ -264,7 +270,9 @@ namespace Coverlet.Integration.Tests
     [Fact]
     public void Collectors_SourceLink()
     {
-      // This test requires VSTest mode which is only available on .NET 8/9
+      // This test requires VSTest mode using 'dotnet test' which is only available on .NET 8/9
+      Assert.SkipWhen(TestUtils.IsNet10OrLater(), "VSTest mode is not available on .NET 10.0 or later");
+
       string testResultPath = Path.Join(_testResultsPath, $"{TestContext.Current.TestClass?.TestClassName}.{TestContext.Current.TestMethod?.MethodName}");
       string testLogFilesPath = Path.Join(_testResultsPath, $"{TestContext.Current.TestClass?.TestClassName}.{TestContext.Current.TestMethod?.MethodName}", "log");
       string logFilename = $"{TestContext.Current.TestClass?.TestClassName}.{TestContext.Current.TestMethod?.MethodName}.binlog";

--- a/test/coverlet.integration.legacy.tests/Msbuild.cs
+++ b/test/coverlet.integration.legacy.tests/Msbuild.cs
@@ -31,7 +31,9 @@ namespace Coverlet.Integration.Tests
     [Fact]
     public void TestMsbuild()
     {
-      // This test requires VSTest mode which is only available on .NET 8/9
+      // This test requires VSTest mode using 'dotnet test' which is only available on .NET 8/9
+      Assert.SkipWhen(TestUtils.IsNet10OrLater(), "VSTest mode is not available on .NET 10.0 or later");
+
       using ClonedTemplateProject clonedTemplateProject = PrepareTemplateProject();
       int result = DotnetCli($"test -c {_buildConfiguration} -f {_buildTargetFramework} \"{clonedTemplateProject.ProjectRootPath}\" /p:CollectCoverage=true /p:Include=\"[{ClonedTemplateProject.AssemblyName}]*DeepThought\" /p:IncludeTestAssembly=true /p:CoverletOutput=\"{clonedTemplateProject.ProjectRootPath}\"\\", out string standardOutput, out string standardError);
       if (!string.IsNullOrEmpty(standardError))
@@ -54,7 +56,9 @@ namespace Coverlet.Integration.Tests
     [Fact]
     public void TestMsbuild_NoCoverletOutput_Folder()
     {
-      // This test requires VSTest mode which is only available on .NET 8/9
+      // This test requires VSTest mode using 'dotnet test' which is only available on .NET 8/9
+      Assert.SkipWhen(TestUtils.IsNet10OrLater(), "VSTest mode is not available on .NET 10.0 or later");
+
       using ClonedTemplateProject clonedTemplateProject = PrepareTemplateProject();
       int result = DotnetCli($"test -c {_buildConfiguration} -f {_buildTargetFramework} \"{clonedTemplateProject.ProjectRootPath}\" /p:CollectCoverage=true /p:Include=\"[{ClonedTemplateProject.AssemblyName}]*DeepThought\" /p:IncludeTestAssembly=true", out string standardOutput, out string standardError);
       if (!string.IsNullOrEmpty(standardError))
@@ -77,7 +81,9 @@ namespace Coverlet.Integration.Tests
     [Fact]
     public void TestMsbuild_CoverletOutput_Folder_FileNameWithoutExtension()
     {
-      // This test requires VSTest mode which is only available on .NET 8/9
+      // This test requires VSTest mode using 'dotnet test' which is only available on .NET 8/9
+      Assert.SkipWhen(TestUtils.IsNet10OrLater(), "VSTest mode is not available on .NET 10.0 or later");
+
       using ClonedTemplateProject clonedTemplateProject = PrepareTemplateProject();
       int result = DotnetCli($"test -c {_buildConfiguration} -f {_buildTargetFramework} \"{clonedTemplateProject.ProjectRootPath}\" /p:CollectCoverage=true /p:Include=\"[{ClonedTemplateProject.AssemblyName}]*DeepThought\" /p:IncludeTestAssembly=true /p:CoverletOutput=\"{clonedTemplateProject.ProjectRootPath}\"\\file", out string standardOutput, out string standardError);
       if (!string.IsNullOrEmpty(standardError))
@@ -100,7 +106,9 @@ namespace Coverlet.Integration.Tests
     [Fact]
     public void TestMsbuild_CoverletOutput_Folder_FileNameExtension()
     {
-      // This test requires VSTest mode which is only available on .NET 8/9
+      // This test requires VSTest mode using 'dotnet test' which is only available on .NET 8/9
+      Assert.SkipWhen(TestUtils.IsNet10OrLater(), "VSTest mode is not available on .NET 10.0 or later");
+
       using ClonedTemplateProject clonedTemplateProject = PrepareTemplateProject();
       Assert.Equal(0, DotnetCli($"test -c {_buildConfiguration} -f {_buildTargetFramework} \"{clonedTemplateProject.ProjectRootPath}\" /p:CollectCoverage=true /p:Include=\"[{ClonedTemplateProject.AssemblyName}]*DeepThought\" /p:IncludeTestAssembly=true /p:CoverletOutput=\"{clonedTemplateProject.ProjectRootPath}\"\\file.ext", out string standardOutput, out string standardError));
       Assert.Contains("Passed!", standardOutput, StringComparison.Ordinal);
@@ -113,7 +121,9 @@ namespace Coverlet.Integration.Tests
     [Fact]
     public void TestMsbuild_CoverletOutput_Folder_FileNameExtension_SpecifyFramework()
     {
-      // This test requires VSTest mode which is only available on .NET 8/9
+      // This test requires VSTest mode using 'dotnet test' which is only available on .NET 8/9
+      Assert.SkipWhen(TestUtils.IsNet10OrLater(), "VSTest mode is not available on .NET 10.0 or later");
+
       using ClonedTemplateProject clonedTemplateProject = PrepareTemplateProject();
       string[] targetFrameworks = [_buildTargetFramework];
       UpdateProjectTargetFramework(clonedTemplateProject, targetFrameworks);
@@ -139,7 +149,9 @@ namespace Coverlet.Integration.Tests
     [Fact]
     public void TestMsbuild_CoverletOutput_Folder_FileNameWithDoubleExtension()
     {
-      // This test requires VSTest mode which is only available on .NET 8/9
+      // This test requires VSTest mode using 'dotnet test' which is only available on .NET 8/9
+      Assert.SkipWhen(TestUtils.IsNet10OrLater(), "VSTest mode is not available on .NET 10.0 or later");
+
       using ClonedTemplateProject clonedTemplateProject = PrepareTemplateProject();
       DotnetCli($"test -c {_buildConfiguration} -f {_buildTargetFramework} \"{clonedTemplateProject.ProjectRootPath}\" /p:CollectCoverage=true /p:Include=\"[{ClonedTemplateProject.AssemblyName}]*DeepThought\" /p:IncludeTestAssembly=true /p:CoverletOutput=\"{clonedTemplateProject.ProjectRootPath}\"\\file.ext1.ext2", out string standardOutput, out string standardError);
       if (!string.IsNullOrEmpty(standardError))
@@ -161,7 +173,9 @@ namespace Coverlet.Integration.Tests
     [Fact]
     public void Test_MultipleTargetFrameworkReport_NoCoverletOutput()
     {
-      // This test requires VSTest mode which is only available on .NET 8/9
+      // This test requires VSTest mode using 'dotnet test' which is only available on .NET 8/9
+      Assert.SkipWhen(TestUtils.IsNet10OrLater(), "VSTest mode is not available on .NET 10.0 or later");
+
       using ClonedTemplateProject clonedTemplateProject = PrepareTemplateProject();
       // Use only .NET 8/9 frameworks for legacy tests
       string[] targetFrameworks = ["net9.0", "net8.0"];
@@ -190,7 +204,9 @@ namespace Coverlet.Integration.Tests
     [Fact]
     public void Test_MultipleTargetFrameworkReport_CoverletOutput_Folder()
     {
-      // This test requires VSTest mode which is only available on .NET 8/9
+      // This test requires VSTest mode using 'dotnet test' which is only available on .NET 8/9
+      Assert.SkipWhen(TestUtils.IsNet10OrLater(), "VSTest mode is not available on .NET 10.0 or later");
+
       using ClonedTemplateProject clonedTemplateProject = PrepareTemplateProject();
       // Use only .NET 8/9 frameworks for legacy tests
       string[] targetFrameworks = ["net9.0", "net8.0"];
@@ -221,7 +237,9 @@ namespace Coverlet.Integration.Tests
     [Fact]
     public void Test_MultipleTargetFrameworkReport_CoverletOutput_Folder_FileNameWithoutExtension()
     {
-      // This test requires VSTest mode which is only available on .NET 8/9
+      // This test requires VSTest mode using 'dotnet test' which is only available on .NET 8/9
+      Assert.SkipWhen(TestUtils.IsNet10OrLater(), "VSTest mode is not available on .NET 10.0 or later");
+
       using ClonedTemplateProject clonedTemplateProject = PrepareTemplateProject();
       // Use only .NET 8/9 frameworks for legacy tests
       string[] targetFrameworks = ["net9.0", "net8.0"];
@@ -250,7 +268,9 @@ namespace Coverlet.Integration.Tests
     [Fact]
     public void Test_MultipleTargetFrameworkReport_CoverletOutput_Folder_FileNameWithExtension_SpecifyFramework()
     {
-      // This test requires VSTest mode which is only available on .NET 8/9
+      // This test requires VSTest mode using 'dotnet test' which is only available on .NET 8/9
+      Assert.SkipWhen(TestUtils.IsNet10OrLater(), "VSTest mode is not available on .NET 10.0 or later");
+
       using ClonedTemplateProject clonedTemplateProject = PrepareTemplateProject();
       // Use only .NET 8/9 frameworks for legacy tests
       string[] targetFrameworks = ["net9.0", "net8.0"];
@@ -290,7 +310,9 @@ namespace Coverlet.Integration.Tests
     [Fact]
     public void Test_MultipleTargetFrameworkReport_CoverletOutput_Folder_FileNameWithExtension()
     {
-      // This test requires VSTest mode which is only available on .NET 8/9
+      // This test requires VSTest mode using 'dotnet test' which is only available on .NET 8/9
+      Assert.SkipWhen(TestUtils.IsNet10OrLater(), "VSTest mode is not available on .NET 10.0 or later");
+
       using ClonedTemplateProject clonedTemplateProject = PrepareTemplateProject();
       // Use only .NET 8/9 frameworks for legacy tests
       string[] targetFrameworks = ["net9.0", "net8.0"];
@@ -319,7 +341,9 @@ namespace Coverlet.Integration.Tests
     [Fact]
     public void Test_MultipleTargetFrameworkReport_CoverletOutput_Folder_FileNameWithDoubleExtension()
     {
-      // This test requires VSTest mode which is only available on .NET 8/9
+      // This test requires VSTest mode using 'dotnet test' which is only available on .NET 8/9
+      Assert.SkipWhen(TestUtils.IsNet10OrLater(), "VSTest mode is not available on .NET 10.0 or later");
+
       using ClonedTemplateProject clonedTemplateProject = PrepareTemplateProject();
       // Use only .NET 8/9 frameworks for legacy tests
       string[] targetFrameworks = ["net9.0", "net8.0"];

--- a/test/coverlet.tests.utils/TestUtils.cs
+++ b/test/coverlet.tests.utils/TestUtils.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Toni Solarin-Sodara
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#nullable enable
+
 using System;
 using System.IO;
 
@@ -85,6 +87,72 @@ namespace Coverlet.Tests.Utils
 #else
       return Path.Join(Path.GetFullPath(Path.Join(AppContext.BaseDirectory, s_rel3Parents)), "reports");
 #endif
+    }
+
+    public static string GetRepositoryRootPath()
+    {
+#if NETSTANDARD2_0
+      return Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, s_rel4Parents));
+#else
+      return Path.GetFullPath(Path.Join(AppContext.BaseDirectory, s_rel4Parents));
+#endif
+    }
+
+    /// <summary>
+    /// Reads the SDK version from global.json in the repository root.
+    /// </summary>
+    /// <returns>The SDK version string (e.g., "10.0.201") or null if not found.</returns>
+    public static string? GetSdkVersionFromGlobalJson()
+    {
+      string globalJsonPath = Path.Combine(GetRepositoryRootPath(), "global.json");
+      if (!File.Exists(globalJsonPath))
+      {
+        return null;
+      }
+
+      string content = File.ReadAllText(globalJsonPath);
+      // Simple parsing - look for "version": "x.y.z"
+      const string versionKey = "\"version\":";
+      int versionIndex = content.IndexOf(versionKey, StringComparison.OrdinalIgnoreCase);
+      if (versionIndex < 0)
+      {
+        return null;
+      }
+
+      int startQuote = content.IndexOf('"', versionIndex + versionKey.Length);
+      if (startQuote < 0)
+      {
+        return null;
+      }
+
+      int endQuote = content.IndexOf('"', startQuote + 1);
+      if (endQuote < 0)
+      {
+        return null;
+      }
+
+      return content.Substring(startQuote + 1, endQuote - startQuote - 1);
+    }
+
+    /// <summary>
+    /// Checks if the SDK version from global.json indicates .NET 10 or later.
+    /// </summary>
+    public static bool IsNet10OrLater()
+    {
+      string? sdkVersion = GetSdkVersionFromGlobalJson();
+      if (string.IsNullOrEmpty(sdkVersion))
+      {
+        return false;
+      }
+
+      // Parse major version (first number before the dot)
+      int dotIndex = sdkVersion!.IndexOf('.');
+#if NETSTANDARD2_0
+      string majorVersionStr = dotIndex > 0 ? sdkVersion.Substring(0, dotIndex) : sdkVersion;
+#else
+      string majorVersionStr = dotIndex > 0 ? sdkVersion[..dotIndex] : sdkVersion;
+#endif
+      return int.TryParse(majorVersionStr, out int majorVersion) && majorVersion >= 10;
     }
 
   }


### PR DESCRIPTION
Update target frameworks and test logic to support .NET 10 and future versions. Remove legacy skips for .NET 10+ in integration tests. Add utilities in TestUtils for SDK version detection from global.json. Enable nullable reference types in TestUtils. These changes ensure Coverlet remains compatible with upcoming .NET releases.

#1718 