### PR TITLE
Improve logging and add test for PascalCase config keys

### DIFF
--- a/src/coverlet.MTP/Collector/CollectorExtension.cs
+++ b/src/coverlet.MTP/Collector/CollectorExtension.cs
@@ -626,13 +626,24 @@ internal sealed class CollectorExtension : ITestHostProcessLifetimeHandler, ITes
   {
     try
     {
+      // Log which testconfig.json file we're looking for
+      string? configPath = TestConfigParser.FindTestConfigFile(testModulePath, _fileSystem);
+      if (configPath is null)
+      {
+        _logger.LogVerbose($"No testconfig.json found for module: {testModulePath}");
+        return null;
+      }
+
+      _logger.LogVerbose($"Found testconfig.json: {configPath}");
+
       CoverletMTPSettings? settings = TestConfigParser.Parse(testModulePath, _fileSystem);
       if (settings is null)
       {
+        _logger.LogVerbose($"testconfig.json exists but contains no Coverlet section: {configPath}");
         return null;
       }
-      _logger.LogVerbose($"testconfig.json settings loaded: Format={string.Join(",", settings.ReportFormats)}, IncludeTestAssembly={settings.IncludeTestAssembly}");
 
+      _logger.LogVerbose($"testconfig.json settings loaded: Format={string.Join(",", settings.ReportFormats)}, IncludeTestAssembly={settings.IncludeTestAssembly}");
       return settings;
     }
     catch (Exception ex)

--- a/src/coverlet.MTP/Collector/CollectorExtension.cs
+++ b/src/coverlet.MTP/Collector/CollectorExtension.cs
@@ -630,13 +630,18 @@ internal sealed class CollectorExtension : ITestHostProcessLifetimeHandler, ITes
       string? configPath = TestConfigParser.FindTestConfigFile(testModulePath, _fileSystem);
       if (configPath is null)
       {
+        // Log both candidate paths so users understand what was searched
+        string? directory = Path.GetDirectoryName(testModulePath);
+        string appName = Path.GetFileNameWithoutExtension(testModulePath);
         _logger.LogVerbose($"No testconfig.json found for module: {testModulePath}");
+        _logger.LogVerbose($"  Searched: {appName}{TestConfigParser.TestConfigFileNameSuffix}, {TestConfigParser.GenericTestConfigFileName}");
         return null;
       }
 
       _logger.LogVerbose($"Found testconfig.json: {configPath}");
 
-      CoverletMTPSettings? settings = TestConfigParser.Parse(testModulePath, _fileSystem);
+      // Use the already-discovered configPath to avoid duplicate filesystem lookups
+      CoverletMTPSettings? settings = TestConfigParser.ParseFromFile(configPath, testModulePath, _fileSystem);
       if (settings is null)
       {
         _logger.LogVerbose($"testconfig.json exists but contains no Coverlet section: {configPath}");

--- a/src/coverlet.MTP/Configuration/TestConfigParser.cs
+++ b/src/coverlet.MTP/Configuration/TestConfigParser.cs
@@ -76,12 +76,13 @@ internal static class TestConfigParser
 
   /// <summary>
   /// Parse settings from a specific testconfig.json file.
+  /// Use this overload when the config path is already known to avoid duplicate filesystem lookups.
   /// </summary>
   /// <param name="configPath">Path to the testconfig.json file</param>
   /// <param name="testModulePath">Path to the test assembly</param>
   /// <param name="fileSystem">File system abstraction</param>
   /// <returns>Parsed settings if file contains Coverlet section, null otherwise</returns>
-  private static CoverletMTPSettings? ParseFromFile(string configPath, string testModulePath, IFileSystem fileSystem)
+  internal static CoverletMTPSettings? ParseFromFile(string configPath, string testModulePath, IFileSystem fileSystem)
   {
     string jsonContent = fileSystem.ReadAllText(configPath);
 

--- a/test/coverlet.MTP.tests/Configuration/TestConfigParserTests.cs
+++ b/test/coverlet.MTP.tests/Configuration/TestConfigParserTests.cs
@@ -350,7 +350,7 @@ public class TestConfigParserTests
   }
 
   [Fact]
-  public void ParseWithPascalCaseKeysLikeUserJsonFormat()
+  public void ParseWithPascalCaseKeysMapsCorrectly()
   {
     // This test uses the exact JSON format the user reported as not working
     // PascalCase keys like "Exclude", "ExcludeByAttribute", "Format", etc.

--- a/test/coverlet.MTP.tests/Configuration/TestConfigParserTests.cs
+++ b/test/coverlet.MTP.tests/Configuration/TestConfigParserTests.cs
@@ -349,5 +349,45 @@ public class TestConfigParserTests
     Assert.Equal(["lcov"], settings.ReportFormats);
   }
 
+  [Fact]
+  public void ParseWithPascalCaseKeysLikeUserJsonFormat()
+  {
+    // This test uses the exact JSON format the user reported as not working
+    // PascalCase keys like "Exclude", "ExcludeByAttribute", "Format", etc.
+    string testDirectory = Path.Combine("C:", "fake", "path");
+    string testModulePath = Path.Combine(testDirectory, "XUnitProject3.Tests.dll");
+    string configPath = Path.Combine(testDirectory, "XUnitProject3.Tests.testconfig.json");
+
+    // This is the exact JSON format from the user's report
+    string jsonContent = """
+    {
+      "platformOptions": {
+        "Coverlet": {
+          "Exclude": "[*.Tests]*,[xunit*]*",
+          "ExcludeByAttribute": "GeneratedCode,ExcludeFromCodeCoverage",
+          "Format": "cobertura,json,lcov,opencover",
+          "SkipAutoProps": true,
+          "ExcludeAssembliesWithoutSources": "MissingAll"
+        }
+      }
+    }
+    """;
+
+    _mockFileSystem.Setup(fs => fs.Exists(configPath)).Returns(true);
+    _mockFileSystem.Setup(fs => fs.ReadAllText(configPath)).Returns(jsonContent);
+
+    // Act
+    CoverletMTPSettings? settings = TestConfigParser.Parse(testModulePath, _mockFileSystem.Object);
+
+    // Assert
+    Assert.NotNull(settings);
+    Assert.Equal(["[coverlet.*]*", "[*.Tests]*", "[xunit*]*"], settings.ExcludeFilters);
+    Assert.Equal(["GeneratedCode", "ExcludeFromCodeCoverage"], settings.ExcludeAttributes);
+    Assert.Equal(["cobertura", "json", "lcov", "opencover"], settings.ReportFormats);
+    Assert.True(settings.SkipAutoProps);
+    Assert.Equal("MissingAll", settings.ExcludeAssembliesWithoutSources);
+    Assert.True(settings.IsFromConfigFile);
+  }
+
   #endregion
 }


### PR DESCRIPTION
Enhanced logging in LoadTestConfigSettings to better trace testconfig.json discovery and parsing. Added a unit test to ensure parsing works with PascalCase keys in testconfig.json.