### PR TITLE
Use sibling runtimeconfigs for shared framework resolution

### DIFF
--- a/src/coverlet.core/Instrumentation/CecilAssemblyResolver.cs
+++ b/src/coverlet.core/Instrumentation/CecilAssemblyResolver.cs
@@ -228,9 +228,20 @@ namespace Coverlet.Core.Instrumentation
       _logger = logger;
       string moduleDirectory = Path.GetDirectoryName(modulePath)!;
       string moduleRuntimeConfigFile = Path.Combine(moduleDirectory, $"{Path.GetFileNameWithoutExtension(modulePath)}.runtimeconfig.json");
-      List<string> runtimeConfigFiles = Directory.Exists(moduleDirectory)
-          ? Directory.GetFiles(moduleDirectory, "*.runtimeconfig.json").ToList()
-          : new List<string>();
+      List<string> runtimeConfigFiles = new List<string>();
+      if (Directory.Exists(moduleDirectory))
+      {
+        try
+        {
+          runtimeConfigFiles = Directory.GetFiles(moduleDirectory, "*.runtimeconfig.json")
+              .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+              .ToList();
+        }
+        catch (Exception ex)
+        {
+          _logger.LogVerbose($"NetCoreSharedFrameworkResolver exception while enumerating runtimeconfig files from '{moduleDirectory}': {ex}");
+        }
+      }
       if (File.Exists(moduleRuntimeConfigFile))
       {
         for (int i = runtimeConfigFiles.Count - 1; i >= 0; i--)

--- a/src/coverlet.core/Instrumentation/CecilAssemblyResolver.cs
+++ b/src/coverlet.core/Instrumentation/CecilAssemblyResolver.cs
@@ -226,27 +226,48 @@ namespace Coverlet.Core.Instrumentation
     public NetCoreSharedFrameworkResolver(string modulePath, ILogger logger)
     {
       _logger = logger;
-
-      string runtimeConfigFile = Path.Combine(
-          Path.GetDirectoryName(modulePath)!,
-          Path.GetFileNameWithoutExtension(modulePath) + ".runtimeconfig.json");
-      if (!File.Exists(runtimeConfigFile))
+      string moduleDirectory = Path.GetDirectoryName(modulePath)!;
+      string moduleRuntimeConfigFile = Path.Combine(moduleDirectory, $"{Path.GetFileNameWithoutExtension(modulePath)}.runtimeconfig.json");
+      List<string> runtimeConfigFiles = Directory.GetFiles(moduleDirectory, "*.runtimeconfig.json").ToList();
+      if (File.Exists(moduleRuntimeConfigFile))
       {
-        return;
+        for (int i = runtimeConfigFiles.Count - 1; i >= 0; i--)
+        {
+          if (runtimeConfigFiles[i].Equals(moduleRuntimeConfigFile, StringComparison.OrdinalIgnoreCase))
+          {
+            runtimeConfigFiles.RemoveAt(i);
+          }
+        }
+        runtimeConfigFiles.Insert(0, moduleRuntimeConfigFile);
       }
 
-      var reader = new RuntimeConfigurationReader(runtimeConfigFile);
-      IEnumerable<(string Name, string Version)> referencedFrameworks = reader.GetFrameworks();
-      string runtimePath = Path.GetDirectoryName(typeof(object).Assembly.Location);
-      string runtimeRootPath = Path.GetFullPath(Path.Combine(runtimePath!, "..", ".."));
-      foreach ((string frameworkName, string frameworkVersion) in referencedFrameworks)
+      string runtimePath = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
+      string runtimeRootPath = Path.GetFullPath(Path.Combine(runtimePath, "..", ".."));
+
+      foreach (string runtimeConfigFile in runtimeConfigFiles)
       {
-        var semVersion = NuGetVersion.Parse(frameworkVersion);
-        var directory = new DirectoryInfo(Path.Combine(runtimeRootPath, frameworkName));
-        string majorVersion = $"{semVersion.Major}.{semVersion.Minor}.";
-        uint latestVersion = directory.GetDirectories().Where(x => x.Name.StartsWith(majorVersion))
-            .Select(x => Convert.ToUInt32(x.Name.Substring(majorVersion.Length))).Max();
-        _aspNetSharedFrameworkDirs.Add(Directory.GetDirectories(directory.FullName, majorVersion + $"{latestVersion}*", SearchOption.TopDirectoryOnly)[0]);
+        try
+        {
+          var reader = new RuntimeConfigurationReader(runtimeConfigFile);
+          IEnumerable<(string Name, string Version)> referencedFrameworks = reader.GetFrameworks();
+          foreach ((string frameworkName, string frameworkVersion) in referencedFrameworks)
+          {
+            var semVersion = NuGetVersion.Parse(frameworkVersion);
+            var directory = new DirectoryInfo(Path.Combine(runtimeRootPath, frameworkName));
+            string majorVersion = $"{semVersion.Major}.{semVersion.Minor}.";
+            uint latestVersion = directory.GetDirectories().Where(x => x.Name.StartsWith(majorVersion))
+                .Select(x => Convert.ToUInt32(x.Name.Substring(majorVersion.Length))).Max();
+            string resolvedPath = Directory.GetDirectories(directory.FullName, majorVersion + $"{latestVersion}*", SearchOption.TopDirectoryOnly)[0];
+            if (!_aspNetSharedFrameworkDirs.Any(path => path.Equals(resolvedPath, StringComparison.OrdinalIgnoreCase)))
+            {
+              _aspNetSharedFrameworkDirs.Add(resolvedPath);
+            }
+          }
+        }
+        catch (Exception ex)
+        {
+          _logger.LogVerbose($"NetCoreSharedFrameworkResolver exception: {ex}");
+        }
       }
 
       _logger.LogVerbose("NetCoreSharedFrameworkResolver search paths:");
@@ -259,7 +280,6 @@ namespace Coverlet.Core.Instrumentation
     public bool TryResolveAssemblyPaths(CompilationLibrary library, List<string> assemblies)
     {
       string dllName = $"{library.Name}.dll";
-
       foreach (string sharedFrameworkPath in _aspNetSharedFrameworkDirs)
       {
         if (!Directory.Exists(sharedFrameworkPath))
@@ -267,16 +287,15 @@ namespace Coverlet.Core.Instrumentation
           continue;
         }
 
-        string[] files = Directory.GetFiles(sharedFrameworkPath);
-        foreach (string file in files)
+        string candidatePath = Path.Combine(sharedFrameworkPath, dllName);
+        if (!File.Exists(candidatePath))
         {
-          if (Path.GetFileName(file).Equals(dllName, StringComparison.OrdinalIgnoreCase))
-          {
-            _logger.LogVerbose($"'{dllName}' found in '{file}'");
-            assemblies.Add(file);
-            return true;
-          }
+          continue;
         }
+
+        _logger.LogVerbose($"'{dllName}' found in '{candidatePath}'");
+        assemblies.Add(candidatePath);
+        return true;
       }
 
       return false;

--- a/src/coverlet.core/Instrumentation/CecilAssemblyResolver.cs
+++ b/src/coverlet.core/Instrumentation/CecilAssemblyResolver.cs
@@ -228,7 +228,9 @@ namespace Coverlet.Core.Instrumentation
       _logger = logger;
       string moduleDirectory = Path.GetDirectoryName(modulePath)!;
       string moduleRuntimeConfigFile = Path.Combine(moduleDirectory, $"{Path.GetFileNameWithoutExtension(modulePath)}.runtimeconfig.json");
-      List<string> runtimeConfigFiles = Directory.GetFiles(moduleDirectory, "*.runtimeconfig.json").ToList();
+      List<string> runtimeConfigFiles = Directory.Exists(moduleDirectory)
+          ? Directory.GetFiles(moduleDirectory, "*.runtimeconfig.json").ToList()
+          : new List<string>();
       if (File.Exists(moduleRuntimeConfigFile))
       {
         for (int i = runtimeConfigFiles.Count - 1; i >= 0; i--)
@@ -252,21 +254,28 @@ namespace Coverlet.Core.Instrumentation
           IEnumerable<(string Name, string Version)> referencedFrameworks = reader.GetFrameworks();
           foreach ((string frameworkName, string frameworkVersion) in referencedFrameworks)
           {
-            var semVersion = NuGetVersion.Parse(frameworkVersion);
-            var directory = new DirectoryInfo(Path.Combine(runtimeRootPath, frameworkName));
-            string majorVersion = $"{semVersion.Major}.{semVersion.Minor}.";
-            uint latestVersion = directory.GetDirectories().Where(x => x.Name.StartsWith(majorVersion))
-                .Select(x => Convert.ToUInt32(x.Name.Substring(majorVersion.Length))).Max();
-            string resolvedPath = Directory.GetDirectories(directory.FullName, majorVersion + $"{latestVersion}*", SearchOption.TopDirectoryOnly)[0];
-            if (!_aspNetSharedFrameworkDirs.Any(path => path.Equals(resolvedPath, StringComparison.OrdinalIgnoreCase)))
+            try
             {
-              _aspNetSharedFrameworkDirs.Add(resolvedPath);
+              var semVersion = NuGetVersion.Parse(frameworkVersion);
+              var directory = new DirectoryInfo(Path.Combine(runtimeRootPath, frameworkName));
+              string majorVersion = $"{semVersion.Major}.{semVersion.Minor}.";
+              uint latestVersion = directory.GetDirectories().Where(x => x.Name.StartsWith(majorVersion))
+                  .Select(x => Convert.ToUInt32(x.Name.Substring(majorVersion.Length))).Max();
+              string resolvedPath = Directory.GetDirectories(directory.FullName, majorVersion + $"{latestVersion}*", SearchOption.TopDirectoryOnly)[0];
+              if (!_aspNetSharedFrameworkDirs.Any(path => path.Equals(resolvedPath, StringComparison.OrdinalIgnoreCase)))
+              {
+                _aspNetSharedFrameworkDirs.Add(resolvedPath);
+              }
+            }
+            catch (Exception ex)
+            {
+              _logger.LogVerbose($"NetCoreSharedFrameworkResolver exception while processing framework '{frameworkName}' version '{frameworkVersion}' from '{runtimeConfigFile}': {ex}");
             }
           }
         }
         catch (Exception ex)
         {
-          _logger.LogVerbose($"NetCoreSharedFrameworkResolver exception: {ex}");
+          _logger.LogVerbose($"NetCoreSharedFrameworkResolver exception while reading '{runtimeConfigFile}': {ex}");
         }
       }
 

--- a/test/coverlet.core.tests/Instrumentation/InstrumenterTests.cs
+++ b/test/coverlet.core.tests/Instrumentation/InstrumenterTests.cs
@@ -714,7 +714,7 @@ public class SampleClass
 
         Assert.True(resolved);
         Assert.NotEmpty(assemblies);
-        AssemblyDefinition asm = AssemblyDefinition.ReadAssembly(assemblies[0]);
+        using AssemblyDefinition asm = AssemblyDefinition.ReadAssembly(assemblies[0]);
         Assert.Equal(textJsonAssembly.Name, asm.Name.Name);
       }
       finally

--- a/test/coverlet.core.tests/Instrumentation/InstrumenterTests.cs
+++ b/test/coverlet.core.tests/Instrumentation/InstrumenterTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Toni Solarin-Sodara
+// Copyright (c) Toni Solarin-Sodara
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
@@ -686,12 +686,12 @@ public class SampleClass
         string modulePath = Path.Combine(tempDirectory, "copied.project.reference.dll");
 
         string runtimeVersion = new DirectoryInfo(Path.GetDirectoryName(typeof(object).Assembly.Location)!).Name;
-        var runtimeVersionParts = Version.Parse(runtimeVersion);
+        var runtimeAssemblyVersion = typeof(object).Assembly.GetName().Version;
         string runtimeConfigFile = Path.Combine(tempDirectory, "testhost.runtimeconfig.json");
         File.WriteAllText(runtimeConfigFile,
             "{\n" +
             "  \"runtimeOptions\": {\n" +
-            $"    \"tfm\": \"net{runtimeVersionParts.Major}.{runtimeVersionParts.Minor}\",\n" +
+            $"    \"tfm\": \"net{runtimeAssemblyVersion.Major}.{runtimeAssemblyVersion.Minor}\",\n" +
             "    \"framework\": {\n" +
             "      \"name\": \"Microsoft.NETCore.App\",\n" +
             $"      \"version\": \"{runtimeVersion}\"\n" +

--- a/test/coverlet.core.tests/Instrumentation/InstrumenterTests.cs
+++ b/test/coverlet.core.tests/Instrumentation/InstrumenterTests.cs
@@ -16,6 +16,7 @@ using Coverlet.Tests.Utils;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Emit;
+using Microsoft.Extensions.DependencyModel;
 using Microsoft.VisualStudio.TestPlatform;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
@@ -673,6 +674,53 @@ public class SampleClass
       // The deprecated version is not available and replaced by actual published .NET runtime versions. Minimal supported version is 6.0.0.
       AssemblyDefinition asm = netstandardResolver.TryWithCustomResolverOnDotNetCore(new AssemblyNameReference("Microsoft.Extensions.Logging.Abstractions", new Version("2.2.0")));
       Assert.NotNull(asm);
+    }
+
+    [Fact]
+    public void TestInstrument_NetstandardAwareAssemblyResolver_SiblingRuntimeConfigCanResolveSharedFrameworkAssembly()
+    {
+      string tempDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+      Directory.CreateDirectory(tempDirectory);
+      try
+      {
+        string modulePath = Path.Combine(tempDirectory, "copied.project.reference.dll");
+
+        string runtimeVersion = new DirectoryInfo(Path.GetDirectoryName(typeof(object).Assembly.Location)!).Name;
+        var runtimeVersionParts = Version.Parse(runtimeVersion);
+        string runtimeConfigFile = Path.Combine(tempDirectory, "testhost.runtimeconfig.json");
+        File.WriteAllText(runtimeConfigFile,
+            "{\n" +
+            "  \"runtimeOptions\": {\n" +
+            $"    \"tfm\": \"net{runtimeVersionParts.Major}.{runtimeVersionParts.Minor}\",\n" +
+            "    \"framework\": {\n" +
+            "      \"name\": \"Microsoft.NETCore.App\",\n" +
+            $"      \"version\": \"{runtimeVersion}\"\n" +
+            "    }\n" +
+            "  }\n" +
+            "}\n");
+
+        NetCoreSharedFrameworkResolver sharedFrameworkResolver = new NetCoreSharedFrameworkResolver(modulePath, _mockLogger.Object);
+        AssemblyName textJsonAssembly = typeof(System.Text.Json.JsonSerializer).Assembly.GetName();
+        var compilationLibrary = new CompilationLibrary(
+            "package",
+            textJsonAssembly.Name,
+            textJsonAssembly.Version.ToString(),
+            "sha512-not-relevant",
+            Enumerable.Empty<string>(),
+            Enumerable.Empty<Dependency>(),
+            true);
+        var assemblies = new List<string>();
+        bool resolved = sharedFrameworkResolver.TryResolveAssemblyPaths(compilationLibrary, assemblies);
+
+        Assert.True(resolved);
+        Assert.NotEmpty(assemblies);
+        AssemblyDefinition asm = AssemblyDefinition.ReadAssembly(assemblies[0]);
+        Assert.Equal(textJsonAssembly.Name, asm.Name.Name);
+      }
+      finally
+      {
+        Directory.Delete(tempDirectory, true);
+      }
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Fix shared-framework assembly resolution for copied project-reference assemblies that do not have their own runtimeconfig file in the test output folder.

## Problem

In the repro from #1718, `Repro.Application.dll` is copied into the test output and coverlet tries to instrument it there.

On SDK `10.0.201`, this fails with `CecilAssemblyResolutionException` for `Microsoft.Extensions.DependencyInjection.Abstractions`, and `Repro.Application` is missing from raw coverage.

The copied module does not have its own runtimeconfig file, but sibling `*.runtimeconfig.json` files are present in the same output folder. coverlet currently does not use those files when resolving shared-framework assemblies.

## Fix

Update `NetCoreSharedFrameworkResolver` to scan sibling `*.runtimeconfig.json` files in the module output directory
